### PR TITLE
Fix incorrect `torch.squeeze` usage

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -126,8 +126,8 @@ def mesolve(
 
     # get saved tensors and restore correct batching
     result = solver.result
-    result.y_save = result.y_save.squeeze(0, 1)
+    result.y_save = result.y_save.squeeze(1).squeeze(0)
     if result.exp_save is not None:
-        result.exp_save = result.exp_save.squeeze(0, 1)
+        result.exp_save = result.exp_save.squeeze(1).squeeze(0)
 
     return result

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -66,8 +66,8 @@ def sesolve(
 
     # get saved tensors and restore correct batching
     result = solver.result
-    result.y_save = result.y_save.squeeze(0, 1)
+    result.y_save = result.y_save.squeeze(1).squeeze(0)
     if result.exp_save is not None:
-        result.exp_save = result.exp_save.squeeze(0, 1)
+        result.exp_save = result.exp_save.squeeze(1).squeeze(0)
 
     return result

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -119,10 +119,10 @@ def smesolve(
 
     # get saved tensors and restore correct batching
     result = solver.result
-    result.y_save = result.y_save.squeeze(0, 1)
+    result.y_save = result.y_save.squeeze(1).squeeze(0)
     if result.exp_save is not None:
-        result.exp_save = result.exp_save.squeeze(0, 1)
+        result.exp_save = result.exp_save.squeeze(1).squeeze(0)
     if result.meas_save is not None:
-        result.meas_save = result.meas_save.squeeze(0, 1)
+        result.meas_save = result.meas_save.squeeze(1).squeeze(0)
 
     return result


### PR DESCRIPTION
Passing a tuple to `torch.squeeze` is only valid in PyTorch >= 2.0.