### PR TITLE
Dictionary API for solver options

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ t_save = np.linspace(0, 1.0, 101)
 # torch.set_default_device('gpu')
 
 # simulation
-options = dq.options.Dopri5(gradient_alg='autograd', verbose=False)
+options = dict(gradient_alg='autograd', verbose=False)
 result = dq.mesolve(H, jump_ops, rho0, t_save, options=options)
 
 # gradient computation

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ t_save = np.linspace(0, 1.0, 101)
 # torch.set_default_device('gpu')
 
 # simulation
-options = dict(gradient_alg='autograd', verbose=False)
-result = dq.mesolve(H, jump_ops, rho0, t_save, options=options)
+options = dict(verbose=False)
+result = dq.mesolve(H, jump_ops, rho0, t_save, gradient='autograd', options=options)
 
 # gradient computation
 loss = dq.expect(a.mH @ a, result.states[-1])  # Tr[a^dag a rho]

--- a/docs/getting_started/examples.md
+++ b/docs/getting_started/examples.md
@@ -1,6 +1,7 @@
 # First examples
 
 First time using dynamiqs? Below are a few basic examples to help you get started. For more advanced tutorials, check out our [Tutorials](../tutorials/index.md) section.
+
 ## Simulate a lossy quantum harmonic oscillator
 
 This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$ using QuTiP-defined objects:
@@ -70,7 +71,7 @@ t_save = np.linspace(0, 1.0, 101)
 # torch.set_default_device('gpu')
 
 # simulation
-options = dq.options.Dopri5(gradient_alg='autograd', verbose=False)
+options = dict(gradient_alg='autograd', verbose=False)
 result = dq.mesolve(H, jump_ops, rho0, t_save, options=options)
 
 # gradient computation

--- a/docs/getting_started/examples.md
+++ b/docs/getting_started/examples.md
@@ -71,8 +71,8 @@ t_save = np.linspace(0, 1.0, 101)
 # torch.set_default_device('gpu')
 
 # simulation
-options = dict(gradient_alg='autograd', verbose=False)
-result = dq.mesolve(H, jump_ops, rho0, t_save, options=options)
+options = dict(verbose=False)
+result = dq.mesolve(H, jump_ops, rho0, t_save, gradient='autograd', options=options)
 
 # gradient computation
 loss = dq.expect(a.mH @ a, result.states[-1])  # Tr[a^dag a rho]

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -21,7 +21,7 @@ def mesolve(
     *,
     exp_ops: list[ArrayLike] | None = None,
     solver: str = 'dopri5',
-    gradient: str = '',
+    gradient: str | None = None,
     options: dict[str, Any] | None = None,
 ) -> Result:
     """Solve the Lindblad master equation for a Hamiltonian and set of jump operators.

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -21,6 +21,7 @@ def mesolve(
     *,
     exp_ops: list[ArrayLike] | None = None,
     solver: str = 'dopri5',
+    gradient: str = '',
     options: dict[str, Any] | None = None,
 ) -> Result:
     """Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
