### PR TITLE
Modify trace for higher performance

### DIFF
--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -39,7 +39,7 @@ def trace(x: Tensor) -> Tensor:
         >>> dq.trace(x)
         tensor(3.)
     """
-    return x.diagonal(offset=0, dim1=-1, dim2=-2).sum(-1)
+    return x.diagonal(dim1=-1, dim2=-2).sum(-1)
 
 
 def expect(O: Tensor, x: Tensor) -> Tensor:


### PR DESCRIPTION
```python
import torch
import timeit

B, N = 10, 10
x = torch.randn(B, N, N)
%timeit x.diagonal(offset=0, dim1=-1, dim2=-2).sum(-1)
%timeit torch.einsum('...ii', x)
# 7.12 µs ± 226 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
# 18.8 µs ± 384 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

B, N = 10, 1000
x = torch.randn(B, N, N)
%timeit x.diagonal(offset=0, dim1=-1, dim2=-2).sum(-1)
%timeit torch.einsum('...ii', x)
# 70.9 µs ± 119 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
# 85.2 µs ± 1.94 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```
