### PR TITLE
Add `ArrayLike` type to replace `TensorLike` and `OperatorLike`

### DIFF
--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -43,8 +43,6 @@ def sesolve(
     # exp_ops: (len(exp_ops), n, n)
     formatter = TensorFormatter(options.cdtype, options.device)
     H_batched, psi0_batched = formatter.format_H_and_state(H, psi0)
-    # H_batched: (b_H, 1, n, n)
-    # psi0_batched: (b_H, b_psi0, n, 1)
     exp_ops = to_tensor(exp_ops, dtype=options.cdtype, device=options.device)
 
     # convert t_save to tensor

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -1,24 +1,22 @@
 from __future__ import annotations
 
-import torch
-
 from .._utils import obj_type_str
 from ..options import Dopri5, Euler, Options, Propagator
 from ..solvers.result import Result
 from ..solvers.utils.tensor_formatter import TensorFormatter
 from ..solvers.utils.utils import check_time_tensor
-from ..utils.tensor_types import OperatorLike, TDOperatorLike, TensorLike
+from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
 from .adaptive import SEDormandPrince5
 from .euler import SEEuler
 from .propagator import SEPropagator
 
 
 def sesolve(
-    H: TDOperatorLike,
-    psi0: OperatorLike,
-    t_save: TensorLike,
+    H: TDArrayLike,
+    psi0: ArrayLike,
+    t_save: ArrayLike,
     *,
-    exp_ops: list[OperatorLike] | None = None,
+    exp_ops: list[ArrayLike] | None = None,
     options: Options | None = None,
 ) -> Result:
     """Solve the Schrödinger equation."""
@@ -40,14 +38,17 @@ def sesolve(
         )
 
     # format and batch all tensors
+    # H_batched: (b_H, 1, n, n)
+    # psi0_batched: (b_H, b_psi0, n, 1)
+    # exp_ops: (len(exp_ops), n, n)
     formatter = TensorFormatter(options.cdtype, options.device)
     H_batched, psi0_batched = formatter.format_H_and_state(H, psi0)
     # H_batched: (b_H, 1, n, n)
     # psi0_batched: (b_H, b_psi0, n, 1)
-    exp_ops = formatter.format(exp_ops)  # (len(exp_ops), n, n)
+    exp_ops = to_tensor(exp_ops, dtype=options.cdtype, device=options.device)
 
     # convert t_save to tensor
-    t_save = torch.as_tensor(t_save, dtype=options.rdtype, device=options.device)
+    t_save = to_tensor(t_save, dtype=options.rdtype, device=options.device)
     check_time_tensor(t_save, arg_name='t_save')
 
     # define the solver

--- a/dynamiqs/solvers/utils/td_tensor.py
+++ b/dynamiqs/solvers/utils/td_tensor.py
@@ -7,19 +7,19 @@ import torch
 from torch import Tensor
 
 from ..._utils import obj_type_str, to_device, type_str
-from ...utils.tensor_types import OperatorLike, TDOperatorLike, get_rdtype, to_tensor
+from ...utils.tensor_types import ArrayLike, TDArrayLike, get_rdtype, to_tensor
 from .utils import cache
 
 
 def to_td_tensor(
-    x: TDOperatorLike,
+    x: TDArrayLike,
     dtype: torch.dtype | None = None,
     device: str | torch.device | None = None,
 ) -> TDTensor:
-    """Convert a `TDOperatorLike` object to a `TDTensor` object."""
+    """Convert a `TDArrayLike` object to a `TDTensor` object."""
     device = to_device(device)
 
-    if isinstance(x, get_args(OperatorLike)):
+    if isinstance(x, get_args(ArrayLike)):
         # convert to tensor
         x = to_tensor(x, dtype=dtype, device=device)
         return ConstantTDTensor(x)

--- a/dynamiqs/solvers/utils/tensor_formatter.py
+++ b/dynamiqs/solvers/utils/tensor_formatter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 
-from ...utils.tensor_types import OperatorLike, TDOperatorLike, to_tensor
+from ...utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
 from ...utils.utils import is_ket, ket_to_dm
 from .td_tensor import TDTensor, to_td_tensor
 
@@ -21,7 +21,7 @@ class TensorFormatter:
         self.state_is_batched = False
 
     def format_H_and_state(
-        self, H: TDOperatorLike, state: OperatorLike, state_to_dm: bool = False
+        self, H: TDArrayLike, state: ArrayLike, state_to_dm: bool = False
     ) -> tuple[TDTensor, Tensor]:
         """Convert and batch Hamiltonian and state (state vector or density matrix)."""
         # convert Hamiltonian to `TDTensor`
@@ -49,10 +49,6 @@ class TensorFormatter:
         state = state.repeat(b_H, 1, 1, 1)  # (b_H, b_state, n, n)
 
         return H, state
-
-    def format(self, operator: OperatorLike) -> Tensor:
-        """Convert and batch a given operator according to the Hamiltonian and state."""
-        return to_tensor(operator, dtype=self.cdtype, device=self.device)
 
     def unbatch(self, save: Tensor | None) -> Tensor | None:
         """Unbatch saved tensors."""

--- a/dynamiqs/utils/tensor_types.py
+++ b/dynamiqs/utils/tensor_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Union, get_args
+from typing import Callable, Union
 
 import numpy as np
 import torch
@@ -15,29 +15,25 @@ __all__ = [
     'to_qutip',
 ]
 
-# type for objects convertible to a torch.Tensor using `torch.as_tensor`
-TensorLike = Union[list, np.ndarray, Tensor]
-
 # type for objects convertible to a torch.Tensor using `to_tensor`
-OperatorLike = Union[TensorLike, Qobj]
+ArrayLike = Union[list, np.ndarray, Tensor, Qobj]
 
 # TODO add typing for Hamiltonian with piecewise-constant factor
 # type for time-dependent objects
-TDOperatorLike = Union[OperatorLike, Callable[[float], Tensor]]
+TDArrayLike = Union[ArrayLike, Callable[[float], Tensor]]
 
 
 def to_tensor(
-    x: OperatorLike | list[OperatorLike] | None,
+    x: ArrayLike | list[ArrayLike] | None,
     *,
     dtype: torch.dtype | None = None,
     device: str | torch.device | None = None,
 ) -> Tensor:
-    """Convert an array-like object (or a list of array-like objects) to a tensor.
+    """Convert an array-like object or a list of array-like objects to a tensor.
 
     Args:
-        x: QuTiP quantum object or NumPy array or Python list or PyTorch tensor or
-            list of these types. If `None` or empty list, returns an empty tensor of
-            shape _(0)_.
+        x: QuTiP quantum object or NumPy array or Python list or PyTorch tensor or list
+            of these types. If `None` returns an empty tensor of shape _(0)_.
         dtype: Data type of the returned tensor.
         device: Device on which the returned tensor is stored.
 
@@ -49,15 +45,15 @@ def to_tensor(
     if isinstance(x, list):
         if len(x) == 0:
             return torch.tensor([], dtype=dtype, device=device)
-        return torch.stack([to_tensor(y, dtype=dtype, device=device) for y in x])
-    if isinstance(x, Qobj):
+        return torch.stack([to_tensor(el, dtype=dtype, device=device) for el in x])
+    elif isinstance(x, Qobj):
         return from_qutip(x, dtype=get_cdtype(dtype), device=device)
-    elif isinstance(x, get_args(TensorLike)):
+    elif isinstance(x, (np.ndarray, Tensor)):
         return torch.as_tensor(x, dtype=dtype, device=device)
     else:
         raise TypeError(
-            'Argument `x` must be an array-like object, but has type'
-            f' {obj_type_str(x)}.'
+            'Argument `x` must be an array-like object or a list of array-like objects,'
+            f' but has type {obj_type_str(x)}.'
         )
 
 

--- a/dynamiqs/utils/tensor_types.py
+++ b/dynamiqs/utils/tensor_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Union
+from typing import Callable, Union, get_args
 
 import numpy as np
 import torch
@@ -45,8 +45,11 @@ def to_tensor(
     if isinstance(x, list):
         if len(x) == 0:
             return torch.tensor([], dtype=dtype, device=device)
-        return torch.stack([to_tensor(el, dtype=dtype, device=device) for el in x])
-    elif isinstance(x, Qobj):
+        if not isinstance(x[0], get_args(ArrayLike)):
+            return torch.as_tensor(x, dtype=dtype, device=device)
+        else:
+            return torch.stack([to_tensor(el, dtype=dtype, device=device) for el in x])
+    if isinstance(x, Qobj):
         return from_qutip(x, dtype=get_cdtype(dtype), device=device)
     elif isinstance(x, (np.ndarray, Tensor)):
         return torch.as_tensor(x, dtype=dtype, device=device)

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -8,7 +8,7 @@ from torch import Tensor
 
 import dynamiqs as dq
 from dynamiqs.options import Options
-from dynamiqs.utils.tensor_types import TensorLike
+from dynamiqs.utils.tensor_types import ArrayLike
 
 
 class OpenSystem(ABC):
@@ -42,7 +42,7 @@ class OpenSystem(ABC):
         return dq.expect(self.loss_op, rho).real
 
     def mesolve(
-        self, t_save: TensorLike, options: Options
+        self, t_save: ArrayLike, options: Options
     ) -> tuple[Tensor, Tensor | None]:
         return dq.mesolve(
             self.H,


### PR DESCRIPTION
On top of #173.

Fuses `TensorLike` and `OperatorLike` for simpler API. I don't really expect anyone to use a `qutip.Qobj` to define their `t_save`, so I think it's fine to not distinguish them. 😅 Also fix a bug with `to_tensor` not working for list of floats.