### PR TITLE
Round time difference in propagator solvers to prevent useless cache reloading

### DIFF
--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -19,8 +19,8 @@ def round_truncate(x: np.float32 | np.float64) -> np.float32 | np.float64:
     # removes any numerical error that may have accumulated in the 5 least significant
     # bits of the mantissa.
     leading = abs(int(np.log2(x)))
-    kept = leading + 18
-    return (x * 2**kept).round() / 2**kept
+    keep = leading + 18
+    return (x * 2**keep).round() / 2**keep
 
 
 class Propagator(AutogradSolver):

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -1,10 +1,22 @@
+from __future__ import annotations
+
 from abc import abstractmethod
 
+import numpy as np
 from torch import Tensor
 
 from .solver import AutogradSolver
 from .utils.td_tensor import ConstantTDTensor
 from .utils.utils import tqdm
+
+
+def round_truncate(x: np.float32 | np.float64) -> np.float32 | np.float64:
+    # round a strictly positive-valued float to remove numerical errors, and enable
+    # comparing floats for equality
+
+    # round to 5 additional decimal places beyond the highest digit of the number
+    decimals = abs(int(np.log10(x))) + 5
+    return (x * 10**decimals).round() / 10**decimals
 
 
 class Propagator(AutogradSolver):
@@ -21,7 +33,10 @@ class Propagator(AutogradSolver):
     def run_autograd(self):
         y, t1 = self.y0, 0.0
         for t2 in tqdm(self.t_stop.cpu().numpy(), disable=not self.options.verbose):
-            y = self.forward(t1, t2 - t1, y)
+            if t2 != 0.0:
+                # round time difference to avoid numerical errors when comparing floats
+                delta_t = round_truncate(t2 - t1)
+                y = self.forward(t1, delta_t, y)
             self.save(y)
             t1 = t2
 

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -14,9 +14,13 @@ def round_truncate(x: np.float32 | np.float64) -> np.float32 | np.float64:
     # round a strictly positive-valued float to remove numerical errors, and enable
     # comparing floats for equality
 
-    # round to 5 additional decimal places beyond the highest digit of the number
-    decimals = abs(int(np.log10(x))) + 5
-    return (x * 10**decimals).round() / 10**decimals
+    # The mantissa of a float32 is stored using 23 bits. The following code rounds and
+    # truncates the float value to the 18 most significant bits of its mantissa. This
+    # removes any numerical error that may have accumulated in the 5 least significant
+    # bits of the mantissa.
+    leading = abs(int(np.log2(x)))
+    kept = leading + 18
+    return (x * 2**kept).round() / 2**kept
 
 
 class Propagator(AutogradSolver):


### PR DESCRIPTION
Fixes #209.

```python
import dynamiqs as dq
import numpy as np

n = 10
a = dq.destroy(n)
H = a.mH @ a
jump_ops = [np.sqrt(0.1) * a]
rho0 = dq.coherent(n, 1.0)
t_save = np.linspace(0.0, 1e-3, 11, np.float32)
res = dq.mesolve(H, jump_ops, rho0, t_save, solver='propagator')
```
Output when adding a `print` statement to `Propagator` and another `print` statement in the cached method `mesolve.propagator` to ensure it runs only once:
```
Propagator: 0.00009999999747378751635551452637 --> 0.00010000000000000000479217360239
MEPropagator: compute propagator
Propagator: 0.00009999999747378751635551452637 --> 0.00010000000000000000479217360239
Propagator: 0.00010000001930166035890579223633 --> 0.00010000000000000000479217360239
Propagator: 0.00009999997564591467380523681641 --> 0.00010000000000000000479217360239
Propagator: 0.00010000003385357558727264404297 --> 0.00010000000000000000479217360239
Propagator: 0.00010000000474974513053894042969 --> 0.00010000000000000000479217360239
Propagator: 0.00009999994654208421707153320312 --> 0.00010000000000000000479217360239
Propagator: 0.00010000000474974513053894042969 --> 0.00010000000000000000479217360239
Propagator: 0.00010000000474974513053894042969 --> 0.00010000000000000000479217360239
Propagator: 0.00010000006295740604400634765625 --> 0.00010000000000000000479217360239
```