### PR TITLE
Fix for two-line parameters when deploying doc

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -190,3 +190,8 @@
 .md-typeset table:not([class]) td.fixed_height code {
     font-weight:600;
 }
+
+/* Fix for two-line parameters when deploying doc */
+.field-body p {
+    display: inline;
+}


### PR DESCRIPTION
The missing culprit. It's likely that the whole file `_mkdocstrings.css` is missing. For now I'm just hacking around it.

<img width="352" alt="Screenshot 2023-07-08 at 19 03 32" src="https://github.com/dynamiqs/dynamiqs/assets/25346881/3fd1beb8-9e41-4d55-880e-240c7e412a08">
