### PR TITLE
Add Rouchon solver of order 1 for SME

### DIFF
--- a/dynamiqs/mesolve/me_solver.py
+++ b/dynamiqs/mesolve/me_solver.py
@@ -1,3 +1,4 @@
+import torch
 from torch import Tensor
 
 from ..solvers.solver import Solver
@@ -13,6 +14,9 @@ class MESolver(Solver):
         # define cached operator
         # non-hermitian Hamiltonian
         self.Hnh = cache(lambda H: H - 0.5j * self.sum_LdagL)  # (b_H, 1, n, n)
+
+        n = self.H.size(-1)
+        self.I = torch.eye(n, device=self.device, dtype=self.cdtype)  # (n, n)
 
     def lindbladian(self, t: float, rho: Tensor) -> Tensor:
         """Compute the action of the Lindbladian on the density matrix.

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from math import sqrt
 
-import torch
 from torch import Tensor
 
 from ..solvers.ode.fixed_solver import AdjointFixedSolver
@@ -18,11 +17,7 @@ from .me_solver import MESolver
 
 
 class MERouchon(MESolver, AdjointFixedSolver):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.n = self.H.size(-1)
-        self.I = torch.eye(self.n, device=self.device, dtype=self.cdtype)  # (n, n)
+    pass
 
 
 class MERouchon1(MERouchon):

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -27,11 +27,11 @@ class MERouchon1(MERouchon):
         if not self.options.sqrt_normalization:
             # define cached operators
             # self.M0, self.M0rev: (b_H, 1, n, n)
-            # self.M1s: (1, len(L), n, n)
             self.M0 = cache(lambda Hnh: self.I - 1j * self.dt * Hnh)
             self.M0rev = cache(lambda Hnh: self.I + 1j * self.dt * Hnh)
 
             # define M1s and M1srev
+            # self.M1s: (1, len(L), n, n)
             self.M1s = sqrt(self.dt) * self.L
             self.M1srev = self.M1s
         else:
@@ -51,11 +51,11 @@ class MERouchon1(MERouchon):
 
             # define cached operators
             # self.M0, self.M0rev: (b_H, 1, n, n)
-            # self.M1s, self.M1srev: (1, len(L), n, n)
             self.M0 = cache(lambda Hnh: self.S - 1j * self.dt * Hnh @ self.S)
             self.M0rev = cache(lambda Hnh: self.Srev + 1j * self.dt * Hnh @ self.Srev)
 
             # define M1s and M1srev
+            # self.M1s, self.M1srev: (1, len(L), n, n)
             self.M1s = sqrt(self.dt) * self.L @ self.S
             self.M1srev = sqrt(self.dt) * self.L @ self.Srev
 

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -171,3 +171,7 @@ Rouchon = Rouchon1
 
 class Rouchon2(ODEFixedStep, AdjointOptions):
     pass
+
+
+class Rouchon1SME(ODEFixedStep):
+    pass

--- a/dynamiqs/smesolve/euler.py
+++ b/dynamiqs/smesolve/euler.py
@@ -11,10 +11,10 @@ class SMEEuler(SMESolver, FixedSolver):
         # sample Wiener process
         dw = self.sample_wiener(self.dt)
 
-        # update state
-        drho = self.dt * self.lindbladian(t, rho) + self.diff_backaction(dw, rho)
-
         # update measured signal
         self.update_meas(dw, rho)
+
+        # update state
+        drho = self.dt * self.lindbladian(t, rho) + self.diff_backaction(dw, rho)
 
         return rho + drho

--- a/dynamiqs/smesolve/rouchon.py
+++ b/dynamiqs/smesolve/rouchon.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import torch
 from torch import Tensor
 
 from ..mesolve.rouchon import MERouchon1
@@ -10,7 +11,11 @@ from .sme_solver import SMESolver
 
 
 class SMERouchon(SMESolver, FixedSolver):
-    pass
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.n = self.H.shape[-1]
+        self.I = torch.eye(self.n, device=self.device, dtype=self.cdtype)  # (n, n)
 
 
 class SMERouchon1(SMERouchon, MERouchon1):

--- a/dynamiqs/smesolve/rouchon.py
+++ b/dynamiqs/smesolve/rouchon.py
@@ -1,32 +1,45 @@
 from __future__ import annotations
 
+from math import sqrt
+
 import torch
 from torch import Tensor
 
-from ..mesolve.rouchon import MERouchon1
 from ..solvers.ode.fixed_solver import FixedSolver
-from ..solvers.utils import kraus_map
+from ..solvers.utils import cache, kraus_map
 from ..utils.utils import unit
 from .sme_solver import SMESolver
 
 
 class SMERouchon(SMESolver, FixedSolver):
+    pass
+
+
+class SMERouchon1(SMERouchon):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.n = self.H.shape[-1]
-        self.I = torch.eye(self.n, device=self.device, dtype=self.cdtype)  # (n, n)
+        # define cached operators
+        # self.M0 (b_H, 1, n, n)
+        self.M0_tmp = cache(lambda Hnh: self.I - 1j * self.dt * Hnh)
 
+        # define M1s
+        # self.M1s: # (1, len(L), n, n)
+        self.M1s = torch.cat(
+            [
+                sqrt(self.dt) * self.T,
+                torch.sqrt(self.dt * (1 - self.etas))[..., None, None] * self.V,
+            ],
+        )[None, ...]
 
-class SMERouchon1(SMERouchon, MERouchon1):
     def forward(self, t: float, rho: Tensor) -> Tensor:
         # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, n, n)
 
         # compute cached operators
-        # H, Hnh, M0: (b_H, 1, ntrajs, n, n)
+        # H, Hnh, M0_tmp: (b_H, 1, ntrajs, n, n)
         H = self.H(t)
         Hnh = self.Hnh(H)
-        M0 = self.M0(Hnh)
+        M0_tmp = self.M0_tmp(Hnh)
 
         # sample Wiener process
         dw = self.sample_wiener(self.dt)
@@ -35,14 +48,9 @@ class SMERouchon1(SMERouchon, MERouchon1):
         dy = self.update_meas(dw, rho)
 
         # update state
-        # M, rho: (b_H, b_rho, ntrajs, n, n)
-        M = M0 + (self.etas.sqrt() * self.V @ dy).sum(-3)
-        rho = (
-            kraus_map(rho, M)
-            + kraus_map(rho, self.M1s)
-            + (1 - self.etas) * kraus_map(rho, self.V) * self.dt
-        )
-
+        # M0: (b_H, 1, ntrajs, n, n)
+        M0 = M0_tmp + ((self.etas.sqrt() * dy)[..., None, None] * self.V).sum(-3)
+        rho = M0 @ rho @ M0.mH + kraus_map(rho, self.M1s)
         rho = unit(rho)
 
         return rho

--- a/dynamiqs/smesolve/rouchon.py
+++ b/dynamiqs/smesolve/rouchon.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from torch import Tensor
+
+from ..mesolve.rouchon import MERouchon1
+from ..solvers.ode.fixed_solver import FixedSolver
+from ..solvers.utils import kraus_map
+from ..utils.utils import unit
+from .sme_solver import SMESolver
+
+
+class SMERouchon(SMESolver, FixedSolver):
+    pass
+
+
+class SMERouchon1(SMERouchon, MERouchon1):
+    def forward(self, t: float, rho: Tensor) -> Tensor:
+        # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, n, n)
+
+        # compute cached operators
+        # H, Hnh, M0: (b_H, 1, ntrajs, n, n)
+        H = self.H(t)
+        Hnh = self.Hnh(H)
+        M0 = self.M0(Hnh)
+
+        # sample Wiener process
+        dw = self.sample_wiener(self.dt)
+
+        # update measured signal
+        dy = self.update_meas(dw, rho)
+
+        # update state
+        # M, rho: (b_H, b_rho, ntrajs, n, n)
+        M = M0 + (self.etas.sqrt() * self.V @ dy).sum(-3)
+        rho = (
+            kraus_map(rho, M)
+            + kraus_map(rho, self.M1s)
+            + (1 - self.etas) * kraus_map(rho, self.V) * self.dt
+        )
+
+        rho = unit(rho)
+
+        return rho

--- a/dynamiqs/smesolve/rouchon.py
+++ b/dynamiqs/smesolve/rouchon.py
@@ -27,8 +27,8 @@ class SMERouchon1(SMERouchon):
         # self.M1s: # (1, len(L), n, n)
         self.M1s = torch.cat(
             [
-                sqrt(self.dt) * self.T,
-                torch.sqrt(self.dt * (1 - self.etas))[..., None, None] * self.V,
+                sqrt(self.dt) * self.Lc,
+                torch.sqrt(self.dt * (1 - self.etas))[..., None, None] * self.Lm,
             ],
         )[None, ...]
 
@@ -49,7 +49,7 @@ class SMERouchon1(SMERouchon):
 
         # update state
         # M0: (b_H, 1, ntrajs, n, n)
-        M0 = M0_tmp + ((self.etas.sqrt() * dy)[..., None, None] * self.V).sum(-3)
+        M0 = M0_tmp + ((self.etas.sqrt() * dy)[..., None, None] * self.Lm).sum(-3)
         rho = M0 @ rho @ M0.mH + kraus_map(rho, self.M1s)
         rho = unit(rho)
 

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -110,7 +110,9 @@ class SMESolver(MESolver):
         prefactor = self.etas.sqrt() * dw
         return (prefactor[..., None, None] * tmp).sum(-3)
 
-    def update_meas(self, dw: Tensor, rho: Tensor):
-        Lp_rho = self.Lp(rho)  # (..., b, n, n)
-        exp_val = self.exp_val(Lp_rho)  # (..., b)
-        self.bin_meas += self.etas.sqrt() * exp_val * self.dt + dw
+    def update_meas(self, dw: Tensor, rho: Tensor) -> Tensor:
+        Lp_rho = self.Lp(rho)  # (..., len(V), n, n)
+        exp_val = self.exp_val(Lp_rho)  # (..., len(V))
+        dy = self.etas.sqrt() * exp_val * self.dt + dw  # (..., len(V))
+        self.bin_meas += dy
+        return dy

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -15,17 +15,20 @@ class SMESolver(MESolver):
         self,
         *args,
         jump_ops: Tensor,
-        meas_ops: Tensor,
         etas: Tensor,
         generator: torch.Generator,
         t_meas: Tensor,
     ):
-        self.V = meas_ops  # (len(V), n, n)
-        self.etas = etas  # (len(V))
-        self.generator = generator
         self.t_meas = t_meas  # (len(t_meas))
-
         super().__init__(*args, jump_ops=jump_ops)
+
+        # split jump operators between purely dissipative (eta = 0) and
+        # monitored (eta != 0)
+        mask = etas == 0.0
+        self.T = jump_ops[mask]  # (len(T), n, n) purely dissipative
+        self.V = jump_ops[~mask]  # (len(V), n, n) monitored
+        self.etas = etas[~mask]  # (len(V))
+        self.generator = generator
 
         # initialize additional save tensors
         batch_sizes = self.y0.shape[:-2]

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -25,17 +25,17 @@ class SMESolver(MESolver):
         # split jump operators between purely dissipative (eta = 0) and
         # monitored (eta != 0)
         mask = etas == 0.0
-        self.T = jump_ops[mask]  # (len(T), n, n) purely dissipative
-        self.V = jump_ops[~mask]  # (len(V), n, n) monitored
-        self.etas = etas[~mask]  # (len(V))
+        self.Lc = jump_ops[mask]  # (len(Lc), n, n) purely dissipative
+        self.Lm = jump_ops[~mask]  # (len(Lm), n, n) monitored
+        self.etas = etas[~mask]  # (len(Lm))
         self.generator = generator
 
         # initialize additional save tensors
         batch_sizes = self.y0.shape[:-2]
 
-        self.meas_shape = (*batch_sizes, len(self.V))
+        self.meas_shape = (*batch_sizes, len(self.Lm))
 
-        # meas_save: (..., len(V), len(t_meas))
+        # meas_save: (..., len(Lm), len(t_meas))
         if len(t_meas) > 0:
             meas_save = torch.zeros(
                 *self.meas_shape,
@@ -82,40 +82,40 @@ class SMESolver(MESolver):
         ).to(dtype=self.rdtype)
 
     @cache
-    def Vp(self, rho: Tensor) -> Tensor:
-        # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, len(V), n, n)
-        # V @ rho + rho @ Vdag
-        V_rho = torch.einsum('bij,...jk->...bik', self.V, rho)
-        return V_rho + V_rho.mH
+    def Lmp(self, rho: Tensor) -> Tensor:
+        # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, len(Lm), n, n)
+        # Lm @ rho + rho @ Lmdag
+        Lm_rho = torch.einsum('bij,...jk->...bik', self.Lm, rho)
+        return Lm_rho + Lm_rho.mH
 
     @cache
-    def exp_val(self, Vp_rho: Tensor) -> Tensor:
-        return trace(Vp_rho).real
+    def exp_val(self, Lmp_rho: Tensor) -> Tensor:
+        return trace(Lmp_rho).real
 
     def diff_backaction(self, dw: Tensor, rho: Tensor) -> Tensor:
         # Compute the measurement backaction term of the diffusive SME.
-        # $$ \sum_k \sqrt{\eta_k} \mathcal{M}[V_k](\rho) dW_k $$
+        # $$ \sum_k \sqrt{\eta_k} \mathcal{M}[Lm_k](\rho) dW_k $$
         # where
-        # $$ \mathcal{M}[V](\rho) = V \rho + \rho V^\dag -
-        # \mathrm{Tr}\left[(V + V^\dag) \rho\right] \rho $$
+        # $$ \mathcal{M}[Lm](\rho) = Lm \rho + \rho Lm^\dag -
+        # \mathrm{Tr}\left[(Lm + Lm^\dag) \rho\right] \rho $$
 
         # rho: (b_H, b_rho, ntrajs, n, n) -> (b_H, b_rho, ntrajs, n, n)
 
-        # V @ rho + rho @ Vdag
-        Vp_rho = self.Vp(rho)  # (..., len(V), n, n)
-        exp_val = self.exp_val(Vp_rho)  # (..., len(V))
+        # Lm @ rho + rho @ Lmdag
+        Lmp_rho = self.Lmp(rho)  # (..., len(Lm), n, n)
+        exp_val = self.exp_val(Lmp_rho)  # (..., len(Lm))
 
-        # V @ rho + rho @ Vdag - Tr(V @ rho + rho @ Vdag) rho
-        # tmp: (..., len(V), n, n)
-        tmp = Vp_rho - exp_val[..., None, None] * rho[..., None, :, :]
+        # Lm @ rho + rho @ Lmdag - Tr(Lm @ rho + rho @ Lmdag) rho
+        # tmp: (..., len(Lm), n, n)
+        tmp = Lmp_rho - exp_val[..., None, None] * rho[..., None, :, :]
 
-        # sum sqrt(eta) * dw * [V @ rho + rho @ Vdag - Tr(V @ rho + rho @ Vdag) rho]
+        # sum sqrt(eta) * dw * [Lm @ rho + rho @ Lmdag - Tr(Lm @ rho + rho @ Lmdag) rho]
         prefactor = self.etas.sqrt() * dw
         return (prefactor[..., None, None] * tmp).sum(-3)
 
     def update_meas(self, dw: Tensor, rho: Tensor) -> Tensor:
-        Vp_rho = self.Vp(rho)  # (..., len(V), n, n)
-        exp_val = self.exp_val(Vp_rho)  # (..., len(V))
-        dy = self.etas.sqrt() * exp_val * self.dt + dw  # (..., len(V))
+        Lmp_rho = self.Lmp(rho)  # (..., len(Lm), n, n)
+        exp_val = self.exp_val(Lmp_rho)  # (..., len(Lm))
+        dy = self.etas.sqrt() * exp_val * self.dt + dw  # (..., len(Lm))
         self.bin_meas += dy
         return dy

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import torch
 
 from .._utils import obj_type_str
-from ..options import Euler, Options, Rouchon1
+from ..options import Euler, Options, Rouchon1SME
 from ..solvers.result import Result
 from ..solvers.utils import batch_H, batch_y0, check_time_tensor, to_td_tensor
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
@@ -105,11 +105,7 @@ def smesolve(
         generator=generator,
         t_meas=t_meas,
     )
-    if isinstance(options, Rouchon1):
-        if options.gradient_alg == 'adjoint':
-            raise ValueError(
-                'The gradient algorithm "adjoint" is not supported by smesolve.'
-            )
+    if isinstance(options, Rouchon1SME):
         solver = SMERouchon1(*args, **kwargs)
     elif isinstance(options, Euler):
         solver = SMEEuler(*args, **kwargs)

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import torch
 
 from .._utils import obj_type_str
-from ..options import Euler, Options
+from ..options import Euler, Options, Rouchon1
 from ..solvers.result import Result
 from ..solvers.utils import batch_H, batch_y0, check_time_tensor, to_td_tensor
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
 from ..utils.utils import is_ket, ket_to_dm
 from .euler import SMEEuler
+from .rouchon import SMERouchon1
 
 
 def smesolve(
@@ -104,7 +105,13 @@ def smesolve(
         generator=generator,
         t_meas=t_meas,
     )
-    if isinstance(options, Euler):
+    if isinstance(options, Rouchon1):
+        if options.gradient_alg == 'adjoint':
+            raise ValueError(
+                'The gradient algorithm "adjoint" is not supported by smesolve.'
+            )
+        solver = SMERouchon1(*args, **kwargs)
+    elif isinstance(options, Euler):
         solver = SMEEuler(*args, **kwargs)
     else:
         raise ValueError(f'Solver options {obj_type_str(options)} is not supported.')

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -88,10 +88,6 @@ def smesolve(
     if torch.any(etas < 0.0) or torch.any(etas > 1.0):
         raise ValueError('Argument `etas` must contain values between 0 and 1.')
 
-    # split jump operators between purely dissipative (eta = 0) and monitored (eta != 0)
-    mask = etas == 0.0
-    meas_ops, etas = jump_ops[~mask], etas[~mask]
-
     # convert t_meas to a tensor
     t_meas = to_tensor(t_meas, dtype=options.rdtype, device=options.device)
     check_time_tensor(t_meas, arg_name='t_meas', allow_empty=True)
@@ -104,7 +100,6 @@ def smesolve(
     args = (H, rho0, t_save, exp_ops, options)
     kwargs = dict(
         jump_ops=jump_ops,
-        meas_ops=meas_ops,
         etas=etas,
         generator=generator,
         t_meas=t_meas,


### PR DESCRIPTION
Here's a little cheatsheet to help checking the solver, it's actually very similar to Rouchon of order 1 for `mesolve`.

<img width="1201" alt="Screenshot 2023-09-08 at 16 41 48" src="https://github.com/dynamiqs/dynamiqs/assets/38159029/615f91a8-2ef0-4567-9010-51854a425fc1">

Note that purely dissipative processes (jump operators not monitored, named $T$ in the code) have $\eta_k=0$, and we can thus compute terms that depend on $\eta_k$ only for monitored jump operators (named $V$ in the code).