### PR TITLE
Performance and notation improvements for the adaptive solver

### DIFF
--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -99,7 +99,7 @@ class ODEAdaptiveStep(Options):
         atol: float = 1e-8,
         rtol: float = 1e-6,
         max_steps: int = 100_000,
-        factor: float = 0.9,
+        safety_factor: float = 0.9,
         min_factor: float = 0.2,
         max_factor: float = 5.0,
         **kwargs,
@@ -108,7 +108,7 @@ class ODEAdaptiveStep(Options):
         self.atol = atol
         self.rtol = rtol
         self.max_steps = max_steps
-        self.factor = factor
+        self.safety_factor = safety_factor
         self.min_factor = min_factor
         self.max_factor = max_factor
 

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -220,7 +220,7 @@ class DormandPrince5(AdaptiveSolver):
         alpha, beta, csol, cerr = self.tableau
 
         # compute iterated Runge-Kutta values
-        k = torch.zeros(7, *f0.shape, dtype=f0.dtype, device=f0.device)
+        k = torch.empty(7, *f0.shape, dtype=f0.dtype, device=f0.device)
         k[0] = f0
         for i in range(1, 7):
             ti = t0 + dt * alpha[i - 1]

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -152,12 +152,12 @@ class AdaptiveSolver(AutogradSolver):
 
         if error <= 1:  # time step accepted -> take next time step at least as large
             return dt * min(
-                self.options.max_factor, max(1.0, self.options.factor * fac_opt)
+                self.options.max_factor, max(1.0, self.options.safety_factor * fac_opt)
             )
 
         if error > 1:  # time step rejected -> reduce next time step
             return dt * min(
-                0.9, max(self.options.min_factor, self.options.factor * fac_opt)
+                0.9, max(self.options.min_factor, self.options.safety_factor * fac_opt)
             )
 
 

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -224,11 +224,11 @@ class DormandPrince5(AdaptiveSolver):
         k[0] = f0
         for i in range(1, 7):
             ti = t0 + dt * alpha[i - 1]
-            yi = y0 + dt * torch.einsum('b,b...', beta[i - 1, :i], k[:i])
+            yi = y0 + torch.tensordot(dt * beta[i - 1, :i], k[:i], dims=([0], [0]))
             k[i] = self.odefun(ti, yi)
 
         # compute results
-        y1 = y0 + dt * torch.einsum('b,b...', csol[:6], k[:6])
-        y1_err = dt * torch.einsum('b,b...', cerr, k)
+        y1 = y0 + torch.tensordot(dt * csol[:6], k[:6], dims=([0], [0]))
+        y1_err = torch.tensordot(dt * cerr, k, dims=([0], [0]))
         f1 = k[-1]
         return f1, y1, y1_err

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -214,21 +214,21 @@ class DormandPrince5(AdaptiveSolver):
         return alpha, beta, csol5, csol5 - csol4
 
     def step(
-        self, f0: Tensor, y0: Tensor, t0: float, dt: float
+        self, f: Tensor, y: Tensor, t: float, dt: float
     ) -> tuple[Tensor, Tensor, Tensor]:
         # import butcher tableau
         alpha, beta, csol, cerr = self.tableau
 
         # compute iterated Runge-Kutta values
-        k = torch.empty(7, *f0.shape, dtype=f0.dtype, device=f0.device)
-        k[0] = f0
+        k = torch.empty(7, *f.shape, dtype=f.dtype, device=f.device)
+        k[0] = f
         for i in range(1, 7):
-            ti = t0 + dt * alpha[i - 1]
-            yi = y0 + torch.tensordot(dt * beta[i - 1, :i], k[:i], dims=([0], [0]))
-            k[i] = self.odefun(ti, yi)
+            dy = torch.tensordot(dt * beta[i - 1, :i], k[:i], dims=([0], [0]))
+            k[i] = self.odefun(t + dt * alpha[i - 1], y + dy)
 
         # compute results
-        y1 = y0 + torch.tensordot(dt * csol[:6], k[:6], dims=([0], [0]))
-        y1_err = torch.tensordot(dt * cerr, k, dims=([0], [0]))
-        f1 = k[-1]
-        return f1, y1, y1_err
+        f_new = k[-1]
+        y_new = y + torch.tensordot(dt * csol[:6], k[:6], dims=([0], [0]))
+        y_err = torch.tensordot(dt * cerr, k, dims=([0], [0]))
+
+        return f_new, y_new, y_err

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -147,17 +147,19 @@ class AdaptiveSolver(AutogradSolver):
         if error == 0:  # no error -> maximally increase the time step
             return dt * self.options.max_factor
 
-        # optimal time step
-        fac_opt = error ** (-1.0 / self.order)
-
         if error <= 1:  # time step accepted -> take next time step at least as large
-            return dt * min(
-                self.options.max_factor, max(1.0, self.options.safety_factor * fac_opt)
+            return dt * max(
+                1.0,
+                min(
+                    self.options.max_factor,
+                    self.options.safety_factor * error ** (-1.0 / self.order),
+                ),
             )
 
         if error > 1:  # time step rejected -> reduce next time step
-            return dt * min(
-                0.9, max(self.options.min_factor, self.options.safety_factor * fac_opt)
+            return dt * max(
+                self.options.min_factor,
+                self.options.safety_factor * error ** (-1.0 / self.order),
             )
 
 


### PR DESCRIPTION
Follows notations and workflow of scipy more closely (see [scipy/integrate/_ivp/rk.py](https://github.com/scipy/scipy/blob/c1ed5ece8ffbf05356a22a8106affcd11bd3aee0/scipy/integrate/_ivp/rk.py#L102)).

Also, moves from `torch.einsum` to `torch.tensordot` for performance. With this simple benchmark, I saw a systematic improvement (sometimes quite a lot for smaller matrices) both on cpu and gpu:
```python
import torch
import timeit

M = 10
N = 1000
device = 'cpu'

c = torch.randn(M, dtype=torch.complex64).to(device)
k = torch.randn(M, N, N, dtype=torch.complex64).to(device)

print(torch.allclose(torch.einsum('b,b...', c, k), torch.tensordot(c, k, dims=([0], [0]))))
%timeit torch.einsum('b,b...', c, k)
%timeit torch.tensordot(c, k, dims=([0], [0]))
```