### PR TITLE
Rouchon1 with cholesky renormalization

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -119,9 +119,12 @@ def mesolve(
         Optional for solver `rouchon1`:
 
         - **sqrt_normalization** _(bool, optional)_ – If `True`, the Kraus map is
-            renormalized at every step to preserve the trace of the density matrix.
-            Recommended only for time-independent problems. Ideal for stiff problems.
+            renormalized with a matrix square root at every time step a CPTP Kraus map.
+            Available only for time-independent problems. Ideal for stiff problems.
             Defaults to `False`.
+        - **cholesky_normalization** _(bool, optional)_ - If `True`, the Kraus map is
+            renormalized with a Cholesky decomposition at every time step to preserve
+            a CPTP Kraus map. Ideal for stiff problems. Defaults to `False`.
 
         Required for `gradient="adjoint"`:
 

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -52,8 +52,8 @@ class MERouchon1(MERouchon):
         # compute rho(t+dt)
         if self.options.cholesky_normalization:
             T = self.T(M0)
-            rho = torch.linalg.solve(T.mH, rho)
-            rho = torch.linalg.solve(T, rho, left=False)
+            rho = torch.linalg.solve_triangular(T.mH, rho, upper=True)
+            rho = torch.linalg.solve_triangular(T, rho, upper=False, left=False)
 
         rho = kraus_map(rho, M0) + kraus_map(rho, self.M1s)  # (b_H, b_rho, n, n)
 
@@ -89,8 +89,8 @@ class MERouchon1(MERouchon):
         # compute rho(t-dt)
         if self.options.cholesky_normalization:
             Trev = self.Trev(M0rev)
-            rho = torch.linalg.solve(Trev.mH, rho)
-            rho = torch.linalg.solve(Trev, rho, left=False)
+            rho = torch.linalg.solve_triangular(Trev.mH, rho, upper=True)
+            rho = torch.linalg.solve_triangular(Trev, rho, upper=False, left=False)
 
         rho = kraus_map(rho, M0rev) - kraus_map(rho, self.M1s)
 
@@ -102,8 +102,8 @@ class MERouchon1(MERouchon):
 
         if self.options.cholesky_normalization:
             T = self.T(M0)
-            phi = torch.linalg.solve(T, phi)
-            phi = torch.linalg.solve(T.mH, phi, left=False)
+            phi = torch.linalg.solve_triangular(T, phi, upper=False)
+            phi = torch.linalg.solve_triangular(T.mH, phi, upper=True, left=False)
 
         return rho, phi
 

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -52,8 +52,8 @@ class MERouchon1(MERouchon):
         # compute rho(t+dt)
         if self.options.cholesky_normalization:
             T = self.T(M0)
-            rho = torch.linalg.solve(T, rho)
-            rho = torch.linalg.solve(T.mH, rho, left=False)
+            rho = torch.linalg.solve(T.mH, rho)
+            rho = torch.linalg.solve(T, rho, left=False)
 
         rho = kraus_map(rho, M0) + kraus_map(rho, self.M1s)  # (b_H, b_rho, n, n)
 
@@ -89,8 +89,8 @@ class MERouchon1(MERouchon):
         # compute rho(t-dt)
         if self.options.cholesky_normalization:
             Trev = self.Trev(M0rev)
-            rho = torch.linalg.solve(Trev, rho)
-            rho = torch.linalg.solve(Trev.mH, rho, left=False)
+            rho = torch.linalg.solve(Trev.mH, rho)
+            rho = torch.linalg.solve(Trev, rho, left=False)
 
         rho = kraus_map(rho, M0rev) - kraus_map(rho, self.M1s)
 
@@ -98,12 +98,12 @@ class MERouchon1(MERouchon):
             rho = unit(rho)
 
         # compute phi(t-dt)
+        phi = kraus_map(phi, M0.mH) + kraus_map(phi, self.M1s.mH)
+
         if self.options.cholesky_normalization:
             T = self.T(M0)
             phi = torch.linalg.solve(T, phi)
             phi = torch.linalg.solve(T.mH, phi, left=False)
-
-        phi = kraus_map(phi, M0.mH) + kraus_map(phi, self.M1s.mH)
 
         return rho, phi
 

--- a/dynamiqs/solvers/options.py
+++ b/dynamiqs/solvers/options.py
@@ -155,8 +155,20 @@ class Euler(ODEFixedStep, AdjointOptions):
 
 
 class Rouchon1(ODEFixedStep, AdjointOptions):
-    def __init__(self, *, cholesky_normalization: bool = False, **kwargs):
+    def __init__(
+        self,
+        *,
+        sqrt_normalization: bool = False,
+        cholesky_normalization: bool = False,
+        **kwargs,
+    ):
         super().__init__(**kwargs)
+        if sqrt_normalization and cholesky_normalization:
+            raise ValueError(
+                'Only one of `sqrt_normalization` and `cholesky_normalization`'
+                ' can be set to `True`.'
+            )
+        self.sqrt_normalization = sqrt_normalization
         self.cholesky_normalization = cholesky_normalization
 
 

--- a/dynamiqs/solvers/options.py
+++ b/dynamiqs/solvers/options.py
@@ -155,9 +155,9 @@ class Euler(ODEFixedStep, AdjointOptions):
 
 
 class Rouchon1(ODEFixedStep, AdjointOptions):
-    def __init__(self, *, sqrt_normalization: bool = False, **kwargs):
+    def __init__(self, *, cholesky_normalization: bool = False, **kwargs):
         super().__init__(**kwargs)
-        self.sqrt_normalization = sqrt_normalization
+        self.cholesky_normalization = cholesky_normalization
 
 
 class Rouchon2(ODEFixedStep, AdjointOptions):

--- a/dynamiqs/solvers/utils/td_tensor.py
+++ b/dynamiqs/solvers/utils/td_tensor.py
@@ -65,6 +65,14 @@ def check_callable(
 
 
 class TDTensor(ABC):
+    """Time-dependent tensor."""
+
+    @property
+    @abstractmethod
+    def is_constant(self) -> bool:
+        """Whether the tensor is constant in time."""
+        pass
+
     @abstractmethod
     def __call__(self, t: float) -> Tensor:
         """Evaluate at a given time"""
@@ -92,6 +100,10 @@ class ConstantTDTensor(TDTensor):
         self.dtype = tensor.dtype
         self.device = tensor.device
 
+    @property
+    def is_constant(self) -> bool:
+        return True
+
     def __call__(self, t: float) -> Tensor:
         return self._tensor
 
@@ -117,6 +129,10 @@ class CallableTDTensor(TDTensor):
         self._shape = shape
         self.dtype = dtype
         self.device = device
+
+    @property
+    def is_constant(self) -> bool:
+        return False
 
     @cache
     def __call__(self, t: float) -> Tensor:

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -46,7 +46,7 @@ def inv_sqrtm(mat: Tensor) -> Tensor:
          https://github.com/pytorch/pytorch/issues/25481#issuecomment-584896176.
     """
     vals, vecs = torch.linalg.eigh(mat)
-    inv_sqrt_vals = torch.diag(vals ** (-0.5)).to(vecs)
+    inv_sqrt_vals = torch.diag_embed(vals ** (-0.5)).to(vecs)
     return vecs @ torch.linalg.solve(vecs, inv_sqrt_vals, left=False)
 
 

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -9,22 +9,22 @@ class TestMERouchon1(SolverTester):
         options = dict(dt=1e-2)
         self._test_batching(leaky_cavity_8, 'rouchon1', options=options)
 
-    @pytest.mark.parametrize('sqrt_normalization', [False, True])
-    def test_correctness(self, sqrt_normalization):
-        options = dict(dt=1e-3, sqrt_normalization=sqrt_normalization)
+    @pytest.mark.parametrize('cholesky_normalization', [False, True])
+    def test_correctness(self, cholesky_normalization):
+        options = dict(dt=1e-3, cholesky_normalization=cholesky_normalization)
         self._test_correctness(
             leaky_cavity_8,
             'rouchon1',
             options=options,
             num_tsave=11,
             ysave_norm_atol=1e-2,
-            exp_save_rtol=1e-2,
+            exp_save_rtol=1e-3,
             exp_save_atol=1e-2,
         )
 
-    @pytest.mark.parametrize('sqrt_normalization', [False, True])
-    def test_autograd(self, sqrt_normalization):
-        options = dict(dt=1e-3, sqrt_normalization=sqrt_normalization)
+    @pytest.mark.parametrize('cholesky_normalization', [False, True])
+    def test_autograd(self, cholesky_normalization):
+        options = dict(dt=1e-3, cholesky_normalization=cholesky_normalization)
         self._test_gradient(
             grad_leaky_cavity_8,
             'rouchon1',
@@ -35,11 +35,11 @@ class TestMERouchon1(SolverTester):
             atol=1e-2,
         )
 
-    @pytest.mark.parametrize('sqrt_normalization', [False, True])
-    def test_adjoint(self, sqrt_normalization):
+    @pytest.mark.parametrize('cholesky_normalization', [False, True])
+    def test_adjoint(self, cholesky_normalization):
         options = dict(
             dt=1e-3,
-            sqrt_normalization=sqrt_normalization,
+            cholesky_normalization=cholesky_normalization,
             parameters=grad_leaky_cavity_8.parameters,
         )
         self._test_gradient(

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -18,7 +18,7 @@ class TestMERouchon1(SolverTester):
             options=options,
             num_tsave=11,
             ysave_norm_atol=1e-2,
-            exp_save_rtol=1e-3,
+            exp_save_rtol=1e-4,
             exp_save_atol=1e-2,
         )
 
@@ -31,7 +31,7 @@ class TestMERouchon1(SolverTester):
             'autograd',
             options=options,
             num_tsave=11,
-            rtol=1e-2,
+            rtol=1e-4,
             atol=1e-2,
         )
 
@@ -48,7 +48,7 @@ class TestMERouchon1(SolverTester):
             'adjoint',
             options=options,
             num_tsave=11,
-            rtol=1e-2,
+            rtol=1e-4,
             atol=1e-2,
         )
 

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -9,9 +9,16 @@ class TestMERouchon1(SolverTester):
         options = dict(dt=1e-2)
         self._test_batching(leaky_cavity_8, 'rouchon1', options=options)
 
+    @pytest.mark.parametrize('sqrt_normalization', [False, True])
     @pytest.mark.parametrize('cholesky_normalization', [False, True])
-    def test_correctness(self, cholesky_normalization):
-        options = dict(dt=1e-3, cholesky_normalization=cholesky_normalization)
+    def test_correctness(self, sqrt_normalization, cholesky_normalization):
+        if sqrt_normalization and cholesky_normalization:
+            return
+        options = dict(
+            dt=1e-3,
+            sqrt_normalization=sqrt_normalization,
+            cholesky_normalization=cholesky_normalization,
+        )
         self._test_correctness(
             leaky_cavity_8,
             'rouchon1',
@@ -22,9 +29,16 @@ class TestMERouchon1(SolverTester):
             exp_save_atol=1e-2,
         )
 
+    @pytest.mark.parametrize('sqrt_normalization', [False, True])
     @pytest.mark.parametrize('cholesky_normalization', [False, True])
-    def test_autograd(self, cholesky_normalization):
-        options = dict(dt=1e-3, cholesky_normalization=cholesky_normalization)
+    def test_autograd(self, sqrt_normalization, cholesky_normalization):
+        if sqrt_normalization and cholesky_normalization:
+            return
+        options = dict(
+            dt=1e-3,
+            sqrt_normalization=sqrt_normalization,
+            cholesky_normalization=cholesky_normalization,
+        )
         self._test_gradient(
             grad_leaky_cavity_8,
             'rouchon1',
@@ -35,10 +49,14 @@ class TestMERouchon1(SolverTester):
             atol=1e-2,
         )
 
+    @pytest.mark.parametrize('sqrt_normalization', [False, True])
     @pytest.mark.parametrize('cholesky_normalization', [False, True])
-    def test_adjoint(self, cholesky_normalization):
+    def test_adjoint(self, sqrt_normalization, cholesky_normalization):
+        if sqrt_normalization and cholesky_normalization:
+            return
         options = dict(
             dt=1e-3,
+            sqrt_normalization=sqrt_normalization,
             cholesky_normalization=cholesky_normalization,
             parameters=grad_leaky_cavity_8.parameters,
         )


### PR DESCRIPTION
This is this idea of Rémi Robin. Essentially, it replaces the square root normalization of Rouchon methods with a cholesky renormalization instead.

The advantage of doing this is that it's fast to compute a Cholesky decomposition, and it's fast to multiply by an inverse. So it can be done at every time step, even for time-dependent problems ! And it has the same advantage as the sqrt method in terms of robustness to stiff problems.

So, for every time step, the time cost is:
 - without normalization: (2 + 2n) matrix multiplications
 - with normalization: (3 + 2n) matrix multiplications, 1 cholesky, 2 linalg.solve calls

(roughly, cholesky and linalg.solve are 2x slower than a matmul, but scale similarly and are supported on GPU)

Another advantage is that the code is now much cleaner. I completely removed the sqrtm_normalization, but can add it back if need be. I think this method is strictly more powerful however.