### PR TITLE
Fix typo in adjoint Rouchon

### DIFF
--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -63,7 +63,7 @@ class MERouchon1(MERouchon):
     def backward_augmented(self, t: float, dt: float, rho: Tensor, phi: Tensor):
         r"""Compute $\rho(t-dt)$ and $\phi(t-dt)$ using a Rouchon method of order 1."""
         # compute rho(t-dt)
-        rho = kraus_map(rho, self.M0(t, dt)) - kraus_map(rho, self.M1s)
+        rho = kraus_map(rho, self.M0(t, -dt)) - kraus_map(rho, self.M1s)
         rho = rho / trace(rho)[..., None, None].real
 
         # compute phi(t-dt)


### PR DESCRIPTION
Fix a small bug introduced in #87. 

Note that a rehaul of the caching will be required to make the adjoint tests pass cleanly. Right now it's still bugged. When caching, we need to:

- check for other arguments being changed (typically `dt` here)
- check whether `requires_grad` is True or False in the current scope (we should update the cache if this has changed), otherwise the given Tensor might be disconnected from the operation graph.

Once this if fixed, the adjoint tests should pass with `atol = 1e-4` instead of the current `atol = 1e-2`.