### PR TITLE
Simpler `to_qutip()` API

### DIFF
--- a/docs/python_api/navigation.md
+++ b/docs/python_api/navigation.md
@@ -37,6 +37,7 @@
         - [isket](utils/utils/isket.md)
         - [isbra](utils/utils/isbra.md)
         - [isdm](utils/utils/isdm.md)
+        - [isop](utils/utils/isop.md)
         - [toket](utils/utils/toket.md)
         - [tobra](utils/utils/tobra.md)
         - [todm](utils/utils/todm.md)

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 import torch
+from torch import Tensor
+
+from .utils.utils import isket
 
 
 def type_str(type: Any) -> str:
@@ -28,3 +31,10 @@ def to_device(device: str | torch.device | None) -> torch.device:
             'Argument `device` must be a string, a `torch.device` or `None` but has'
             f' type {obj_type_str(device)}.'
         )
+
+
+def hdim(x: Tensor) -> int:
+    if isket(x):
+        return x.size(-2)
+    else:
+        return x.size(-1)

--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -18,6 +18,7 @@ __all__ = [
     'isket',
     'isbra',
     'isdm',
+    'isop',
     'toket',
     'tobra',
     'todm',
@@ -441,6 +442,26 @@ def isdm(x: Tensor) -> bool:
         >>> dq.isdm(torch.ones(5, 3, 3))
         True
         >>> dq.isdm(torch.ones(3, 1))
+        False
+    """
+    return x.size(-1) == x.size(-2)
+
+
+def isop(x: Tensor) -> bool:
+    r"""Returns True if a tensor is in the format of an operator.
+
+    Args:
+        x _(...)_: Tensor.
+
+    Returns:
+        True if the last two dimensions of `x` are equal, False otherwise.
+
+    Examples:
+        >>> dq.isop(torch.ones(3, 3))
+        True
+        >>> dq.isop(torch.ones(5, 3, 3))
+        True
+        >>> dq.isop(torch.ones(3, 1))
         False
     """
     return x.size(-1) == x.size(-2)


### PR DESCRIPTION
More straightforward way to define the system dimensions, compatible with `ptrace()`.