### PR TITLE
Add extra args to callable Hamiltonians

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -38,8 +38,8 @@ def mesolve(
     the graph of operations is not stored to improve performance.
 
     For time-dependent problems, the Hamiltonian `H` can be passed as a function with
-    signature `H(t: float) -> Tensor`. Piecewise constant Hamiltonians can also be
-    passed as... TODO Complete with full Hamiltonian format
+    signature `H(t: float, *H_args) -> Tensor`. Piecewise constant Hamiltonians can also
+    be passed as... TODO Complete with full Hamiltonian format
 
     Available solvers:
       - `Dopri5`: Dormand-Prince of order 5. Default solver.
@@ -52,8 +52,8 @@ def mesolve(
     Args:
         H _(Tensor or Callable)_: Hamiltonian.
             Can be a tensor of shape `(n, n)` or `(b_H, n, n)` if batched, or a callable
-            `H(t: float) -> Tensor` that returns a tensor of either possible shapes
-            at every time between `t=0` and `t=t_save[-1]`.
+            `H(t: float, *H_args) -> Tensor` that returns a tensor of either possible
+            shapes at every time between `t=0` and `t=t_save[-1]`.
         jump_ops _(Tensor, or list of Tensors)_: List of jump operators.
             Each jump operator should be a tensor of shape `(n, n)`.
         rho0 _(Tensor)_: Initial density matrix.
@@ -119,7 +119,9 @@ def mesolve(
     # rho0: (b_H, b_rho0, n, n)
     # exp_ops: (len(exp_ops), n, n)
     # jump_ops: (len(jump_ops), n, n)
-    H = to_td_tensor(H, dtype=options.cdtype, device=options.device)
+    H = to_td_tensor(
+        H, dtype=options.cdtype, device=options.device, args=options.H_args
+    )
     rho0 = to_tensor(rho0, dtype=options.cdtype, device=options.device)
     H = batch_H(H)
     rho0 = batch_y0(rho0, H)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -57,7 +57,9 @@ def sesolve(
     # H: (b_H, 1, n, n)
     # psi0: (b_H, b_psi0, n, 1)
     # exp_ops: (len(exp_ops), n, n)
-    H = to_td_tensor(H, dtype=options.cdtype, device=options.device)
+    H = to_td_tensor(
+        H, dtype=options.cdtype, device=options.device, args=options.H_args
+    )
     psi0 = to_tensor(psi0, dtype=options.cdtype, device=options.device)
     H = batch_H(H)
     psi0 = batch_y0(psi0, H)

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -73,7 +73,9 @@ def smesolve(
     # rho0: (b_H, b_rho0, ntrajs, n, n)
     # exp_ops: (len(exp_ops), n, n)
     # jump_ops: (len(jump_ops), n, n)
-    H = to_td_tensor(H, dtype=options.cdtype, device=options.device)
+    H = to_td_tensor(
+        H, dtype=options.cdtype, device=options.device, args=options.H_args
+    )
     rho0 = to_tensor(rho0, dtype=options.cdtype, device=options.device)
     H = batch_H(H).unsqueeze(2)
     rho0 = batch_y0(rho0, H).unsqueeze(2).repeat(1, 1, ntrajs, 1, 1)

--- a/dynamiqs/solvers/options.py
+++ b/dynamiqs/solvers/options.py
@@ -28,6 +28,7 @@ class Options:
         verbose: bool = True,
         dtype: torch.complex64 | torch.complex128 | None = None,
         device: str | torch.device | None = None,
+        H_args: tuple[Any, ...] = (),
     ):
         """...
 
@@ -42,6 +43,7 @@ class Options:
                 the corresponding precision.
             device (string or torch.device, optional): Device on which the tensors are
                 stored.
+            H_args (tuple, optional): Additional arguments passed to the Hamiltonian
         """
         self.gradient_alg = gradient_alg
         self.save_states = save_states
@@ -49,6 +51,7 @@ class Options:
         self.cdtype = get_cdtype(dtype)
         self.rdtype = dtype_complex_to_real(self.cdtype)
         self.device = to_device(device)
+        self.H_args = H_args
 
         # check that the gradient algorithm is supported
         if self.gradient_alg is not None and self.gradient_alg not in self.GRADIENT_ALG:


### PR DESCRIPTION
Small PR to add Hamiltonians of the form `H(t: float, *args) -> Tensor` instead of `H(t: float) -> Tensor`.

- [ ] Test it works with an example.
- [ ] Write a test function ?