### PR TITLE
Add result class

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import torch
 
 from ..options import Dopri5, Euler, Options, Rouchon1, Rouchon1_5, Rouchon2
-from ..solvers.utils.tensor_formatter import TensorFormatter
 from ..solvers.result import Result
+from ..solvers.utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import MEDormandPrince5
 from .euler import MEEuler
@@ -62,7 +62,7 @@ def mesolve(
         options (Options, optional): Solver options. See the list of available solvers.
 
     Returns:
-        Simulation result.
+        Result of the master equation integration.
     """
     # H: (b_H?, n, n), rho0: (b_rho0?, n, n) -> (y_save, exp_save) with
     #    - y_save: (b_H?, b_rho0?, len(t_save), n, n)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import torch
-from torch import Tensor
 
 from ..options import Dopri5, Euler, Options, Propagator
 from ..solvers.utils.tensor_formatter import TensorFormatter
+from ..solvers.result import Result
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import SEDormandPrince5
 from .euler import SEEuler
@@ -18,7 +18,7 @@ def sesolve(
     *,
     exp_ops: OperatorLike | list[OperatorLike] | None = None,
     options: Options | None = None,
-) -> tuple[Tensor, Tensor | None]:
+) -> Result:
     # H: (b_H?, n, n), psi0: (b_psi0?, n, 1) -> (y_save, exp_save) with
     #    - y_save: (b_H?, b_psi0?, len(t_save), n, 1)
     #    - exp_save: (b_H?, b_psi0?, len(exp_ops), len(t_save))
@@ -54,8 +54,8 @@ def sesolve(
     solver.run()
 
     # get saved tensors and restore correct batching
-    psi_save, exp_save = solver.y_save, solver.exp_save
-    psi_save = formatter.unbatch(psi_save)
-    exp_save = formatter.unbatch(exp_save)
+    result = solver.result
+    result.y_save = formatter.unbatch(result.y_save)
+    result.exp_save = formatter.unbatch(result.exp_save)
 
-    return psi_save, exp_save
+    return result

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import torch
 
 from ..options import Dopri5, Euler, Options, Propagator
-from ..solvers.utils.tensor_formatter import TensorFormatter
 from ..solvers.result import Result
+from ..solvers.utils.tensor_formatter import TensorFormatter
 from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
 from .adaptive import SEDormandPrince5
 from .euler import SEEuler

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -131,10 +131,10 @@ class AdjointFixedAutograd(torch.autograd.Function):
         solver.run_nograd()
 
         # save results and model parameters
-        ctx.save_for_backward(solver.y_save)
+        ctx.save_for_backward(solver.result.y_save)
 
         # returning `y_save` is required for custom backward functions
-        return solver.y_save, solver.exp_save
+        return solver.result.y_save, solver.result.exp_save
 
     @staticmethod
     def backward(ctx: FunctionCtx, *grad_y: Tensor) -> tuple[None, Tensor, Tensor]:

--- a/dynamiqs/solvers/result.py
+++ b/dynamiqs/solvers/result.py
@@ -17,12 +17,12 @@ def memory_str(x: Tensor) -> str:
         return f'{mem / 1024:.2f} Kb'
     elif mem < 1024**3:
         return f'{mem / 1024**2:.2f} Mb'
-
-    return f'{mem / 1024**3:.2f} Gb'
+    else:
+        return f'{mem / 1024**3:.2f} Gb'
 
 
 def tensor_str(x: Tensor) -> str:
-    return f'tensor {tuple(x.size())} [{memory_str(x)}]'
+    return f'Tensor {tuple(x.size())} | {memory_str(x)}'
 
 
 class Result:
@@ -32,6 +32,16 @@ class Result:
         self.exp_save = exp_save
         self.start_time: float | None = None
         self.end_time: float | None = None
+
+    @property
+    def states(self) -> Tensor:
+        # alias for y_save
+        return self.y_save
+
+    @property
+    def expvals(self) -> Tensor:
+        # alias for exp_save
+        return self.exp_save
 
     @property
     def solver_str(self) -> str:
@@ -57,7 +67,7 @@ class Result:
 
     def __str__(self):
         tmp = (
-            '==== Result ===\n'
+            '==== Result ====\n'
             f'Options    : {self.solver_str}\n'
             f'Start      : {self.start_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
             f'End        : {self.end_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'

--- a/dynamiqs/solvers/result.py
+++ b/dynamiqs/solvers/result.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from torch import Tensor
+
+from ..options import Options
+
+
+def memory_bytes(x: Tensor) -> int:
+    return x.element_size() * x.numel()
+
+
+def memory_str(x: Tensor) -> str:
+    mem = memory_bytes(x)
+    if mem < 1024**2:
+        return f'{mem / 1024:.2f} Kb'
+    elif mem < 1024**3:
+        return f'{mem / 1024**2:.2f} Mb'
+
+    return f'{mem / 1024**3:.2f} Gb'
+
+
+def tensor_str(x: Tensor) -> str:
+    return f'tensor {tuple(x.size())} [{memory_str(x)}]'
+
+
+class Result:
+    def __init__(self, options: Options, y_save: Tensor, exp_save: Tensor):
+        self.options = options
+        self.y_save = y_save
+        self.exp_save = exp_save
+        self.start_time: float | None = None
+        self.end_time: float | None = None
+
+    @property
+    def solver_str(self) -> str:
+        return self.options.__class__.__name__
+
+    @property
+    def start_datetime(self) -> datetime | None:
+        if self.start_time is None:
+            return None
+        return datetime.fromtimestamp(self.start_time)
+
+    @property
+    def end_datetime(self) -> datetime | None:
+        if self.end_time is None:
+            return None
+        return datetime.fromtimestamp(self.end_time)
+
+    @property
+    def total_time(self) -> timedelta | None:
+        if self.start_datetime is None or self.end_datetime is None:
+            return None
+        return self.end_datetime - self.start_datetime
+
+    def __str__(self):
+        tmp = (
+            '==== Result ===\n'
+            f'Options    : {self.solver_str}\n'
+            f'Start      : {self.start_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
+            f'End        : {self.end_datetime.strftime("%Y-%m-%d %H:%M:%S")}\n'
+            f'Total time : {self.total_time.total_seconds():.2f} s\n'
+            f'y_save     : {tensor_str(self.y_save)}'
+        )
+        if self.exp_save is not None:
+            tmp += f'\nexp_save   : {tensor_str(self.exp_save)}'
+        return tmp
+
+    def to_qutip(self) -> Result:
+        raise NotImplementedError
+
+    def to_numpy(self) -> Result:
+        raise NotImplementedError
+
+    def save(self, filename: str):
+        raise NotImplementedError
+
+    def load(self, filename: str) -> Result:
+        raise NotImplementedError

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -7,9 +7,9 @@ import torch
 from torch import Tensor
 
 from ..options import Options
+from .result import Result
 from .utils.td_tensor import TDTensor
 from .utils.utils import bexpect
-from .result import Result
 
 
 class Solver(ABC):

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from time import time
 
 import torch
 from torch import Tensor
@@ -8,6 +9,7 @@ from torch import Tensor
 from ..options import Options
 from .utils.td_tensor import TDTensor
 from .utils.utils import bexpect
+from .result import Result
 
 
 class Solver(ABC):
@@ -49,32 +51,34 @@ class Solver(ABC):
         self.save_counter = 0
 
         # initialize save tensors
-        batch_sizes, (m, n) = self.y0.shape[:-2], self.y0.shape[-2:]
+        batch_sizes, (m, n) = y0.shape[:-2], y0.shape[-2:]
 
         if self.options.save_states:
             # y_save: (..., len(t_save), m, n)
-            self.y_save = torch.zeros(
-                *batch_sizes,
-                len(self.t_save),
-                m,
-                n,
-                dtype=self.y0.dtype,
-                device=self.y0.device,
+            y_save = torch.zeros(
+                *batch_sizes, len(t_save), m, n, dtype=y0.dtype, device=y0.device
             )
 
         if len(self.exp_ops) > 0:
             # exp_save: (..., len(exp_ops), len(t_save))
-            self.exp_save = torch.zeros(
+            exp_save = torch.zeros(
                 *batch_sizes,
-                len(self.exp_ops),
-                len(self.t_save),
-                dtype=self.y0.dtype,
-                device=self.y0.device,
+                len(exp_ops),
+                len(t_save),
+                dtype=y0.dtype,
+                device=y0.device,
             )
         else:
-            self.exp_save = None
+            exp_save = None
+
+        self.result = Result(options, y_save, exp_save)
 
     def run(self):
+        self.result.start_time = time()
+        self._run()
+        self.result.end_time = time()
+
+    def _run(self):
         if self.options.gradient_alg is None:
             self.run_nograd()
 
@@ -92,19 +96,19 @@ class Solver(ABC):
 
     def _save_y(self, y: Tensor):
         if self.options.save_states:
-            self.y_save[..., self.save_counter, :, :] = y
+            self.result.y_save[..., self.save_counter, :, :] = y
         # otherwise only save the state if it is the final state
         elif self.save_counter == len(self.t_save) - 1:
-            self.y_save = y
+            self.result.y_save = y
 
     def _save_exp_ops(self, y: Tensor):
         if len(self.exp_ops) > 0:
-            self.exp_save[..., self.save_counter] = bexpect(self.exp_ops, y)
+            self.result.exp_save[..., self.save_counter] = bexpect(self.exp_ops, y)
 
 
 class AutogradSolver(Solver):
-    def run(self):
-        super().run()
+    def _run(self):
+        super()._run()
         if self.options.gradient_alg == 'autograd':
             self.run_autograd()
 
@@ -118,8 +122,8 @@ class AutogradSolver(Solver):
 
 
 class AdjointSolver(AutogradSolver):
-    def run(self):
-        super().run()
+    def _run(self):
+        super()._run()
         if self.options.gradient_alg == 'adjoint':
             self.run_adjoint()
 

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -13,6 +13,6 @@ class TestAdaptive(MESolverTester):
         options = dq.options.Dopri5()
         self._test_batching(options, leaky_cavity_8)
 
-    def test_rho_save(self):
+    def test_y_save(self):
         options = dq.options.Dopri5()
-        self._test_rho_save(options, leaky_cavity_8, num_t_save=11)
+        self._test_y_save(options, leaky_cavity_8, num_t_save=11)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -13,6 +13,6 @@ class TestMEEuler(MESolverTester):
         options = dq.options.Euler(dt=1e-2)
         self._test_batching(options, leaky_cavity_8)
 
-    def test_rho_save(self):
+    def test_y_save(self):
         options = dq.options.Euler(dt=1e-4)
-        self._test_rho_save(options, leaky_cavity_8, num_t_save=11)
+        self._test_y_save(options, leaky_cavity_8, num_t_save=11)

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -18,9 +18,9 @@ class TestMERouchon1(MEAdjointSolverTester):
         options = dq.options.Rouchon1(dt=1e-2)
         self._test_batching(options, leaky_cavity_8)
 
-    def test_rho_save(self):
+    def test_y_save(self):
         options = dq.options.Rouchon1(dt=1e-3)
-        self._test_rho_save(options, leaky_cavity_8, num_t_save=11)
+        self._test_y_save(options, leaky_cavity_8, num_t_save=11)
 
     def test_adjoint(self):
         options = dq.options.Rouchon1(dt=1e-3)
@@ -34,9 +34,9 @@ class TestMERouchon1_5(MEAdjointSolverTester):
         self._test_batching(options, leaky_cavity_8)
 
     @pytest.mark.skip(reason='failing - to fix')
-    def test_rho_save(self):
+    def test_y_save(self):
         options = dq.options.Rouchon1_5(dt=1e-3)
-        self._test_rho_save(options, leaky_cavity_8, num_t_save=11)
+        self._test_y_save(options, leaky_cavity_8, num_t_save=11)
 
 
 class TestMERouchon2(MEAdjointSolverTester):
@@ -44,9 +44,9 @@ class TestMERouchon2(MEAdjointSolverTester):
         options = dq.options.Rouchon2(dt=1e-2)
         self._test_batching(options, leaky_cavity_8)
 
-    def test_rho_save(self):
+    def test_y_save(self):
         options = dq.options.Rouchon2(dt=1e-3)
-        self._test_rho_save(options, leaky_cavity_8, num_t_save=11)
+        self._test_y_save(options, leaky_cavity_8, num_t_save=11)
 
     def test_adjoint(self):
         options = dq.options.Rouchon2(dt=1e-3)

--- a/tests/sesolve/se_solver_tester.py
+++ b/tests/sesolve/se_solver_tester.py
@@ -25,29 +25,29 @@ class SESolverTester:
         )
 
         # no batching
-        psi_save, exp_save = run_sesolve(system.H, system.psi0)
-        assert psi_save.shape == (num_t_save, n, 1)
-        assert exp_save.shape == (n_exp_ops, num_t_save)
+        result = run_sesolve(system.H, system.psi0)
+        assert result.y_save.shape == (num_t_save, n, 1)
+        assert result.exp_save.shape == (n_exp_ops, num_t_save)
 
         # batched H
-        psi_save, exp_save = run_sesolve(system.H_batched, system.psi0)
-        assert psi_save.shape == (b_H, num_t_save, n, 1)
-        assert exp_save.shape == (b_H, n_exp_ops, num_t_save)
+        result = run_sesolve(system.H_batched, system.psi0)
+        assert result.y_save.shape == (b_H, num_t_save, n, 1)
+        assert result.exp_save.shape == (b_H, n_exp_ops, num_t_save)
 
         # batched psi0
-        psi_save, exp_save = run_sesolve(system.H, system.psi0_batched)
-        assert psi_save.shape == (b_psi0, num_t_save, n, 1)
-        assert exp_save.shape == (b_psi0, n_exp_ops, num_t_save)
+        result = run_sesolve(system.H, system.psi0_batched)
+        assert result.y_save.shape == (b_psi0, num_t_save, n, 1)
+        assert result.exp_save.shape == (b_psi0, n_exp_ops, num_t_save)
 
         # batched H and psi0
-        psi_save, exp_save = run_sesolve(system.H_batched, system.psi0_batched)
-        assert psi_save.shape == (b_H, b_psi0, num_t_save, n, 1)
-        assert exp_save.shape == (b_H, b_psi0, n_exp_ops, num_t_save)
+        result = run_sesolve(system.H_batched, system.psi0_batched)
+        assert result.y_save.shape == (b_H, b_psi0, num_t_save, n, 1)
+        assert result.exp_save.shape == (b_H, b_psi0, n_exp_ops, num_t_save)
 
     def test_batching(self):
         pass
 
-    def _test_psi_save(
+    def _test_y_save(
         self,
         options: Options,
         system: ClosedSystem,
@@ -57,16 +57,16 @@ class SESolverTester:
     ):
         t_save = system.t_save(num_t_save)
 
-        psi_save, _ = dq.sesolve(
+        y_save = dq.sesolve(
             system.H,
             system.psi0,
             t_save,
             exp_ops=system.exp_ops,
             options=options,
-        )
+        ).y_save
 
-        errs = torch.norm(psi_save - system.psis(t_save), dim=(-2, -1))
+        errs = torch.norm(y_save - system.psis(t_save), dim=(-2, -1))
         assert torch.all(errs <= norm_atol)
 
-    def test_psi_save(self):
+    def test_y_save(self):
         pass

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -13,6 +13,6 @@ class TestAdaptive(SESolverTester):
         options = dq.options.Dopri5()
         self._test_batching(options, cavity_8)
 
-    def test_rho_save(self):
+    def test_y_save(self):
         options = dq.options.Dopri5()
-        self._test_psi_save(options, cavity_8, num_t_save=11)
+        self._test_y_save(options, cavity_8, num_t_save=11)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -13,6 +13,6 @@ class TestSEEuler(SESolverTester):
         options = dq.options.Euler(dt=1e-2)
         self._test_batching(options, cavity_8)
 
-    def test_psi_save(self):
+    def test_y_save(self):
         options = dq.options.Euler(dt=1e-4)
-        self._test_psi_save(options, cavity_8, num_t_save=11)
+        self._test_y_save(options, cavity_8, num_t_save=11)

--- a/tests/sesolve/test_propagator.py
+++ b/tests/sesolve/test_propagator.py
@@ -13,6 +13,6 @@ class TestPropagator(SESolverTester):
         options = dq.options.Propagator()
         self._test_batching(options, cavity_8)
 
-    def test_psi_save(self):
+    def test_y_save(self):
         options = dq.options.Propagator()
-        self._test_psi_save(options, cavity_8, num_t_save=11)
+        self._test_y_save(options, cavity_8, num_t_save=11)


### PR DESCRIPTION
First basic proposal for a result class, here's how the printing looks:
```python
>>> result = dq.mesolve(...)
>>> print(result)
==== Result ===
Options    : Rouchon1
Start      : 2023-07-02 15:12:13
End        : 2023-07-02 15:12:13
Total time : 0.45 s
y_save     : tensor (4, 101, 64, 64) [12.62 Mb]
exp_save   : tensor (4, 2, 101) [6.31 Kb]
```

There's a lot to add, here's a quick list on the top of my head:
- [ ] Implement `to_qutip()` and `to_numpy()` returning a new object where we converted `y_save` and `exp_save` to a list of `Qobj`/numpy array or just big numpy arrays.
- [ ] Implement `save()` and `load()`: we need to save dynamiqs current version, the commit version (+ wip if needed) and a version saving scheme (we raise an error if we try to load an incompatible version). I think it would also be nice to have a hash for each result object, e.g. if someone wants to use them as index in a database.
- [ ] Implement solver specific savings (e.g. for adaptive solvers the number of iterations).
- [ ] Implement a `__str__` method for `Options` base class and child classes.

Moreover, we should probably choose other name for the api than `y_save` and `exp_save` (I think they are good internally though), we can just set aliases on the result class for the uses, what do you think about `states` and `expects`?

I'd like to rebase #141 on this once we agree on the structure.