### PR TITLE
Change the API of PWC to accept arbitrary times

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import torch
+from torch import Tensor
 
 
 def type_str(type: Any) -> str:
@@ -28,3 +29,20 @@ def to_device(device: str | torch.device | None) -> torch.device:
             'Argument `device` must be a string, a `torch.device` or `None` but has'
             f' type {obj_type_str(device)}.'
         )
+
+
+def check_time_tensor(x: Tensor, arg_name: str, allow_empty=False):
+    # check that a time tensor is valid (it must be a 1D tensor sorted in strictly
+    # ascending order and containing only positive values)
+    if x.ndim != 1:
+        raise ValueError(
+            f'Argument `{arg_name}` must be a 1D tensor, but is a {x.ndim}D tensor.'
+        )
+    if not allow_empty and len(x) == 0:
+        raise ValueError(f'Argument `{arg_name}` must contain at least one element.')
+    if not torch.all(torch.diff(x) > 0):
+        raise ValueError(
+            f'Argument `{arg_name}` must be sorted in strictly ascending order.'
+        )
+    if not torch.all(x >= 0):
+        raise ValueError(f'Argument `{arg_name}` must contain positive values only.')

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._utils import obj_type_str
+from .._utils import check_time_tensor, obj_type_str
 from ..solvers.options import Dopri5, Euler, Propagator, Rouchon1, Rouchon2
 from ..solvers.result import Result
-from ..solvers.utils import batch_H, batch_y0, check_time_tensor, to_td_tensor
+from ..solvers.utils import batch_H, batch_y0, to_td_tensor
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
 from ..utils.utils import isket, todm
 from .adaptive import MEDormandPrince5

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from .._utils import obj_type_str
+from .._utils import check_time_tensor, obj_type_str
 from ..solvers.options import Dopri5, Euler, Propagator
 from ..solvers.result import Result
-from ..solvers.utils import batch_H, batch_y0, check_time_tensor, to_td_tensor
+from ..solvers.utils import batch_H, batch_y0, to_td_tensor
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
 from .adaptive import SEDormandPrince5
 from .euler import SEEuler

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -4,10 +4,10 @@ from typing import Any
 
 import torch
 
-from .._utils import obj_type_str
+from .._utils import check_time_tensor, obj_type_str
 from ..solvers.options import Euler, Rouchon1
 from ..solvers.result import Result
-from ..solvers.utils import batch_H, batch_y0, check_time_tensor, to_td_tensor
+from ..solvers.utils import batch_H, batch_y0, to_td_tensor
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
 from ..utils.utils import isket, todm
 from .euler import SMEEuler

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -154,20 +154,3 @@ def cache(func):
         return grad_cached_func(*args, grad_enabled=torch.is_grad_enabled(), **kwargs)
 
     return wrapper
-
-
-def check_time_tensor(x: Tensor, arg_name: str, allow_empty=False):
-    # check that a time tensor is valid (it must be a 1D tensor sorted in strictly
-    # ascending order and containing only positive values)
-    if x.ndim != 1:
-        raise ValueError(
-            f'Argument `{arg_name}` must be a 1D tensor, but is a {x.ndim}D tensor.'
-        )
-    if not allow_empty and len(x) == 0:
-        raise ValueError(f'Argument `{arg_name}` must contain at least one element.')
-    if not torch.all(torch.diff(x) > 0):
-        raise ValueError(
-            f'Argument `{arg_name}` must be sorted in strictly ascending order.'
-        )
-    if not torch.all(x >= 0):
-        raise ValueError(f'Argument `{arg_name}` must contain positive values only.')

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import torch
 from torch import Tensor
 
+from .._utils import check_time_tensor
 from .tensor_types import dtype_complex_to_real, get_cdtype, to_device
 
 __all__ = [
@@ -121,6 +122,8 @@ def pwc_pulse(times: Tensor, values: Tensor) -> callable[[float], Tensor]:
         >>> pulse(1.2)
         tensor([0.+0.j, 0.+0.j])
     """
+
+    check_time_tensor(times, 'times')
 
     def pulse(t):
         if t < times[0] or t >= times[-1]:

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -104,7 +104,7 @@ def pwc_pulse(times: Tensor, values: Tensor) -> callable[[float], Tensor]:
         filled with random complex numbers for the parameter `values`.
 
     Args:
-        Times _(n+1)_: Time intervals.
+        times _(n+1)_: Time points between which the pulse takes constant values.
         values _(..., n)_: Pulse complex values.
 
     Returns:


### PR DESCRIPTION
This is more general, aligns with #239 `plot_pwc_pulse()` function, and is more common (see e.g. `plt.stairs()` in `matplotlib`).

I had to move `check_time_tensor()` to the common `_utils` file.