### PR TITLE
Add `__version__` fetched from `pyproject.toml`

### DIFF
--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -1,4 +1,9 @@
+from importlib.metadata import version
+
 from .mesolve import mesolve
 from .sesolve import sesolve
 from .smesolve import smesolve
 from .utils import *
+
+# get version from pyproject.toml
+__version__ = version(__package__)


### PR DESCRIPTION
Fix #195.

For now the single source of truth for the package version is the version defined in `pyproject.toml`. This is temporary, I'm still thinking about the best workflow to properly manage our package versioning (including a clean and easy changelog, automatic publishing on pypi upon new git tag, easily access the documentation of older versions on the website, etc...).

Again thanks to @blaise-vignon for opening the issue.