### PR TITLE
Update run_nograd with inference_mode

### DIFF
--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -113,7 +113,7 @@ class AutogradSolver(Solver):
             self.run_autograd()
 
     def run_nograd(self):
-        with torch.no_grad():
+        with torch.inference_mode():
             self.run_autograd()
 
     @abstractmethod


### PR DESCRIPTION
See https://pytorch.org/docs/stable/generated/torch.inference_mode.html.

Quoting the PyTorch doc:

> Inference mode is the extreme version of no-grad mode. Just like in no-grad mode, computations in inference mode are not recorded in the backward graph, but enabling inference mode will allow PyTorch to speed up your model even more. This better runtime comes with a drawback: tensors created in inference mode will not be able to be used in computations to be recorded by autograd after exiting inference mode.
>
> Enable inference mode when you are performing computations that don’t need to be recorded in the backward graph, AND you don’t plan on using the tensors created in inference mode in any computation that is to be recorded by autograd later.
> 
> It is recommended that you try out inference mode in the parts of your code that do not require autograd tracking (e.g., data processing and model evaluation). If it works out of the box for your use case it’s a free performance win. If you run into errors after enabling inference mode, check that you are not using tensors created in inference mode in computations that are recorded by autograd after exiting inference mode. If you cannot avoid such use in your case, you can always switch back to no-grad mode.