@@ -75,6 +76,7 @@ def mesolve(
     # options
     if options is None:
         options = {}
+    options['gradient_alg'] = gradient
     if solver == 'dopri5':
         options = Dopri5(**options)
         SOLVER_CLASS = MEDormandPrince5

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from typing import Any
+
 from .._utils import obj_type_str
-from ..options import Dopri5, Euler, Options, Rouchon1, Rouchon2
+from ..solvers.options import Dopri5, Euler, Rouchon1, Rouchon2
 from ..solvers.result import Result
 from ..solvers.utils import batch_H, batch_y0, check_time_tensor, to_td_tensor
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
@@ -18,7 +20,8 @@ def mesolve(
     t_save: ArrayLike,
     *,
     exp_ops: list[ArrayLike] | None = None,
-    options: Options | None = None,
+    solver: str = 'dopri5',
+    options: dict[str, Any] | None = None,
 ) -> Result:
     """Solve the Lindblad master equation for a Hamiltonian and set of jump operators.
 
@@ -69,8 +72,23 @@ def mesolve(
     #    - y_save: (b_H?, b_rho0?, len(t_save), n, n)
     #    - exp_save: (b_H?, b_rho0?, len(exp_ops), len(t_save))
 
-    # default options
-    options = options or Dopri5()
+    # options
+    if options is None:
+        options = {}
+    if solver == 'dopri5':
+        options = Dopri5(**options)
+        SOLVER_CLASS = MEDormandPrince5
+    elif solver == 'euler':
+        options = Euler(**options)
+        SOLVER_CLASS = MEEuler
+    elif solver == 'rouchon' or solver == 'rouchon1':
+        options = Rouchon1(**options)
+        SOLVER_CLASS = MERouchon1
+    elif solver == 'rouchon2':
+        options = Rouchon2(**options)
+        SOLVER_CLASS = MERouchon2
+    else:
+        raise ValueError(f'Solver "{solver}" is not supported.')
 
     # check jump_ops
     if not isinstance(jump_ops, list):
@@ -110,16 +128,7 @@ def mesolve(
 
     # define the solver
     args = (H, rho0, t_save, exp_ops, options)
-    if isinstance(options, Rouchon1):
-        solver = MERouchon1(*args, jump_ops=jump_ops)
-    elif isinstance(options, Rouchon2):
-        solver = MERouchon2(*args, jump_ops=jump_ops)
-    elif isinstance(options, Dopri5):
-        solver = MEDormandPrince5(*args, jump_ops=jump_ops)
-    elif isinstance(options, Euler):
-        solver = MEEuler(*args, jump_ops=jump_ops)
-    else:
-        raise ValueError(f'Solver options {obj_type_str(options)} is not supported.')
+    solver = SOLVER_CLASS(*args, jump_ops=jump_ops)
 
     # compute the result
     solver.run()

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -19,6 +19,7 @@ def sesolve(
     *,
     exp_ops: list[ArrayLike] | None = None,
     solver: str = 'dopri5',
+    gradient: str | None = None,
     options: dict[str, Any] | None = None,
 ) -> Result:
     """Solve the Schrödinger equation."""
@@ -32,6 +33,7 @@ def sesolve(
     # options
     if options is None:
         options = {}
+    options['gradient_alg'] = gradient
     if solver == 'dopri5':
         options = Dopri5(**options)
         SOLVER_CLASS = SEDormandPrince5

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 
 from .._utils import obj_type_str
-from ..options import Euler, Options
+from ..solvers.options import Euler
 from ..solvers.result import Result
 from ..solvers.utils import batch_H, batch_y0, check_time_tensor, to_td_tensor
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
@@ -22,7 +24,8 @@ def smesolve(
     t_meas: ArrayLike | None = None,
     seed: int | None = None,
     exp_ops: list[ArrayLike] | None = None,
-    options: Options | None = None,
+    solver: str = '',
+    options: dict[str, Any] | None = None,
 ) -> Result:
     """Solve the Stochastic master equation."""
     # H: (b_H?, n, n), rho0: (b_rho0?, n, n) -> (y_save, exp_save, meas_save) with
@@ -30,11 +33,19 @@ def smesolve(
     #    - exp_save: (b_H?, b_rho0?, ntrajs, len(exp_ops), len(t_save))
     #    - meas_save: (b_H?, b_rho0?, ntrajs, len(meas_ops), len(t_meas) - 1)
 
-    # default options
-    if options is None:
+    # default solver
+    if solver == '':
         raise ValueError(
-            'No default solver yet, please specify one using the `options` argument.'
+            'No default solver yet, please specify one using the `solver` argument.'
         )
+    # options
+    if options is None:
+        options = {}
+    if solver == 'euler':
+        options = Euler(**options)
+        SOLVER_CLASS = SMEEuler
+    else:
+        raise ValueError(f'Solver "{solver}" is not supported.')
 
     # check jump_ops
     if not isinstance(jump_ops, list):
@@ -109,10 +120,7 @@ def smesolve(
         generator=generator,
         t_meas=t_meas,
     )
-    if isinstance(options, Euler):
-        solver = SMEEuler(*args, **kwargs)
-    else:
-        raise ValueError(f'Solver options {obj_type_str(options)} is not supported.')
+    solver = SOLVER_CLASS(*args, **kwargs)
 
     # compute the result
     solver.run()

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -25,6 +25,7 @@ def smesolve(
     seed: int | None = None,
     exp_ops: list[ArrayLike] | None = None,
     solver: str = '',
+    gradient: str | None = None,
     options: dict[str, Any] | None = None,
 ) -> Result:
     """Solve the Stochastic master equation."""
@@ -41,6 +42,7 @@ def smesolve(
     # options
     if options is None:
         options = {}
+    options['gradient_alg'] = gradient
     if solver == 'euler':
         options = Euler(**options)
         SOLVER_CLASS = SMEEuler

--- a/dynamiqs/solvers/options.py
+++ b/dynamiqs/solvers/options.py
@@ -5,14 +5,13 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-from ._utils import to_device
-from .utils.tensor_types import dtype_complex_to_real, get_cdtype
+from .._utils import to_device
+from ..utils.tensor_types import dtype_complex_to_real, get_cdtype
 
 __all__ = [
     'Propagator',
     'Dopri5',
     'Euler',
-    'Rouchon',
     'Rouchon1',
     'Rouchon2',
 ]
@@ -151,10 +150,6 @@ class Dopri5(ODEAdaptiveStep):
     pass
 
 
-# make alias for Dopri5
-Default = Dopri5
-
-
 class Euler(ODEFixedStep):
     pass
 
@@ -163,10 +158,6 @@ class Rouchon1(ODEFixedStep, AdjointOptions):
     def __init__(self, *, sqrt_normalization: bool = False, **kwargs):
         super().__init__(**kwargs)
         self.sqrt_normalization = sqrt_normalization
-
-
-# make alias for Rouchon1
-Rouchon = Rouchon1
 
 
 class Rouchon2(ODEFixedStep, AdjointOptions):

--- a/dynamiqs/solvers/result.py
+++ b/dynamiqs/solvers/result.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from torch import Tensor
 
-from ..options import Options
+from .options import Options
 
 
 def memory_bytes(x: Tensor) -> int:

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -6,7 +6,7 @@ from time import time
 import torch
 from torch import Tensor
 
-from ..options import Options
+from .options import Options
 from .result import Result
 from .utils.td_tensor import TDTensor
 from .utils.utils import bexpect

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from math import cos, exp, pi, sin, sqrt
+from typing import Any
 
 import torch
 from torch import Tensor
 
 import dynamiqs as dq
-from dynamiqs.options import Options
 from dynamiqs.solvers.result import Result
 from dynamiqs.utils.tensor_types import ArrayLike
 
@@ -23,10 +23,21 @@ class OpenSystem(System):
         return self.n, self.n
 
     def _run(
-        self, H: Tensor, y0: Tensor, t_save: ArrayLike, options: Options
+        self,
+        H: Tensor,
+        y0: Tensor,
+        t_save: ArrayLike,
+        solver: str,
+        options: dict[str, Any],
     ) -> Result:
         return dq.mesolve(
-            H, self.jump_ops, y0, t_save, exp_ops=self.exp_ops, options=options
+            H,
+            self.jump_ops,
+            y0,
+            t_save,
+            exp_ops=self.exp_ops,
+            solver=solver,
+            options=options,
         )
 
 

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -28,7 +28,9 @@ class OpenSystem(System):
         y0: Tensor,
         t_save: ArrayLike,
         solver: str,
-        options: dict[str, Any],
+        *,
+        gradient: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> Result:
         return dq.mesolve(
             H,
@@ -37,6 +39,7 @@ class OpenSystem(System):
             t_save,
             exp_ops=self.exp_ops,
             solver=solver,
+            gradient=gradient,
             options=options,
         )
 

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -1,18 +1,16 @@
-import dynamiqs as dq
-
 from ..solver_tester import SolverTester
 from .open_system import grad_leaky_cavity_8, leaky_cavity_8
 
 
 class TestAdaptive(SolverTester):
     def test_batching(self):
-        options = dq.options.Dopri5()
-        self._test_batching(options, leaky_cavity_8)
+        options = dict()
+        self._test_batching('dopri5', options, leaky_cavity_8)
 
     def test_correctness(self):
-        options = dq.options.Dopri5()
-        self._test_correctness(options, leaky_cavity_8, num_t_save=11)
+        options = dict()
+        self._test_correctness('dopri5', options, leaky_cavity_8, num_t_save=11)
 
     def test_autograd(self):
-        options = dq.options.Dopri5(gradient_alg='autograd')
-        self._test_gradient(options, grad_leaky_cavity_8, num_t_save=11)
+        options = dict(gradient_alg='autograd')
+        self._test_gradient('dopri5', options, grad_leaky_cavity_8, num_t_save=11)

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -4,13 +4,10 @@ from .open_system import grad_leaky_cavity_8, leaky_cavity_8
 
 class TestAdaptive(SolverTester):
     def test_batching(self):
-        options = dict()
-        self._test_batching('dopri5', options, leaky_cavity_8)
+        self._test_batching(leaky_cavity_8, 'dopri5')
 
     def test_correctness(self):
-        options = dict()
-        self._test_correctness('dopri5', options, leaky_cavity_8, num_t_save=11)
+        self._test_correctness(leaky_cavity_8, 'dopri5', num_t_save=11)
 
     def test_autograd(self):
-        options = dict(gradient_alg='autograd')
-        self._test_gradient('dopri5', options, grad_leaky_cavity_8, num_t_save=11)
+        self._test_gradient(grad_leaky_cavity_8, 'dopri5', 'autograd', num_t_save=11)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,17 +1,16 @@
-import dynamiqs as dq
-
 from ..solver_tester import SolverTester
 from .open_system import grad_leaky_cavity_8, leaky_cavity_8
 
 
 class TestMEEuler(SolverTester):
     def test_batching(self):
-        options = dq.options.Euler(dt=1e-2)
-        self._test_batching(options, leaky_cavity_8)
+        options = dict(dt=1e-2)
+        self._test_batching('euler', options, leaky_cavity_8)
 
     def test_correctness(self):
-        options = dq.options.Euler(dt=1e-4)
+        options = dict(dt=1e-4)
         self._test_correctness(
+            'euler',
             options,
             leaky_cavity_8,
             num_t_save=11,
@@ -21,7 +20,7 @@ class TestMEEuler(SolverTester):
         )
 
     def test_autograd(self):
-        options = dq.options.Euler(dt=1e-3, gradient_alg='autograd')
+        options = dict(dt=1e-3, gradient_alg='autograd')
         self._test_gradient(
-            options, grad_leaky_cavity_8, num_t_save=11, rtol=1e-2, atol=1e-2
+            'euler', options, grad_leaky_cavity_8, num_t_save=11, rtol=1e-2, atol=1e-2
         )

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -5,14 +5,14 @@ from .open_system import grad_leaky_cavity_8, leaky_cavity_8
 class TestMEEuler(SolverTester):
     def test_batching(self):
         options = dict(dt=1e-2)
-        self._test_batching('euler', options, leaky_cavity_8)
+        self._test_batching(leaky_cavity_8, 'euler', options=options)
 
     def test_correctness(self):
         options = dict(dt=1e-4)
         self._test_correctness(
-            'euler',
-            options,
             leaky_cavity_8,
+            'euler',
+            options=options,
             num_t_save=11,
             y_save_norm_atol=1e-2,
             exp_save_rtol=1e-2,
@@ -20,7 +20,13 @@ class TestMEEuler(SolverTester):
         )
 
     def test_autograd(self):
-        options = dict(dt=1e-3, gradient_alg='autograd')
+        options = dict(dt=1e-3)
         self._test_gradient(
-            'euler', options, grad_leaky_cavity_8, num_t_save=11, rtol=1e-2, atol=1e-2
+            grad_leaky_cavity_8,
+            'euler',
+            'autograd',
+            options=options,
+            num_t_save=11,
+            rtol=1e-2,
+            atol=1e-2,
         )

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -1,20 +1,19 @@
 import pytest
 
-import dynamiqs as dq
-
 from ..solver_tester import SolverTester
 from .open_system import grad_leaky_cavity_8, leaky_cavity_8
 
 
 class TestMERouchon1(SolverTester):
     def test_batching(self):
-        options = dq.options.Rouchon1(dt=1e-2)
-        self._test_batching(options, leaky_cavity_8)
+        options = dict(dt=1e-2)
+        self._test_batching('rouchon1', options, leaky_cavity_8)
 
     @pytest.mark.parametrize('sqrt_normalization', [False, True])
     def test_correctness(self, sqrt_normalization):
-        options = dq.options.Rouchon1(dt=1e-3, sqrt_normalization=sqrt_normalization)
+        options = dict(dt=1e-3, sqrt_normalization=sqrt_normalization)
         self._test_correctness(
+            'rouchon1',
             options,
             leaky_cavity_8,
             num_t_save=11,
@@ -25,34 +24,45 @@ class TestMERouchon1(SolverTester):
 
     @pytest.mark.parametrize('sqrt_normalization', [False, True])
     def test_autograd(self, sqrt_normalization):
-        options = dq.options.Rouchon1(
+        options = dict(
             dt=1e-3, sqrt_normalization=sqrt_normalization, gradient_alg='autograd'
         )
         self._test_gradient(
-            options, grad_leaky_cavity_8, num_t_save=11, rtol=1e-2, atol=1e-2
+            'rouchon1',
+            options,
+            grad_leaky_cavity_8,
+            num_t_save=11,
+            rtol=1e-2,
+            atol=1e-2,
         )
 
     @pytest.mark.parametrize('sqrt_normalization', [False, True])
     def test_adjoint(self, sqrt_normalization):
-        options = dq.options.Rouchon1(
+        options = dict(
             dt=1e-3,
             sqrt_normalization=sqrt_normalization,
             gradient_alg='adjoint',
             parameters=grad_leaky_cavity_8.parameters,
         )
         self._test_gradient(
-            options, grad_leaky_cavity_8, num_t_save=11, rtol=1e-2, atol=1e-2
+            'rouchon1',
+            options,
+            grad_leaky_cavity_8,
+            num_t_save=11,
+            rtol=1e-2,
+            atol=1e-2,
         )
 
 
 class TestMERouchon2(SolverTester):
     def test_batching(self):
-        options = dq.options.Rouchon2(dt=1e-2)
-        self._test_batching(options, leaky_cavity_8)
+        options = dict(dt=1e-2)
+        self._test_batching('rouchon2', options, leaky_cavity_8)
 
     def test_correctness(self):
-        options = dq.options.Rouchon2(dt=1e-3)
+        options = dict(dt=1e-3)
         self._test_correctness(
+            'rouchon2',
             options,
             leaky_cavity_8,
             num_t_save=11,
@@ -62,11 +72,13 @@ class TestMERouchon2(SolverTester):
         )
 
     def test_autograd(self):
-        options = dq.options.Rouchon2(dt=1e-3, gradient_alg='autograd')
-        self._test_gradient(options, grad_leaky_cavity_8, num_t_save=11)
+        options = dict(dt=1e-3, gradient_alg='autograd')
+        self._test_gradient('rouchon2', options, grad_leaky_cavity_8, num_t_save=11)
 
     def test_adjoint(self):
-        options = dq.options.Rouchon2(
+        options = dict(
             dt=1e-3, gradient_alg='adjoint', parameters=grad_leaky_cavity_8.parameters
         )
-        self._test_gradient(options, grad_leaky_cavity_8, num_t_save=11, atol=1e-4)
+        self._test_gradient(
+            'rouchon2', options, grad_leaky_cavity_8, num_t_save=11, atol=1e-4
+        )

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -7,15 +7,15 @@ from .open_system import grad_leaky_cavity_8, leaky_cavity_8
 class TestMERouchon1(SolverTester):
     def test_batching(self):
         options = dict(dt=1e-2)
-        self._test_batching('rouchon1', options, leaky_cavity_8)
+        self._test_batching(leaky_cavity_8, 'rouchon1', options=options)
 
     @pytest.mark.parametrize('sqrt_normalization', [False, True])
     def test_correctness(self, sqrt_normalization):
         options = dict(dt=1e-3, sqrt_normalization=sqrt_normalization)
         self._test_correctness(
-            'rouchon1',
-            options,
             leaky_cavity_8,
+            'rouchon1',
+            options=options,
             num_t_save=11,
             y_save_norm_atol=1e-2,
             exp_save_rtol=1e-2,
@@ -24,13 +24,12 @@ class TestMERouchon1(SolverTester):
 
     @pytest.mark.parametrize('sqrt_normalization', [False, True])
     def test_autograd(self, sqrt_normalization):
-        options = dict(
-            dt=1e-3, sqrt_normalization=sqrt_normalization, gradient_alg='autograd'
-        )
+        options = dict(dt=1e-3, sqrt_normalization=sqrt_normalization)
         self._test_gradient(
-            'rouchon1',
-            options,
             grad_leaky_cavity_8,
+            'rouchon1',
+            'autograd',
+            options=options,
             num_t_save=11,
             rtol=1e-2,
             atol=1e-2,
@@ -41,13 +40,13 @@ class TestMERouchon1(SolverTester):
         options = dict(
             dt=1e-3,
             sqrt_normalization=sqrt_normalization,
-            gradient_alg='adjoint',
             parameters=grad_leaky_cavity_8.parameters,
         )
         self._test_gradient(
-            'rouchon1',
-            options,
             grad_leaky_cavity_8,
+            'rouchon1',
+            'adjoint',
+            options=options,
             num_t_save=11,
             rtol=1e-2,
             atol=1e-2,
@@ -57,14 +56,14 @@ class TestMERouchon1(SolverTester):
 class TestMERouchon2(SolverTester):
     def test_batching(self):
         options = dict(dt=1e-2)
-        self._test_batching('rouchon2', options, leaky_cavity_8)
+        self._test_batching(leaky_cavity_8, 'rouchon2', options=options)
 
     def test_correctness(self):
         options = dict(dt=1e-3)
         self._test_correctness(
-            'rouchon2',
-            options,
             leaky_cavity_8,
+            'rouchon2',
+            options=options,
             num_t_save=11,
             y_save_norm_atol=1e-2,
             exp_save_rtol=1e-2,
@@ -72,13 +71,22 @@ class TestMERouchon2(SolverTester):
         )
 
     def test_autograd(self):
-        options = dict(dt=1e-3, gradient_alg='autograd')
-        self._test_gradient('rouchon2', options, grad_leaky_cavity_8, num_t_save=11)
+        options = dict(dt=1e-3)
+        self._test_gradient(
+            grad_leaky_cavity_8,
+            'rouchon2',
+            gradient='autograd',
+            options=options,
+            num_t_save=11,
+        )
 
     def test_adjoint(self):
-        options = dict(
-            dt=1e-3, gradient_alg='adjoint', parameters=grad_leaky_cavity_8.parameters
-        )
+        options = dict(dt=1e-3, parameters=grad_leaky_cavity_8.parameters)
         self._test_gradient(
-            'rouchon2', options, grad_leaky_cavity_8, num_t_save=11, atol=1e-4
+            grad_leaky_cavity_8,
+            'rouchon2',
+            'adjoint',
+            options=options,
+            num_t_save=11,
+            atol=1e-4,
         )

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -24,7 +24,9 @@ class ClosedSystem(System):
         y0: Tensor,
         t_save: ArrayLike,
         solver: str,
-        options: dict[str, Any],
+        *,
+        gradient: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> Result:
         return dq.sesolve(
             H,
@@ -32,6 +34,7 @@ class ClosedSystem(System):
             t_save,
             exp_ops=self.exp_ops,
             solver=solver,
+            gradient=gradient,
             options=options,
         )
 

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from math import cos, pi, sin, sqrt
+from typing import Any
 
 import torch
 from torch import Tensor
 
 import dynamiqs as dq
-from dynamiqs.options import Options
 from dynamiqs.solvers.result import Result
 from dynamiqs.utils.tensor_types import ArrayLike
 
@@ -19,13 +19,19 @@ class ClosedSystem(System):
         return self.n, 1
 
     def _run(
-        self, H: Tensor, y0: Tensor, t_save: ArrayLike, options: Options
+        self,
+        H: Tensor,
+        y0: Tensor,
+        t_save: ArrayLike,
+        solver: str,
+        options: dict[str, Any],
     ) -> Result:
         return dq.sesolve(
             H,
             y0,
             t_save,
             exp_ops=self.exp_ops,
+            solver=solver,
             options=options,
         )
 

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -1,18 +1,16 @@
-import dynamiqs as dq
-
 from ..solver_tester import SolverTester
 from .closed_system import cavity_8, grad_cavity_8
 
 
 class TestAdaptive(SolverTester):
     def test_batching(self):
-        options = dq.options.Dopri5()
-        self._test_batching(options, cavity_8)
+        options = dict()
+        self._test_batching('dopri5', options, cavity_8)
 
     def test_correctness(self):
-        options = dq.options.Dopri5()
-        self._test_correctness(options, cavity_8, num_t_save=11)
+        options = dict()
+        self._test_correctness('dopri5', options, cavity_8, num_t_save=11)
 
     def test_autograd(self):
-        options = dq.options.Dopri5(gradient_alg='autograd')
-        self._test_gradient(options, grad_cavity_8, num_t_save=11)
+        options = dict(gradient_alg='autograd')
+        self._test_gradient('dopri5', options, grad_cavity_8, num_t_save=11)

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -4,13 +4,10 @@ from .closed_system import cavity_8, grad_cavity_8
 
 class TestAdaptive(SolverTester):
     def test_batching(self):
-        options = dict()
-        self._test_batching('dopri5', options, cavity_8)
+        self._test_batching(cavity_8, 'dopri5')
 
     def test_correctness(self):
-        options = dict()
-        self._test_correctness('dopri5', options, cavity_8, num_t_save=11)
+        self._test_correctness(cavity_8, 'dopri5', num_t_save=11)
 
     def test_autograd(self):
-        options = dict(gradient_alg='autograd')
-        self._test_gradient('dopri5', options, grad_cavity_8, num_t_save=11)
+        self._test_gradient(grad_cavity_8, 'dopri5', 'autograd', num_t_save=11)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -5,14 +5,14 @@ from .closed_system import cavity_8, grad_cavity_8
 class TestSEEuler(SolverTester):
     def test_batching(self):
         options = dict(dt=1e-2)
-        self._test_batching('euler', options, cavity_8)
+        self._test_batching(cavity_8, 'euler', options=options)
 
     def test_correctness(self):
         options = dict(dt=1e-4)
         self._test_correctness(
-            'euler',
-            options,
             cavity_8,
+            'euler',
+            options=options,
             num_t_save=11,
             y_save_norm_atol=1e-2,
             exp_save_rtol=1e-1,
@@ -20,7 +20,13 @@ class TestSEEuler(SolverTester):
         )
 
     def test_autograd(self):
-        options = dict(dt=1e-4, gradient_alg='autograd')
+        options = dict(dt=1e-4)
         self._test_gradient(
-            'euler', options, grad_cavity_8, num_t_save=11, rtol=1e-1, atol=1e-2
+            grad_cavity_8,
+            'euler',
+            'autograd',
+            options=options,
+            num_t_save=11,
+            rtol=1e-1,
+            atol=1e-2,
         )

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,17 +1,16 @@
-import dynamiqs as dq
-
 from ..solver_tester import SolverTester
 from .closed_system import cavity_8, grad_cavity_8
 
 
 class TestSEEuler(SolverTester):
     def test_batching(self):
-        options = dq.options.Euler(dt=1e-2)
-        self._test_batching(options, cavity_8)
+        options = dict(dt=1e-2)
+        self._test_batching('euler', options, cavity_8)
 
     def test_correctness(self):
-        options = dq.options.Euler(dt=1e-4)
+        options = dict(dt=1e-4)
         self._test_correctness(
+            'euler',
             options,
             cavity_8,
             num_t_save=11,
@@ -21,5 +20,7 @@ class TestSEEuler(SolverTester):
         )
 
     def test_autograd(self):
-        options = dq.options.Euler(dt=1e-4, gradient_alg='autograd')
-        self._test_gradient(options, grad_cavity_8, num_t_save=11, rtol=1e-1, atol=1e-2)
+        options = dict(dt=1e-4, gradient_alg='autograd')
+        self._test_gradient(
+            'euler', options, grad_cavity_8, num_t_save=11, rtol=1e-1, atol=1e-2
+        )

--- a/tests/sesolve/test_propagator.py
+++ b/tests/sesolve/test_propagator.py
@@ -1,18 +1,16 @@
-import dynamiqs as dq
-
 from ..solver_tester import SolverTester
 from .closed_system import cavity_8, grad_cavity_8
 
 
 class TestPropagator(SolverTester):
     def test_batching(self):
-        options = dq.options.Propagator()
-        self._test_batching(options, cavity_8)
+        options = dict()
+        self._test_batching('propagator', options, cavity_8)
 
     def test_correctness(self):
-        options = dq.options.Propagator()
-        self._test_correctness(options, cavity_8, num_t_save=11)
+        options = dict()
+        self._test_correctness('propagator', options, cavity_8, num_t_save=11)
 
     def test_autograd(self):
-        options = dq.options.Propagator(gradient_alg='autograd')
-        self._test_gradient(options, grad_cavity_8, num_t_save=11)
+        options = dict(gradient_alg='autograd')
+        self._test_gradient('propagator', options, grad_cavity_8, num_t_save=11)

--- a/tests/sesolve/test_propagator.py
+++ b/tests/sesolve/test_propagator.py
@@ -4,13 +4,10 @@ from .closed_system import cavity_8, grad_cavity_8
 
 class TestPropagator(SolverTester):
     def test_batching(self):
-        options = dict()
-        self._test_batching('propagator', options, cavity_8)
+        self._test_batching(cavity_8, 'propagator')
 
     def test_correctness(self):
-        options = dict()
-        self._test_correctness('propagator', options, cavity_8, num_t_save=11)
+        self._test_correctness(cavity_8, 'propagator', num_t_save=11)
 
     def test_autograd(self):
-        options = dict(gradient_alg='autograd')
-        self._test_gradient('propagator', options, grad_cavity_8, num_t_save=11)
+        self._test_gradient(grad_cavity_8, 'propagator', 'autograd', num_t_save=11)

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from abc import ABC
 from typing import Any

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -1,15 +1,14 @@
 import logging
 from abc import ABC
+from typing import Any
 
 import torch
-
-from dynamiqs.options import Options
 
 from .system import System
 
 
 class SolverTester(ABC):
-    def _test_batching(self, options: Options, system: System):
+    def _test_batching(self, solver: str, options: dict[str, Any], system: System):
         """Test the batching of `H` and `y0`, and the returned object sizes."""
         m, n = system._state_shape
         n_exp_ops = len(system.exp_ops)
@@ -18,7 +17,7 @@ class SolverTester(ABC):
         num_t_save = 11
         t_save = system.t_save(num_t_save)
 
-        run = lambda H, y0: system._run(H, y0, t_save, options)
+        run = lambda H, y0: system._run(H, y0, t_save, solver, options)
 
         # no batching
         result = run(system.H, system.y0)
@@ -45,7 +44,8 @@ class SolverTester(ABC):
 
     def _test_correctness(
         self,
-        options: Options,
+        solver: str,
+        options: dict[str, Any],
         system: System,
         *,
         num_t_save: int,
@@ -54,7 +54,7 @@ class SolverTester(ABC):
         exp_save_atol: float = 1e-5,
     ):
         t_save = system.t_save(num_t_save)
-        result = system.run(t_save, options)
+        result = system.run(t_save, solver, options)
 
         # === test y_save
         errs = torch.linalg.norm(result.y_save - system.states(t_save), dim=(-2, -1))
@@ -74,7 +74,8 @@ class SolverTester(ABC):
 
     def _test_gradient(
         self,
-        options: Options,
+        solver: str,
+        options: dict[str, Any],
         system: System,
         *,
         num_t_save: int,
@@ -82,7 +83,7 @@ class SolverTester(ABC):
         atol: float = 1e-5,
     ):
         t_save = system.t_save(num_t_save)
-        result = system.run(t_save, options)
+        result = system.run(t_save, solver, options)
 
         # === test gradients depending on final y_save
         loss_state = system.loss_state(result.y_save[-1])

--- a/tests/system.py
+++ b/tests/system.py
@@ -74,9 +74,20 @@ class System(ABC):
         y0: Tensor,
         t_save: ArrayLike,
         solver: str,
-        options: dict[str, Any],
+        *,
+        gradient: str | None = None,
+        options: dict[str, Any] | None = None,
     ) -> Result:
         pass
 
-    def run(self, t_save: ArrayLike, solver: str, options: dict[str, Any]) -> Result:
-        return self._run(self.H, self.y0, t_save, solver, options)
+    def run(
+        self,
+        t_save: ArrayLike,
+        solver: str,
+        *,
+        gradient: str | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> Result:
+        return self._run(
+            self.H, self.y0, t_save, solver, gradient=gradient, options=options
+        )

--- a/tests/system.py
+++ b/tests/system.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod, abstractproperty
+from typing import Any
 
 import torch
 from torch import Tensor
 
 import dynamiqs as dq
-from dynamiqs.options import Options
 from dynamiqs.solvers.result import Result
 from dynamiqs.utils.tensor_types import ArrayLike
 
@@ -69,9 +69,14 @@ class System(ABC):
 
     @abstractmethod
     def _run(
-        self, H: Tensor, y0: Tensor, t_save: ArrayLike, options: Options
+        self,
+        H: Tensor,
+        y0: Tensor,
+        t_save: ArrayLike,
+        solver: str,
+        options: dict[str, Any],
     ) -> Result:
         pass
 
-    def run(self, t_save: ArrayLike, options: Options) -> Result:
-        return self._run(self.H, self.y0, t_save, options)
+    def run(self, t_save: ArrayLike, solver: str, options: dict[str, Any]) -> Result:
+        return self._run(self.H, self.y0, t_save, solver, options)


### PR DESCRIPTION
This is a proposal to simplify the options API.

Before:
```python
options = dq.options.Rouchon1(dt=1e-3, gradient_alg='autograd', verbose=False)
result = dq.mesolve(H, jump_ops, rho0, t_save, options=options)
```
After
```python
options = dict(dt=1e-3, verbose=False)
result = dq.mesolve(H, jump_ops, rho0, t_save, solver='rouchon1', gradient='autograd', options=options)
```