### PR TITLE
Add support for PWC tensor

### DIFF
--- a/dynamiqs/mesolve/propagator.py
+++ b/dynamiqs/mesolve/propagator.py
@@ -10,17 +10,20 @@ from .me_solver import MESolver
 class MEPropagator(MESolver, Propagator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.lindbladian = slindbladian(self.H, self.L)  # (b_H, 1, n^2, n^2)
+        # self.lindbladian: (b_H, 1, n^2, n^2)
+        self.lindbladian = cache(lambda H: slindbladian(H, self.L))
         self.y0 = operator_to_vector(self.y0)  # (b_H, b_rho, n^2, 1)
 
     @cache
-    def propagator(self, delta_t: float) -> Tensor:
+    def propagator(self, lindbladian: Tensor, delta_t: float) -> Tensor:
         # -> (b_H, 1, n^2, n^2)
-        return torch.matrix_exp(self.lindbladian * delta_t)
+        return torch.matrix_exp(lindbladian * delta_t)
 
     def forward(self, t: float, delta_t: float, rho_vec: Tensor) -> Tensor:
         # rho: (b_H, b_rho, n^2, 1) -> (b_H, b_rho, n^2, 1)
-        return self.propagator(delta_t) @ rho_vec  # (b_H, b_rho, n^2, 1)
+        H = self.H(t)
+        lindbladian = self.lindbladian(H)
+        return self.propagator(lindbladian, delta_t) @ rho_vec  # (b_H, b_rho, n^2, 1)
 
     def save(self, y: Tensor):
         # override `save` method to convert `y` from vector to operator

--- a/dynamiqs/sesolve/propagator.py
+++ b/dynamiqs/sesolve/propagator.py
@@ -7,10 +7,11 @@ from ..solvers.utils import cache
 
 class SEPropagator(Propagator):
     @cache
-    def propagator(self, delta_t: float) -> Tensor:
+    def propagator(self, H: Tensor, delta_t: float) -> Tensor:
         # -> (b_H, 1, n, n)
-        return torch.matrix_exp(-1j * self.H * delta_t)
+        return torch.matrix_exp(-1j * H * delta_t)
 
     def forward(self, t: float, delta_t: float, psi: Tensor) -> Tensor:
         # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
-        return self.propagator(delta_t) @ psi
+        H = self.H(t)
+        return self.propagator(H, delta_t) @ psi

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor
 
 from ..mesolve.me_solver import MESolver
-from ..solvers.utils import cache
+from ..solvers.utils import cache, merge_tensors
 from ..utils.utils import trace
 
 
@@ -52,7 +52,7 @@ class SMESolver(MESolver):
         self.bin_meas = torch.zeros(self.meas_shape)  # (..., len(etas))
 
     def _init_time_logic(self):
-        self.tstop = torch.cat((self.tsave, self.tmeas)).unique().sort()[0]
+        self.tstop = merge_tensors(self.tsave, self.tmeas)
         self.tstop_counter = 0
 
         self.tsave_mask = torch.isin(self.tstop, self.tsave)

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -6,7 +6,8 @@ import numpy as np
 from torch import Tensor
 
 from .solver import AutogradSolver
-from .utils.td_tensor import ConstantTDTensor
+from .utils import merge_tensors
+from .utils.td_tensor import CallableTDTensor, PWCTDTensor
 from .utils.utils import tqdm
 
 
@@ -27,12 +28,18 @@ class Propagator(AutogradSolver):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # check that Hamiltonian is time-independent
-        if not isinstance(self.H, ConstantTDTensor):
-            raise TypeError(
-                'Solver `Propagator` requires a time-independent Hamiltonian.'
+        if isinstance(self.H, CallableTDTensor):
+            raise ValueError(
+                'Solver `Propagator` requires a time-independent or piecewise-constant'
+                ' Hamiltonian, but a time-dependent Hamiltonian in the callable format'
+                ' was provided.'
             )
-        self.H = self.H(0.0)
+        elif isinstance(self.H, PWCTDTensor):
+            # merge tstop with pwc times that are in the interval [0.0, tsave[-1]],
+            # to make sure no piecewise constant part is skipped during the evolution
+            mask = (0.0 <= self.H.times) & (self.H.times <= self.tsave[-1])
+            additional_tstop = self.H.times[mask]
+            self.tstop = merge_tensors(self.tstop, additional_tstop)
 
     def run_autograd(self):
         y, t1 = self.y0, 0.0
@@ -41,7 +48,8 @@ class Propagator(AutogradSolver):
                 # round time difference to avoid numerical errors when comparing floats
                 delta_t = round_truncate(t2 - t1)
                 y = self.forward(t1, delta_t, y)
-            self.save(y)
+            if t2 in self.tsave:
+                self.save(y)
             t1 = t2
 
     @abstractmethod

--- a/dynamiqs/solvers/utils/td_tensor.py
+++ b/dynamiqs/solvers/utils/td_tensor.py
@@ -16,7 +16,7 @@ from ...utils.tensor_types import (
     get_cdtype,
     to_tensor,
 )
-from .utils import cache
+from .utils import cache, merge_tensors
 
 
 def to_td_tensor(
@@ -187,6 +187,8 @@ class PWCTDTensor(TDTensor):
 
         self._static = static  # (n, n)
         self._pwc = pwc
+
+        self.times = merge_tensors(*[times for _, times, _ in pwc])
 
     def __call__(self, t: float) -> Tensor:
         total_tensor = torch.zeros(self._shape, dtype=self._dtype, device=self._device)

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -171,3 +171,7 @@ def check_time_tensor(x: Tensor, arg_name: str, allow_empty=False):
         )
     if not torch.all(x >= 0):
         raise ValueError(f'Argument `{arg_name}` must contain positive values only.')
+
+
+def merge_tensors(*x: Tensor) -> Tensor:
+    return torch.cat(x).unique().sort()[0]

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -93,12 +93,12 @@ def pwc_pulse(
     r"""Returns a function that takes a time $t$ and returns the piecewise-constant
     (PWC) pulse value at this time.
 
-    The time interval $[t_\text{start}, t_\text{end}]$ is split into $n$ bins, where
+    The time interval $[t_\text{start}, t_\text{end})$ is split into $n$ bins, where
     $n$ is the last dimension of `values` with shape _(..., n)_. The pulse value at
     time $t$ is defined by
 
-    - `torch.zeros(...)` if $t$ is not in $[t_\text{start}, t_\text{end}]$,
-    - `values[..., k]` if $t$ is in the $k$-th bin of $[t_\text{start}, t_\text{end}]$.
+    - `torch.zeros(...)` if $t$ is not in $[t_\text{start}, t_\text{end})$,
+    - `values[..., k]` if $t$ is in the $k$-th bin of $[t_\text{start}, t_\text{end})$.
 
     Notes:
         You can use [rand_complex()][dynamiqs.rand_complex] to generate a tensor
@@ -126,14 +126,10 @@ def pwc_pulse(
     """
 
     def pulse(t):
-        if t < t_start or t > t_end:
+        if t < t_start or t >= t_end:
             # return a null tensor of appropriate shape
             batch_sizes = values.shape[:-1]
             return torch.zeros(batch_sizes, dtype=values.dtype, device=values.device)
-        elif t == t_end:
-            # return the last value, this case if necessary to avoid an out of bounds
-            # index error when computing `idx` below
-            return values[..., -1]
         else:
             # find the index corresponding to time t for t in [t_start, t_end[
             n = values.size(-1)

--- a/dynamiqs/utils/tensor_types.py
+++ b/dynamiqs/utils/tensor_types.py
@@ -18,9 +18,15 @@ __all__ = [
 # type for objects convertible to a torch.Tensor using `to_tensor`
 ArrayLike = Union[list, np.ndarray, Tensor, Qobj]
 
-# TODO add typing for Hamiltonian with piecewise-constant factor
 # type for time-dependent objects
-TDArrayLike = Union[ArrayLike, Callable[[float], Tensor]]
+# - constant: e.g. H0
+# - callable: e.g. lambda t: H0 + H1 * f(t)
+# - piecewise-constant (pwc): e.g. (H0, (H1, times, values))
+TDArrayLike = Union[
+    ArrayLike,  # constant
+    Callable[[float], Tensor],  # callable
+    tuple[Union[ArrayLike, tuple[ArrayLike, ArrayLike, ArrayLike]]],  # pwc
+]
 
 
 def to_tensor(

--- a/dynamiqs/utils/tensor_types.py
+++ b/dynamiqs/utils/tensor_types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Callable, Union, get_args
+from typing import Callable, Tuple, Union, get_args
 
 import numpy as np
 import torch
@@ -25,7 +25,7 @@ ArrayLike = Union[list, np.ndarray, Tensor, Qobj]
 TDArrayLike = Union[
     ArrayLike,  # constant
     Callable[[float], Tensor],  # callable
-    tuple[Union[ArrayLike, tuple[ArrayLike, ArrayLike, ArrayLike]]],  # pwc
+    Tuple[Union[ArrayLike, Tuple[ArrayLike, ArrayLike, ArrayLike]]],  # pwc
 ]
 
 


### PR DESCRIPTION
This PR implements support for PWC Hamiltonian.

Notably it allows to use the propagator solver for optimal control problems with PWC drives, which leads to a huge speedup (e.g. optimisation of Fock 2 preparation with cavity + transmon goes from ~3 minutes to ~20 seconds on my CPU). I think it’s important to have a good enough PWC Hamiltonian `sesolve` solver, because this is the first step of many optimal control proof-of-concept, it's a quick way to know wether something is doable or not.

The propagator solver is by far our best solver for sesolve (for constant and PWC Hamiltonian), we're roughly on par with qutip performance-wise for n ≤ 300 on CPU. There are many possible improvements to be made to the propagator solver, namely support for sparse matrices, and use of e.g. Krylov method to compute directly the application of the matrix exponential to the state. Here's an example mini benchmark:
```python
n = 128
a = dq.destroy(n)
K = 0.1
H = a.mH @ a - K/2 * a.mH @ a.mH @ a @ a
psi0 = dq.coherent(n, 3)
tsave = np.linspace(0, 1.0, 11)

# ...

# === sesolve timing results
# dynamiqs (dopri5, CPU):     125.061 ± 10.26 ms
# dynamiqs (propagator, CPU): 3.141 ± 0.51 ms
# qutip:                      3.439 ± 0.17 ms
```

<details>
  <summary>Mini benchmark code</summary>

```python
import dynamiqs as dq
import qutip as qt
import numpy as np
from time import time

def run(f):
    niters = 10
    res = []
    for _ in range(niters):
        start = time()
        f()
        end = time()
        res.append((end - start) * 1000)
    res = np.array(res)
    print(f'{res.mean():.3f} ± {res.std():.2f} ms')

n = 128
a = dq.destroy(n)
K = 0.1
H = a.mH @ a - K/2 * a.mH @ a.mH @ a @ a
psi0 = dq.coherent(n, 3)
tsave = np.linspace(0, 1.0, 11)

# dynamiqs, dopri5
run(lambda: dq.sesolve(H, psi0, tsave, options=dict(verbose=False)))

# dynamiqs, propagator
run(lambda: dq.sesolve(H, psi0, tsave, solver='propagator', options=dict(verbose=False)))

# qutip, propagator
H = dq.to_qutip(H)
psi0 = dq.to_qutip(psi0)
run(lambda: qt.sesolve(H, psi0, tsave))
```

</details>

I propose to modify the doc later, once this is a bit more used and we have converged on the PWC format. For now the chosen format is tuple of static and PWC parts `(H0, (H1, times, values), ...)` where `times` has shape `n+1` and `values` has shape `n`. It’s a bit tricky to use lists because we also allow them for batched tensors.