### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ We hope that this library will prove beneficial to the community for e.g. simula
 
 ## Installation
 
-We will soon make a first release of the library on PyPi. In the meantime, you can clone the repository locally and install directly from source:
+We will soon make a first release of the library on PyPi. In the meantime, you can install directly from source:
 
 ```shell
-git clone https://github.com/dynamiqs/dynamiqs.git
-pip install -e dynamiqs
+pip install git+https://github.com/dynamiqs/dynamiqs.git
 ```
 
 ## Examples

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,8 +1,7 @@
 # Installation
 
-We will soon make a first release of the library on PyPi. In the meantime, you can clone the repository locally and install directly from source:
+We will soon make a first release of the library on PyPi. In the meantime, you can install directly from source:
 
 ```shell
-git clone https://github.com/dynamiqs/dynamiqs.git
-pip install -e dynamiqs
+pip install git+https://github.com/dynamiqs/dynamiqs.git
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,10 @@ dependencies = [
     "methodtools",
 ]
 
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
 [project.optional-dependencies]
 dev = [
     "taskipy",
@@ -26,9 +30,6 @@ dev = [
     "mkdocs-literate-nav",
     "mkdocs-section-index",
 ]
-
-[tool.setuptools]
-packages = ["dynamiqs"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
The previous installation was broken when installing with pip in non-editable mode. This fixes the issue, and switches from the default `setuptools` to `flit` to package our library (much simpler to use).