### PR TITLE
Add `smesolve`

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -97,7 +97,7 @@ def mesolve(
     options = options or Dopri5()
 
     # define the solver
-    args = (H_batched, rho0_batched, t_save, exp_ops, options)
+    args = (H_batched, rho0_batched, t_save, t_save, exp_ops, options)
     if isinstance(options, Rouchon1):
         solver = MERouchon1(*args, jump_ops=jump_ops)
     elif isinstance(options, Rouchon1_5):

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ..options import Dopri5, Euler, Options, Rouchon1, Rouchon1_5, Rouchon2
-from ..utils.solver_utils import check_time_array
+from ..utils.solver_utils import check_time_tensor
 from ..utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import MEDormandPrince5
@@ -93,7 +93,7 @@ def mesolve(
 
     # convert t_save to a tensor
     t_save = torch.as_tensor(t_save, dtype=options.rdtype, device=options.device)
-    check_time_array(t_save, 't_save')
+    check_time_tensor(t_save, arg_name='t_save')
 
     # default options
     options = options or Dopri5()

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -4,6 +4,7 @@ import torch
 from torch import Tensor
 
 from ..options import Dopri5, Euler, Options, Rouchon1, Rouchon1_5, Rouchon2
+from ..utils.solver_utils import check_time_array
 from ..utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import MEDormandPrince5
@@ -92,12 +93,14 @@ def mesolve(
 
     # convert t_save to a tensor
     t_save = torch.as_tensor(t_save, dtype=options.rdtype, device=options.device)
+    check_time_array(t_save, 't_save')
 
     # default options
     options = options or Dopri5()
 
     # define the solver
-    args = (H_batched, rho0_batched, t_save, t_save, exp_ops, options)
+    t_save_all = t_save
+    args = (H_batched, rho0_batched, t_save_all, t_save, exp_ops, options)
     if isinstance(options, Rouchon1):
         solver = MERouchon1(*args, jump_ops=jump_ops)
     elif isinstance(options, Rouchon1_5):

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -99,8 +99,7 @@ def mesolve(
     options = options or Dopri5()
 
     # define the solver
-    t_save_all = t_save
-    args = (H_batched, rho0_batched, t_save_all, t_save, exp_ops, options)
+    args = (H_batched, rho0_batched, t_save, exp_ops, options)
     if isinstance(options, Rouchon1):
         solver = MERouchon1(*args, jump_ops=jump_ops)
     elif isinstance(options, Rouchon1_5):

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -4,7 +4,8 @@ import torch
 
 from ..options import Dopri5, Euler, Options, Rouchon1, Rouchon1_5, Rouchon2
 from ..solvers.result import Result
-from ..solvers.utils.tensor_formatter import TensorFormatter, check_time_tensor
+from ..solvers.utils.tensor_formatter import TensorFormatter
+from ..solvers.utils.utils import check_time_tensor
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import MEDormandPrince5
 from .euler import MEEuler

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -4,6 +4,7 @@ import torch
 from torch import Tensor
 
 from ..options import Dopri5, Euler, Options, Propagator
+from ..utils.solver_utils import check_time_array
 from ..utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import SEDormandPrince5
@@ -35,12 +36,14 @@ def sesolve(
 
     # convert t_save to tensor
     t_save = torch.as_tensor(t_save, dtype=options.rdtype, device=options.device)
+    check_time_array(t_save, 't_save')
 
     # default options
     options = options or Dopri5()
 
     # define the solver
-    args = (H_batched, psi0_batched, t_save, t_save, exp_ops, options)
+    t_save_all = t_save
+    args = (H_batched, psi0_batched, t_save_all, t_save, exp_ops, options)
     if isinstance(options, Euler):
         solver = SEEuler(*args)
     elif isinstance(options, Dopri5):

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ..options import Dopri5, Euler, Options, Propagator
-from ..utils.solver_utils import check_time_array
+from ..utils.solver_utils import check_time_tensor
 from ..utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import SEDormandPrince5
@@ -36,7 +36,7 @@ def sesolve(
 
     # convert t_save to tensor
     t_save = torch.as_tensor(t_save, dtype=options.rdtype, device=options.device)
-    check_time_array(t_save, 't_save')
+    check_time_tensor(t_save, arg_name='t_save')
 
     # default options
     options = options or Dopri5()

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -42,8 +42,7 @@ def sesolve(
     options = options or Dopri5()
 
     # define the solver
-    t_save_all = t_save
-    args = (H_batched, psi0_batched, t_save_all, t_save, exp_ops, options)
+    args = (H_batched, psi0_batched, t_save, exp_ops, options)
     if isinstance(options, Euler):
         solver = SEEuler(*args)
     elif isinstance(options, Dopri5):

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -40,7 +40,7 @@ def sesolve(
     options = options or Dopri5()
 
     # define the solver
-    args = (H_batched, psi0_batched, t_save, exp_ops, options)
+    args = (H_batched, psi0_batched, t_save, t_save, exp_ops, options)
     if isinstance(options, Euler):
         solver = SEEuler(*args)
     elif isinstance(options, Dopri5):

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -4,7 +4,8 @@ import torch
 
 from ..options import Dopri5, Euler, Options, Propagator
 from ..solvers.result import Result
-from ..solvers.utils.tensor_formatter import TensorFormatter, check_time_tensor
+from ..solvers.utils.tensor_formatter import TensorFormatter
+from ..solvers.utils.utils import check_time_tensor
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import SEDormandPrince5
 from .euler import SEEuler

--- a/dynamiqs/smesolve/euler.py
+++ b/dynamiqs/smesolve/euler.py
@@ -1,0 +1,20 @@
+from torch import Tensor
+
+from ..solvers.ode.fixed_solver import FixedSolver
+from .sme_solver import SMESolver
+
+
+class SMEEuler(SMESolver, FixedSolver):
+    def forward(self, t: float, rho: Tensor) -> Tensor:
+        # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, n, n)
+
+        # sample Wiener process
+        dw = self.sample_wiener(self.dt)
+
+        # update state
+        drho = self.dt * self.lindbladian(t, rho) + self.diff_backaction(rho, dw)
+
+        # update measured signal
+        self.update_meas(rho, dw)
+
+        return rho + drho

--- a/dynamiqs/smesolve/euler.py
+++ b/dynamiqs/smesolve/euler.py
@@ -12,9 +12,9 @@ class SMEEuler(SMESolver, FixedSolver):
         dw = self.sample_wiener(self.dt)
 
         # update state
-        drho = self.dt * self.lindbladian(t, rho) + self.diff_backaction(rho, dw)
+        drho = self.dt * self.lindbladian(t, rho) + self.diff_backaction(dw, rho)
 
         # update measured signal
-        self.update_meas(rho, dw)
+        self.update_meas(dw, rho)
 
         return rho + drho

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from math import sqrt
+
+import torch
+from torch import Tensor
+
+from ..mesolve.me_solver import MESolver
+from ..options import Options
+from ..utils.solver_utils import cache
+from ..utils.td_tensor import TDTensor
+from ..utils.utils import trace
+
+
+class SMESolver(MESolver):
+    def __init__(
+        self,
+        H: TDTensor,
+        y0: Tensor,
+        exp_ops: Tensor,
+        options: Options,
+        *,
+        jump_ops: Tensor,
+        meas_ops: Tensor,
+        etas: Tensor,
+        generator: torch.Generator,
+        t_save_y: Tensor,
+        t_save_meas: Tensor,
+    ):
+        t_save = torch.cat((t_save_y, t_save_meas)).unique().sort()[0]
+        super().__init__(H, y0, t_save, t_save_y, exp_ops, options, jump_ops=jump_ops)
+
+        self.meas_ops = meas_ops  # (len(meas_ops), n, n)
+        self.t_save_meas = t_save_meas  # (len(t_save_meas))
+        self.etas = etas  # (len(meas_ops))
+        self.generator = generator
+
+        self.save_meas_counter = 0
+
+        # initialize additional save tensors
+        batch_sizes = self.y0.shape[:-2]
+
+        self.meas_shape = (*batch_sizes, len(self.meas_ops))
+
+        # meas_save: (..., len(meas_ops), len(t_save_meas))
+        if len(t_save_meas) > 0:
+            self.meas_save = torch.zeros(
+                *self.meas_shape,
+                len(self.t_save_meas) - 1,
+                dtype=self.dtype_real,
+                device=self.device,
+            )
+        else:
+            self.meas_save = None
+
+        # tensor to hold the sum of measurement results on a time bin
+        self.bin_meas = torch.zeros(self.meas_shape)  # (..., len(etas))
+
+    def _save(self, t: float, y: Tensor):
+        if t in self.t_save_y:
+            super()._save(t, y)
+        if t in self.t_save_meas:
+            self.save_meas()
+
+    def save_meas(self):
+        if self.save_meas_counter != 0:
+            t_bin = (
+                self.t_save_meas[self.save_meas_counter]
+                - self.t_save_meas[self.save_meas_counter - 1]
+            )
+            self.meas_save[..., self.save_meas_counter - 1] = self.bin_meas / t_bin
+            self.bin_meas = torch.zeros_like(self.bin_meas)
+        self.save_meas_counter += 1
+
+    def sample_wiener(self, dt: float) -> Tensor:
+        # -> (b_H, b_rho, ntrajs)
+        return torch.normal(
+            torch.zeros(*self.meas_shape), sqrt(dt), generator=self.generator
+        ).to(dtype=self.dtype_real)
+
+    @cache
+    def Lp(self, rho: Tensor) -> Tensor:
+        # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, n, n)
+        # L @ rho + rho @ Ldag
+        L_rho = torch.einsum('bij,...jk->...bik', self.meas_ops, rho)
+        return L_rho + L_rho.mH
+
+    def diff_backaction(self, rho: Tensor, dw: Tensor) -> Tensor:
+        # Compute the measurement backaction term of the diffusive SME.
+        # $$ \sum_k \sqrt{\eta_k} \mathcal{M}[L_k](\rho) dW_k $$
+        # where
+        # $$ \mathcal{M}[L](\rho) = L \rho + \rho L^\dag -
+        # \mathrm{Tr}\left[(L + L^\dag) \rho\right] \rho $$
+
+        # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, n, n)
+
+        # L @ rho + rho @ Ldag
+        Lp_rho = self.Lp(rho)  # (..., b, n, n)
+
+        # L @ rho + rho @ Ldag - Tr(L @ rho + rho @  Ldag) rho
+        tmp = Lp_rho - torch.einsum('...bii,...jk->...bjk', Lp_rho, rho)
+        # tmp: (..., b, n, n)
+
+        # sum sqrt(eta) * dw * [L @ rho + rho @ Ldag - Tr(L @ rho + rho @ Ldag) rho]
+        fact = (self.etas.sqrt() * dw).to(self.dtype)
+        return torch.einsum('...b,...bij->...ij', fact, tmp)
+
+    def update_meas(self, rho: Tensor, dw: Tensor):
+        tr = trace(self.Lp(rho)).real
+        self.bin_meas += self.etas.sqrt() * tr * self.dt + dw

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor
 
 from ..mesolve.me_solver import MESolver
-from ..utils.solver_utils import cache
+from ..solvers.utils.utils import cache
 from ..utils.utils import trace
 
 
@@ -34,14 +34,16 @@ class SMESolver(MESolver):
 
         # meas_save: (..., len(meas_ops), len(t_meas))
         if len(t_meas) > 0:
-            self.meas_save = torch.zeros(
+            meas_save = torch.zeros(
                 *self.meas_shape,
                 len(t_meas) - 1,
                 dtype=self.dtype_real,
                 device=self.device,
             )
         else:
-            self.meas_save = None
+            meas_save = None
+
+        self.result.meas_save = meas_save
 
         # tensor to hold the sum of measurement results on a time bin
         self.bin_meas = torch.zeros(self.meas_shape)  # (..., len(etas))
@@ -67,7 +69,7 @@ class SMESolver(MESolver):
             t_bin = (
                 self.t_meas[self.t_meas_counter] - self.t_meas[self.t_meas_counter - 1]
             )
-            self.meas_save[..., self.t_meas_counter - 1] = self.bin_meas / t_bin
+            self.result.meas_save[..., self.t_meas_counter - 1] = self.bin_meas / t_bin
             self.bin_meas = torch.zeros_like(self.bin_meas)
 
     def sample_wiener(self, dt: float) -> Tensor:

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -24,29 +24,31 @@ class SMESolver(MESolver):
         meas_ops: Tensor,
         etas: Tensor,
         generator: torch.Generator,
-        t_save_y: Tensor,
-        t_save_meas: Tensor,
+        t_save: Tensor,
+        t_meas: Tensor,
     ):
-        t_save = torch.cat((t_save_y, t_save_meas)).unique().sort()[0]
-        super().__init__(H, y0, t_save, t_save_y, exp_ops, options, jump_ops=jump_ops)
+        t_save_all = torch.cat((t_save, t_meas)).unique().sort()[0]
+        super().__init__(H, y0, t_save_all, t_save, exp_ops, options, jump_ops=jump_ops)
 
         self.meas_ops = meas_ops  # (len(meas_ops), n, n)
-        self.t_save_meas = t_save_meas  # (len(t_save_meas))
+        self.t_meas = t_meas  # (len(t_meas))
         self.etas = etas  # (len(meas_ops))
         self.generator = generator
 
-        self.save_meas_counter = 0
+        # save logic for meas
+        self.t_meas_mask = torch.isin(self.t_save_all, t_meas)
+        self.t_meas_counter = 0
 
         # initialize additional save tensors
         batch_sizes = self.y0.shape[:-2]
 
         self.meas_shape = (*batch_sizes, len(self.meas_ops))
 
-        # meas_save: (..., len(meas_ops), len(t_save_meas))
-        if len(t_save_meas) > 0:
+        # meas_save: (..., len(meas_ops), len(t_meas))
+        if len(t_meas) > 0:
             self.meas_save = torch.zeros(
                 *self.meas_shape,
-                len(self.t_save_meas) - 1,
+                len(t_meas) - 1,
                 dtype=self.dtype_real,
                 device=self.device,
             )
@@ -56,21 +58,19 @@ class SMESolver(MESolver):
         # tensor to hold the sum of measurement results on a time bin
         self.bin_meas = torch.zeros(self.meas_shape)  # (..., len(etas))
 
-    def _save(self, t: float, y: Tensor):
-        if t in self.t_save_y:
-            super()._save(t, y)
-        if t in self.t_save_meas:
-            self.save_meas()
+    def _save(self, y: Tensor):
+        super()._save(y)
+        if self.t_meas_mask[self.t_save_all_counter]:
+            self._save_meas(y)
+            self.t_meas_counter += 1
 
-    def save_meas(self):
-        if self.save_meas_counter != 0:
+    def _save_meas(self):
+        if self.t_meas_counter != 0:
             t_bin = (
-                self.t_save_meas[self.save_meas_counter]
-                - self.t_save_meas[self.save_meas_counter - 1]
+                self.t_meas[self.t_meas_counter] - self.t_meas[self.t_meas_counter - 1]
             )
-            self.meas_save[..., self.save_meas_counter - 1] = self.bin_meas / t_bin
+            self.meas_save[..., self.t_meas_counter - 1] = self.bin_meas / t_bin
             self.bin_meas = torch.zeros_like(self.bin_meas)
-        self.save_meas_counter += 1
 
     def sample_wiener(self, dt: float) -> Tensor:
         # -> (b_H, b_rho, ntrajs)

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -64,7 +64,7 @@ class SMESolver(MESolver):
             self._save_meas(y)
             self.t_meas_counter += 1
 
-    def _save_meas(self):
+    def _save_meas(self, y: Tensor):
         if self.t_meas_counter != 0:
             t_bin = (
                 self.t_meas[self.t_meas_counter] - self.t_meas[self.t_meas_counter - 1]

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -4,6 +4,7 @@ import torch
 from torch import Tensor
 
 from ..options import Euler, Options
+from ..utils.solver_utils import check_time_array
 from ..utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .euler import SMEEuler
@@ -46,6 +47,7 @@ def smesolve(
 
     # convert t_save to a tensor
     t_save = torch.as_tensor(t_save, dtype=options.rdtype, device=options.device)
+    check_time_array(t_save, 't_save')
 
     # convert etas to a tensor and check
     etas = torch.as_tensor(etas, dtype=options.rdtype, device=options.device)
@@ -67,6 +69,7 @@ def smesolve(
     t_meas = torch.as_tensor(
         [] if t_meas is None else t_meas, dtype=options.rdtype, device=options.device
     )
+    check_time_array(t_meas, 't_meas', allow_empty=True)
 
     # define random number generator from seed
     generator = torch.Generator(device=options.device)
@@ -85,8 +88,8 @@ def smesolve(
         meas_ops=meas_ops,
         etas=etas,
         generator=generator,
-        t_save_y=t_save,
-        t_save_meas=t_meas,
+        t_save=t_save,
+        t_meas=t_meas,
     )
     if isinstance(options, Euler):
         solver = SMEEuler(*args, **kwargs)

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -82,13 +82,12 @@ def smesolve(
         )
 
     # define the solver
-    args = (H_batched, rho0_batched, exp_ops, options)
+    args = (H_batched, rho0_batched, t_save, exp_ops, options)
     kwargs = dict(
         jump_ops=jump_ops,
         meas_ops=meas_ops,
         etas=etas,
         generator=generator,
-        t_save=t_save,
         t_meas=t_meas,
     )
     if isinstance(options, Euler):

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -1,23 +1,110 @@
 from __future__ import annotations
 
-from typing import Any
-
-import numpy as np
+import torch
 from torch import Tensor
+
+from ..options import Euler, Options
+from ..utils.tensor_formatter import TensorFormatter
+from ..utils.tensor_types import (
+    OperatorLike,
+    TDOperatorLike,
+    TensorLike,
+    dtype_complex_to_real,
+)
+from .euler import SMEEuler
 
 
 def smesolve(
-    H: Tensor,
-    Ls: list[Tensor],
-    Ms: list[Tensor],
-    etas: list[float],
-    rho0: Tensor,
-    tlist: np.ndarray,
+    H: TDOperatorLike,
+    jump_ops: OperatorLike | list[OperatorLike],
+    rho0: OperatorLike,
+    t_save: TensorLike,
+    etas: TensorLike,
     ntrajs: int,
-    solver: str,
-    options: dict[str, Any] | None = None,
-) -> Tensor:
-    raise NotImplementedError(
-        'the Stochastic Master Equation solvers are not implemented yet, come '
-        'back soon!'
+    *,
+    t_meas: TensorLike | None = None,
+    seed: int | None = None,
+    exp_ops: OperatorLike | list[OperatorLike] | None = None,
+    options: Options | None = None,
+    dtype: torch.complex64 | torch.complex128 | None = None,
+    device: torch.device | None = None,
+) -> tuple[Tensor, Tensor | None, Tensor | None]:
+    # H: (b_H?, n, n), rho0: (b_rho0?, n, n) -> (y_save, exp_save, meas_save) with
+    #    - y_save: (b_H?, b_rho0?, ntrajs, len(t_save), n, n)
+    #    - exp_save: (b_H?, b_rho0?, ntrajs, len(exp_ops), len(t_save))
+    #    - meas_save: (b_H?, b_rho0?, ntrajs, len(meas_ops), len(t_meas) - 1)
+
+    # check jump_ops
+    if isinstance(jump_ops, list) and len(jump_ops) == 0:
+        raise ValueError(
+            'Argument `jump_ops` must be a non-empty list of tensors. Otherwise,'
+            ' consider using `sesolve`.'
+        )
+
+    # format and batch all tensors
+    formatter = TensorFormatter(dtype, device)
+    H_batched, rho0_batched = formatter.format_H_and_state(H, rho0, state_to_dm=True)
+    H_batched = H_batched.unsqueeze(2)
+    rho0_batched = rho0_batched.unsqueeze(2).repeat(1, 1, ntrajs, 1, 1)
+    # H_batched: (b_H, 1, 1, n, n)
+    # rho0_batched: (b_H, b_rho0, ntrajs, n, n)
+    exp_ops = formatter.format(exp_ops)  # (len(exp_ops), n, n)
+    jump_ops = formatter.format(jump_ops)  # (len(jump_ops), n, n)
+
+    # convert t_save to a tensor
+    t_save = torch.as_tensor(t_save, dtype=dtype_complex_to_real(dtype), device=device)
+
+    # convert etas to a tensor and check
+    etas = torch.as_tensor(etas, dtype=dtype_complex_to_real(dtype), device=device)
+    if len(etas) != len(jump_ops):
+        raise ValueError('Argument `etas` must have the same length as `jump_ops`.')
+    if torch.all(etas == 0.0):
+        raise ValueError(
+            'Argument `etas` must contain at least one non-zero value. Otherwise, '
+            'consider using `mesolve`.'
+        )
+
+    # split jump operators between purely dissipative (eta = 0) and monitored (eta != 0)
+    mask = etas == 0.0
+    meas_ops, etas = jump_ops[~mask], etas[~mask]
+
+    # convert t_meas to a tensor
+    t_meas = torch.as_tensor(
+        [] if t_meas is None else t_meas,
+        dtype=dtype_complex_to_real(dtype),
+        device=device,
     )
+
+    # define random number generator from seed
+    generator = torch.Generator(device=device)
+    generator.seed() if seed is None else generator.manual_seed(seed)
+
+    # default options
+    if options is None:
+        raise ValueError()
+
+    # define the solver
+    args = (H_batched, rho0_batched, exp_ops, options)
+    kwargs = dict(
+        jump_ops=jump_ops,
+        meas_ops=meas_ops,
+        etas=etas,
+        generator=generator,
+        t_save_y=t_save,
+        t_save_meas=t_meas,
+    )
+    if isinstance(options, Euler):
+        solver = SMEEuler(*args, **kwargs)
+    else:
+        raise NotImplementedError(f'Solver options {type(options)} is not implemented.')
+
+    # compute the result
+    solver.run()
+
+    # get saved tensors and restore correct batching
+    rho_save, exp_save, meas_save = solver.y_save, solver.exp_save, solver.meas_save
+    rho_save = formatter.unbatch(rho_save)
+    exp_save = formatter.unbatch(exp_save)
+    meas_save = formatter.unbatch(meas_save)
+
+    return rho_save, exp_save, meas_save

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -4,7 +4,7 @@ import torch
 from torch import Tensor
 
 from ..options import Euler, Options
-from ..utils.solver_utils import check_time_array
+from ..utils.solver_utils import check_time_tensor
 from ..utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .euler import SMEEuler
@@ -47,7 +47,7 @@ def smesolve(
 
     # convert t_save to a tensor
     t_save = torch.as_tensor(t_save, dtype=options.rdtype, device=options.device)
-    check_time_array(t_save, 't_save')
+    check_time_tensor(t_save, arg_name='t_save')
 
     # convert etas to a tensor and check
     etas = torch.as_tensor(etas, dtype=options.rdtype, device=options.device)
@@ -69,7 +69,7 @@ def smesolve(
     t_meas = torch.as_tensor(
         [] if t_meas is None else t_meas, dtype=options.rdtype, device=options.device
     )
-    check_time_array(t_meas, 't_meas', allow_empty=True)
+    check_time_tensor(t_meas, arg_name='t_meas', allow_empty=True)
 
     # define random number generator from seed
     generator = torch.Generator(device=options.device)

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import torch
-from torch import Tensor
 
 from ..options import Euler, Options
-from ..utils.solver_utils import check_time_tensor
-from ..utils.tensor_formatter import TensorFormatter
+from ..solvers.result import Result
+from ..solvers.utils.tensor_formatter import TensorFormatter
+from ..solvers.utils.utils import check_time_tensor
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .euler import SMEEuler
 
@@ -22,7 +22,7 @@ def smesolve(
     seed: int | None = None,
     exp_ops: OperatorLike | list[OperatorLike] | None = None,
     options: Options | None = None,
-) -> tuple[Tensor, Tensor | None, Tensor | None]:
+) -> Result:
     # H: (b_H?, n, n), rho0: (b_rho0?, n, n) -> (y_save, exp_save, meas_save) with
     #    - y_save: (b_H?, b_rho0?, ntrajs, len(t_save), n, n)
     #    - exp_save: (b_H?, b_rho0?, ntrajs, len(exp_ops), len(t_save))
@@ -99,9 +99,9 @@ def smesolve(
     solver.run()
 
     # get saved tensors and restore correct batching
-    rho_save, exp_save, meas_save = solver.y_save, solver.exp_save, solver.meas_save
-    rho_save = formatter.unbatch(rho_save)
-    exp_save = formatter.unbatch(exp_save)
-    meas_save = formatter.unbatch(meas_save)
+    result = solver.result
+    result.y_save = formatter.unbatch(result.y_save)
+    result.exp_save = formatter.unbatch(result.exp_save)
+    result.meas_save = formatter.unbatch(result.meas_save)
 
-    return rho_save, exp_save, meas_save
+    return result

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -35,12 +35,12 @@ def smesolve(
         )
 
     # format and batch all tensors
+    # H_batched: (b_H, 1, 1, n, n)
+    # rho0_batched: (b_H, b_rho0, ntrajs, n, n)
     formatter = TensorFormatter(options.dtype, options.device)
     H_batched, rho0_batched = formatter.format_H_and_state(H, rho0, state_to_dm=True)
     H_batched = H_batched.unsqueeze(2)
     rho0_batched = rho0_batched.unsqueeze(2).repeat(1, 1, ntrajs, 1, 1)
-    # H_batched: (b_H, 1, 1, n, n)
-    # rho0_batched: (b_H, b_rho0, ntrajs, n, n)
     exp_ops = formatter.format(exp_ops)  # (len(exp_ops), n, n)
     jump_ops = formatter.format(jump_ops)  # (len(jump_ops), n, n)
 

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -31,7 +31,7 @@ def smesolve(
     if isinstance(jump_ops, list) and len(jump_ops) == 0:
         raise ValueError(
             'Argument `jump_ops` must be a non-empty list of tensors. Otherwise,'
-            ' consider using `sesolve`.'
+            ' consider using `ssesolve`.'
         )
 
     # format and batch all tensors
@@ -56,6 +56,8 @@ def smesolve(
             'Argument `etas` must contain at least one non-zero value. Otherwise, '
             'consider using `mesolve`.'
         )
+    if torch.any(etas < 0.0) or torch.any(etas > 1.0):
+        raise ValueError('Argument `etas` must contain values between 0 and 1.')
 
     # split jump operators between purely dissipative (eta = 0) and monitored (eta != 0)
     mask = etas == 0.0
@@ -72,7 +74,9 @@ def smesolve(
 
     # default options
     if options is None:
-        raise ValueError()
+        raise ValueError(
+            'No default solver yet, please specify one using the options argument.'
+        )
 
     # define the solver
     args = (H_batched, rho0_batched, exp_ops, options)

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -24,7 +24,7 @@ class AdaptiveSolver(AutogradSolver):
         Series in Computational Mathematics`.
         """
         # initialize the progress bar
-        pbar = tqdm(total=self.t_save_all[-1].item(), disable=not self.options.verbose)
+        pbar = tqdm(total=self.t_stop[-1].item(), disable=not self.options.verbose)
 
         # initialize the ODE routine
         t0 = 0.0
@@ -36,7 +36,7 @@ class AdaptiveSolver(AutogradSolver):
         # run the ODE routine
         t, y, ft = t0, self.y0, f0
         step_counter = 0
-        for ts in self.t_save_all.cpu().numpy():
+        for ts in self.t_stop.cpu().numpy():
             while t < ts:
                 # update time step
                 dt = self.update_tstep(dt, error)

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -69,7 +69,7 @@ class AdaptiveSolver(AutogradSolver):
                     )
 
             # save solution
-            self.save(y)
+            self.save(ts, y)
 
             # use cache to retrieve time step and error
             dt, error = cache

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -24,7 +24,7 @@ class AdaptiveSolver(AutogradSolver):
         Series in Computational Mathematics`.
         """
         # initialize the progress bar
-        pbar = tqdm(total=self.t_save[-1].item(), disable=not self.options.verbose)
+        pbar = tqdm(total=self.t_save_all[-1].item(), disable=not self.options.verbose)
 
         # initialize the ODE routine
         t0 = 0.0
@@ -36,7 +36,7 @@ class AdaptiveSolver(AutogradSolver):
         # run the ODE routine
         t, y, ft = t0, self.y0, f0
         step_counter = 0
-        for ts in self.t_save.cpu().numpy():
+        for ts in self.t_save_all.cpu().numpy():
             while t < ts:
                 # update time step
                 dt = self.update_tstep(dt, error)
@@ -69,7 +69,7 @@ class AdaptiveSolver(AutogradSolver):
                     )
 
             # save solution
-            self.save(ts, y)
+            self.save(y)
 
             # use cache to retrieve time step and error
             dt, error = cache

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -44,14 +44,15 @@ class FixedSolver(AutogradSolver):
         y = self.y0
         for t in tqdm(times[:-1], disable=not self.options.verbose):
             # save solution
-            if t >= self.next_tsave():
-                self.save(y)
+            next_tsave = self.next_tsave()
+            if t >= next_tsave:
+                self.save(next_tsave, y)
 
             # iterate solution
             y = self.forward(t, y)
 
         # save final time step (`t` goes `0.0` to `t_save[-1]` excluded)
-        self.save(y)
+        self.save(self.t_save[-1], y)
 
     @abstractmethod
     def forward(self, t: float, y: Tensor):

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -27,30 +27,30 @@ class FixedSolver(AutogradSolver):
             step inside `solver` and the time step inside the iteration loop. A small
             error can thus buildup throughout the ODE integration. TODO Fix this.
         """
-        # assert that `t_save_all` values are multiples of `dt`
+        # assert that `t_stop` values are multiples of `dt`
         if not torch.allclose(
-            torch.round(self.t_save_all / self.dt), self.t_save_all / self.dt
+            torch.round(self.t_stop / self.dt), self.t_stop / self.dt
         ):
             raise ValueError(
-                'For fixed time step solvers, every value of `t_save_all` must be a'
+                'For fixed time step solvers, every value of `t_stop` must be a'
                 ' multiple of the time step `dt`.'
             )
 
         # define time values
-        num_times = torch.round(self.t_save_all[-1] / self.dt).int() + 1
-        times = torch.linspace(0.0, self.t_save_all[-1], num_times)
+        num_times = torch.round(self.t_stop[-1] / self.dt).int() + 1
+        times = torch.linspace(0.0, self.t_stop[-1], num_times)
 
         # run the ode routine
         y = self.y0
         for t in tqdm(times[:-1], disable=not self.options.verbose):
             # save solution
-            if t >= self.next_t_save_all():
+            if t >= self.next_t_stop():
                 self.save(y)
 
             # iterate solution
             y = self.forward(t, y)
 
-        # save final time step (`t` goes `0.0` to `t_save_all[-1]` excluded)
+        # save final time step (`t` goes `0.0` to `t_stop[-1]` excluded)
         self.save(y)
 
     @abstractmethod
@@ -64,27 +64,25 @@ class AdjointFixedSolver(FixedSolver, AdjointSolver):
 
     def run_augmented(self):
         """Integrate the augmented ODE backward using a fixed time step integrator."""
-        # check t_save_all_bwd
-        if not (self.t_save_all_bwd.ndim == 1 and len(self.t_save_all_bwd) == 2):
+        # check t_stop_bwd
+        if not (self.t_stop_bwd.ndim == 1 and len(self.t_stop_bwd) == 2):
             raise ValueError(
-                '`t_save_all_bwd` should be a tensor of size (2,), but has size'
-                f' {self.t_save_all_bwd.shape}.'
+                '`t_stop_bwd` should be a tensor of size (2,), but has size'
+                f' {self.t_stop_bwd.shape}.'
             )
-        if self.t_save_all_bwd[1] <= self.t_save_all_bwd[0]:
-            raise ValueError('`t_save_all_bwd` should be sorted in ascending order.')
+        if self.t_stop_bwd[1] <= self.t_stop_bwd[0]:
+            raise ValueError('`t_stop_bwd` should be sorted in ascending order.')
 
-        T = self.t_save_all_bwd[1] - self.t_save_all_bwd[0]
+        T = self.t_stop_bwd[1] - self.t_stop_bwd[0]
         if not torch.allclose(torch.round(T / self.dt), T / self.dt):
             raise ValueError(
-                'For fixed time step adjoint solvers, every value of `t_save_all_bwd` '
+                'For fixed time step adjoint solvers, every value of `t_stop_bwd` '
                 'must be a multiple of the time step `dt`.'
             )
 
         # define time values
         num_times = torch.round(T / self.dt).int() + 1
-        times = torch.linspace(
-            self.t_save_all_bwd[1], self.t_save_all_bwd[0], num_times
-        )
+        times = torch.linspace(self.t_stop_bwd[1], self.t_stop_bwd[0], num_times)
 
         # run the ode routine
         y, a, g = self.y_bwd, self.a_bwd, self.g_bwd
@@ -128,7 +126,7 @@ class AdjointFixedAutograd(torch.autograd.Function):
         """Forward pass of the ODE integrator."""
         # save into context for backward pass
         ctx.solver = solver
-        ctx.t_save_all = solver.t_save_all
+        ctx.t_stop = solver.t_stop
 
         # integrate the ODE forward without storing the graph of operations
         solver.run_nograd()
@@ -145,7 +143,7 @@ class AdjointFixedAutograd(torch.autograd.Function):
 
         An augmented ODE is integrated backwards starting from the final state computed
         during the forward pass. Integration is done in multiple sequential runs
-        between every checkpoint of the forward pass, as defined by `t_save_all`. This
+        between every checkpoint of the forward pass, as defined by `t_stop`. This
         helps with the stability of the backward integration.
 
         Throughout this function, `y` is the state, `a = dL/dy` is the adjoint state,
@@ -154,13 +152,13 @@ class AdjointFixedAutograd(torch.autograd.Function):
         """
         # unpack context
         solver = ctx.solver
-        t_save_all = ctx.t_save_all
+        t_stop = ctx.t_stop
         y_save = ctx.saved_tensors[0]
 
         # initialize time list
-        t_save_all = t_save_all
-        if t_save_all[0] != 0.0:
-            t_save_all = torch.cat((torch.zeros(1), t_save_all))
+        t_stop = t_stop
+        if t_stop[0] != 0.0:
+            t_stop = torch.cat((torch.zeros(1), t_stop))
 
         # locally disable gradient computation
         with torch.no_grad():
@@ -183,10 +181,10 @@ class AdjointFixedAutograd(torch.autograd.Function):
 
             # solve the augmented equation backward between every checkpoint
             for i in tqdm(
-                range(len(t_save_all) - 1, 0, -1), disable=not solver.options.verbose
+                range(len(t_stop) - 1, 0, -1), disable=not solver.options.verbose
             ):
                 # initialize time between both checkpoints
-                solver.t_save_all_bwd = t_save_all[i - 1 : i + 1]
+                solver.t_stop_bwd = t_stop[i - 1 : i + 1]
 
                 # run odeint on augmented state
                 solver.run_augmented()

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -32,8 +32,8 @@ class FixedSolver(AutogradSolver):
             torch.round(self.t_stop / self.dt), self.t_stop / self.dt
         ):
             raise ValueError(
-                'For fixed time step solvers, every value of `t_stop` must be a'
-                ' multiple of the time step `dt`.'
+                'For fixed time step solvers, every value of `t_save` (and also '
+                '`t_meas` for SME solvers) must be a multiple of the time step `dt`.'
             )
 
         # define time values

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -19,9 +19,9 @@ class Propagator(AutogradSolver):
 
     def run_autograd(self):
         y, t1 = self.y0, 0.0
-        for t2 in tqdm(self.t_save.cpu().numpy(), disable=not self.options.verbose):
+        for t2 in tqdm(self.t_save_all.cpu().numpy(), disable=not self.options.verbose):
             y = self.forward(t1, t2 - t1, y)
-            self.save(t2, y)
+            self.save(y)
             t1 = t2
 
     @abstractmethod

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -21,8 +21,8 @@ class Propagator(AutogradSolver):
         y, t1 = self.y0, 0.0
         for t2 in tqdm(self.t_save.cpu().numpy(), disable=not self.options.verbose):
             y = self.forward(t1, t2 - t1, y)
+            self.save(t2, y)
             t1 = t2
-            self.save(y)
 
     @abstractmethod
     def forward(self, t: float, delta_t: float, y: Tensor):

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -19,7 +19,7 @@ class Propagator(AutogradSolver):
 
     def run_autograd(self):
         y, t1 = self.y0, 0.0
-        for t2 in tqdm(self.t_save_all.cpu().numpy(), disable=not self.options.verbose):
+        for t2 in tqdm(self.t_stop.cpu().numpy(), disable=not self.options.verbose):
             y = self.forward(t1, t2 - t1, y)
             self.save(y)
             t1 = t2

--- a/dynamiqs/solvers/result.py
+++ b/dynamiqs/solvers/result.py
@@ -26,10 +26,17 @@ def tensor_str(x: Tensor) -> str:
 
 
 class Result:
-    def __init__(self, options: Options, y_save: Tensor, exp_save: Tensor):
+    def __init__(
+        self,
+        options: Options,
+        y_save: Tensor,
+        exp_save: Tensor,
+        meas_save: Tensor | None = None,
+    ):
         self.options = options
         self.y_save = y_save
         self.exp_save = exp_save
+        self.meas_save = meas_save
         self.start_time: float | None = None
         self.end_time: float | None = None
 
@@ -39,9 +46,14 @@ class Result:
         return self.y_save
 
     @property
-    def expvals(self) -> Tensor:
+    def expvals(self) -> Tensor | None:
         # alias for exp_save
         return self.exp_save
+
+    @property
+    def measvals(self) -> Tensor | None:
+        # alias for meas_save
+        return self.meas_save
 
     @property
     def solver_str(self) -> str:
@@ -72,10 +84,12 @@ class Result:
             f'Start      : {self.start_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
             f'End        : {self.end_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
             f'Total time : {self.total_time.total_seconds():.2f} s\n'
-            f'y_save     : {tensor_str(self.y_save)}'
+            f'states     : {tensor_str(self.states)}'
         )
-        if self.exp_save is not None:
-            tmp += f'\nexp_save   : {tensor_str(self.exp_save)}'
+        if self.expvals is not None:
+            tmp += f'\nexpvals    : {tensor_str(self.expvals)}'
+        if self.measvals is not None:
+            tmp += f'\nmeasvals   : {tensor_str(self.measvals)}'
         return tmp
 
     def to_qutip(self) -> Result:

--- a/dynamiqs/solvers/result.py
+++ b/dynamiqs/solvers/result.py
@@ -46,12 +46,12 @@ class Result:
         return self.y_save
 
     @property
-    def expvals(self) -> Tensor | None:
+    def expects(self) -> Tensor | None:
         # alias for exp_save
         return self.exp_save
 
     @property
-    def measvals(self) -> Tensor | None:
+    def measurements(self) -> Tensor | None:
         # alias for meas_save
         return self.meas_save
 
@@ -80,16 +80,16 @@ class Result:
     def __str__(self):
         tmp = (
             '==== Result ====\n'
-            f'Options    : {self.solver_str}\n'
-            f'Start      : {self.start_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
-            f'End        : {self.end_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
-            f'Total time : {self.total_time.total_seconds():.2f} s\n'
-            f'states     : {tensor_str(self.states)}'
+            f'Method       : {self.solver_str}\n'
+            f'Start        : {self.start_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
+            f'End          : {self.end_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
+            f'Total time   : {self.total_time.total_seconds():.2f} s\n'
+            f'states       : {tensor_str(self.states)}'
         )
-        if self.expvals is not None:
-            tmp += f'\nexpvals    : {tensor_str(self.expvals)}'
-        if self.measvals is not None:
-            tmp += f'\nmeasvals   : {tensor_str(self.measvals)}'
+        if self.expects is not None:
+            tmp += f'\nexpects      : {tensor_str(self.expects)}'
+        if self.measurements is not None:
+            tmp += f'\nmeasurements : {tensor_str(self.measurements)}'
         return tmp
 
     def to_qutip(self) -> Result:

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -12,13 +12,30 @@ from ..utils.td_tensor import TDTensor
 from ..utils.tensor_types import dtype_complex_to_real
 
 
-class Solver(ABC):
+class BaseSolver(ABC):
+    def __init__(self, t_save_all: Tensor):
+        self.t_save_all = t_save_all
+        self.t_save_all_counter = 0
+
+    def next_t_save_all(self) -> float:
+        return self.t_save_all[self.t_save_all_counter].item()
+
+    def save(self, y: Tensor):
+        self._save(y)
+        self.t_save_all_counter += 1
+
+    @abstractmethod
+    def _save(self, y: Tensor):
+        pass
+
+
+class Solver(BaseSolver):
     def __init__(
         self,
         H: TDTensor,
         y0: Tensor,
+        t_save_all: Tensor,
         t_save: Tensor,
-        t_save_y: Tensor,
         exp_ops: Tensor,
         options: Options,
     ):
@@ -31,35 +48,24 @@ class Solver(ABC):
             exp_ops:
             options:
         """
-        # check that `t_save` is valid (it must be a non-empty 1D tensor sorted in
-        # strictly ascending order and containing only positive values)
-        if t_save.ndim != 1 or len(t_save) == 0:
-            raise ValueError('Argument `t_save` must be a non-empty 1D tensor.')
-        if not torch.all(torch.diff(t_save) > 0):
-            raise ValueError(
-                'Argument `t_save` must be sorted in strictly ascending order.'
-            )
-        if not torch.all(t_save >= 0):
-            raise ValueError('Argument `t_save` must contain positive values only.')
-
+        super().__init__(t_save_all)
         self.H = H
         self.y0 = y0
-        self.t_save = t_save
-        self.t_save_y = t_save_y
         self.exp_ops = exp_ops
         self.options = options
 
-        self.save_counter = 0
-        self.save_y_counter = 0
+        # save logic for states and exp_ops
+        self.t_save_mask = torch.isin(self.t_save_all, t_save)
+        self.t_save_counter = 0
 
         # initialize save tensors
         batch_sizes, (m, n) = self.y0.shape[:-2], self.y0.shape[-2:]
 
         if self.options.save_states:
-            # y_save: (..., len(t_save_y), m, n)
+            # y_save: (..., len(t_save), m, n)
             self.y_save = torch.zeros(
                 *batch_sizes,
-                len(self.t_save_y),
+                len(t_save),
                 m,
                 n,
                 dtype=self.dtype,
@@ -67,11 +73,11 @@ class Solver(ABC):
             )
 
         if len(self.exp_ops) > 0:
-            # exp_save: (..., len(exp_ops), len(t_save_y))
+            # exp_save: (..., len(exp_ops), len(t_save))
             self.exp_save = torch.zeros(
                 *batch_sizes,
                 len(self.exp_ops),
-                len(self.t_save_y),
+                len(t_save),
                 dtype=self.dtype,
                 device=self.device,
             )
@@ -98,28 +104,22 @@ class Solver(ABC):
     def run_nograd(self):
         pass
 
-    def next_tsave(self) -> float:
-        return self.t_save[self.save_counter].item()
-
-    def save(self, t: float, y: Tensor):
-        self._save(t, y)
-        self.save_counter += 1
-
-    def _save(self, t: float, y: Tensor):
-        self._save_y(y)
-        self._save_exp_ops(y)
-        self.save_y_counter += 1
+    def _save(self, y: Tensor):
+        if self.t_save_mask[self.t_save_all_counter]:
+            self._save_y(y)
+            self._save_exp_ops(y)
+            self.t_save_counter += 1
 
     def _save_y(self, y: Tensor):
         if self.options.save_states:
-            self.y_save[..., self.save_y_counter, :, :] = y
+            self.y_save[..., self.t_save_counter, :, :] = y
         # otherwise only save the state if it is the final state
-        elif self.save_y_counter == len(self.t_save_y) - 1:
+        elif self.t_save_counter == len(self.t_save) - 1:
             self.y_save = y
 
     def _save_exp_ops(self, y: Tensor):
         if len(self.exp_ops) > 0:
-            self.exp_save[..., self.save_y_counter] = bexpect(self.exp_ops, y)
+            self.exp_save[..., self.t_save_counter] = bexpect(self.exp_ops, y)
 
 
 class AutogradSolver(Solver):

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from functools import cached_property
 
 import torch
 from torch import Tensor
@@ -8,6 +9,7 @@ from torch import Tensor
 from ..options import Options
 from ..utils.solver_utils import bexpect
 from ..utils.td_tensor import TDTensor
+from ..utils.tensor_types import dtype_complex_to_real
 
 
 class Solver(ABC):
@@ -16,6 +18,7 @@ class Solver(ABC):
         H: TDTensor,
         y0: Tensor,
         t_save: Tensor,
+        t_save_y: Tensor,
         exp_ops: Tensor,
         options: Options,
     ):
@@ -42,37 +45,51 @@ class Solver(ABC):
         self.H = H
         self.y0 = y0
         self.t_save = t_save
+        self.t_save_y = t_save_y
         self.exp_ops = exp_ops
         self.options = options
         self._cache = {}
 
         self.save_counter = 0
+        self.save_y_counter = 0
 
         # initialize save tensors
         batch_sizes, (m, n) = self.y0.shape[:-2], self.y0.shape[-2:]
 
         if self.options.save_states:
-            # y_save: (..., len(t_save), m, n)
+            # y_save: (..., len(t_save_y), m, n)
             self.y_save = torch.zeros(
                 *batch_sizes,
-                len(self.t_save),
+                len(self.t_save_y),
                 m,
                 n,
-                dtype=self.y0.dtype,
-                device=self.y0.device,
+                dtype=self.dtype,
+                device=self.device,
             )
 
         if len(self.exp_ops) > 0:
-            # exp_save: (..., len(exp_ops), len(t_save))
+            # exp_save: (..., len(exp_ops), len(t_save_y))
             self.exp_save = torch.zeros(
                 *batch_sizes,
                 len(self.exp_ops),
-                len(self.t_save),
-                dtype=self.y0.dtype,
-                device=self.y0.device,
+                len(self.t_save_y),
+                dtype=self.dtype,
+                device=self.device,
             )
         else:
             self.exp_save = None
+
+    @cached_property
+    def dtype(self) -> torch.complex64 | torch.complex128:
+        return self.y0.dtype
+
+    @cached_property
+    def device(self) -> torch.device:
+        return self.y0.device
+
+    @cached_property
+    def dtype_real(self) -> torch.float32 | torch.float64:
+        return dtype_complex_to_real(self.y0.dtype)
 
     def run(self):
         if self.options.gradient_alg is None:
@@ -85,21 +102,25 @@ class Solver(ABC):
     def next_tsave(self) -> float:
         return self.t_save[self.save_counter].item()
 
-    def save(self, y: Tensor):
+    def save(self, t: float, y: Tensor):
+        self._save(t, y)
+        self.save_counter += 1
+
+    def _save(self, t: float, y: Tensor):
         self._save_y(y)
         self._save_exp_ops(y)
-        self.save_counter += 1
+        self.save_y_counter += 1
 
     def _save_y(self, y: Tensor):
         if self.options.save_states:
-            self.y_save[..., self.save_counter, :, :] = y
+            self.y_save[..., self.save_y_counter, :, :] = y
         # otherwise only save the state if it is the final state
-        elif self.save_counter == len(self.t_save) - 1:
+        elif self.save_y_counter == len(self.t_save_y) - 1:
             self.y_save = y
 
     def _save_exp_ops(self, y: Tensor):
         if len(self.exp_ops) > 0:
-            self.exp_save[..., self.save_counter] = bexpect(self.exp_ops, y)
+            self.exp_save[..., self.save_y_counter] = bexpect(self.exp_ops, y)
 
 
 class AutogradSolver(Solver):

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -48,7 +48,6 @@ class Solver(ABC):
         self.t_save_y = t_save_y
         self.exp_ops = exp_ops
         self.options = options
-        self._cache = {}
 
         self.save_counter = 0
         self.save_y_counter = 0

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -154,16 +154,16 @@ def cache(func):
     return wrapper
 
 
-def check_time_tensor(x: Tensor, name: str, allow_empty=False):
+def check_time_tensor(x: Tensor, arg_name: str, allow_empty=False):
     # check that a time tensor is valid (it must be a 1D tensor sorted in strictly
     # ascending order and containing only positive values)
     if x.ndim != 1:
-        raise ValueError(f'Argument `{name}` must be a 1D tensor.')
+        raise ValueError(f'Argument `{arg_name}` must be a 1D tensor.')
     if not allow_empty and len(x) == 0:
-        raise ValueError(f'Argument `{name}` must contain at least one element.')
+        raise ValueError(f'Argument `{arg_name}` must contain at least one element.')
     if not torch.all(torch.diff(x) > 0):
         raise ValueError(
-            f'Argument `{name}` must be sorted in strictly ascending order.'
+            f'Argument `{arg_name}` must be sorted in strictly ascending order.'
         )
     if not torch.all(x >= 0):
-        raise ValueError(f'Argument `{name}` must contain positive values only.')
+        raise ValueError(f'Argument `{arg_name}` must contain positive values only.')

--- a/dynamiqs/utils/solver_utils.py
+++ b/dynamiqs/utils/solver_utils.py
@@ -147,8 +147,8 @@ def cache(func):
     return wrapper
 
 
-def check_time_array(x: Tensor, name: str, allow_empty=False):
-    # check that a time array is valid (it must be a 1D tensor sorted in strictly
+def check_time_tensor(x: Tensor, name: str, allow_empty=False):
+    # check that a time tensor is valid (it must be a 1D tensor sorted in strictly
     # ascending order and containing only positive values)
     if x.ndim != 1:
         raise ValueError(f'Argument `{name}` must be a 1D tensor.')

--- a/dynamiqs/utils/solver_utils.py
+++ b/dynamiqs/utils/solver_utils.py
@@ -145,3 +145,18 @@ def cache(func):
         return grad_cached_func(*args, grad_enabled=torch.is_grad_enabled(), **kwargs)
 
     return wrapper
+
+
+def check_time_array(x: Tensor, name: str, allow_empty=False):
+    # check that a time array is valid (it must be a 1D tensor sorted in strictly
+    # ascending order and containing only positive values)
+    if x.ndim != 1:
+        raise ValueError(f'Argument `{name}` must be a 1D tensor.')
+    if not allow_empty and len(x) == 0:
+        raise ValueError(f'Argument `{name}` must contain at least one element.')
+    if not torch.all(torch.diff(x) > 0):
+        raise ValueError(
+            f'Argument `{name}` must be sorted in strictly ascending order.'
+        )
+    if not torch.all(x >= 0):
+        raise ValueError(f'Argument `{name}` must contain positive values only.')


### PR DESCRIPTION
Here's a first attempt at writing `smesolve`, with a basic Euler scheme (that works!), and only for diffusive-type measurement. Thanks to the arbitrary batching of the state and the reorganisation of the solvers, this was actually quite easy. I had to slighlty modify the saving logic of the `Solver` base class (see first commit).

Left to do (in other PRs):
- [ ] Rouchon method
- [ ] run trajectories in //
- [ ] testing
- [ ] jump SME (later)

Two things we need to discuss together:
1. Currently the signal value we get at each time step `dt` is integrated to give a value for each entry of `t_save`. Maybe it's better that the user specifies a separate `tbin` parameter (which divides `t_save[-1]`) over which we integrate the signal regularly, and keep `t_save` only for the state?
2. Moreover, the returned signal has one element less than `t_save`, because technically we don't have the signal value for the first time. This is a bit annoying for post-processing. We could _fake_ a first measurement by computing the signal on `rho_0`?