### PR TITLE
Simplify solver time logic

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import torch
+
 from .._utils import check_time_tensor, obj_type_str
 from ..solvers.options import Dopri5, Euler, Propagator, Rouchon1, Rouchon2
 from ..solvers.result import Result
@@ -213,14 +215,13 @@ def mesolve(
     check_time_tensor(tsave, arg_name='tsave')
 
     # define the solver
-    args = (H, rho0, tsave, exp_ops, options)
-    solver = SOLVER_CLASS(*args, jump_ops=jump_ops)
+    tmeas = torch.empty(0)
+    solver = SOLVER_CLASS(H, rho0, tsave, tmeas, exp_ops, options, jump_ops=jump_ops)
 
     # compute the result
-    solver.run()
+    result = solver.run()
 
     # get saved tensors and restore correct batching
-    result = solver.result
     result.ysave = result.ysave.squeeze(0, 1)
     if result.exp_save is not None:
         result.exp_save = result.exp_save.squeeze(0, 1)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+import torch
+
 from .._utils import check_time_tensor, obj_type_str
 from ..solvers.options import Dopri5, Euler, Propagator
 from ..solvers.result import Result
@@ -172,14 +174,13 @@ def sesolve(
     check_time_tensor(tsave, arg_name='tsave')
 
     # define the solver
-    args = (H, psi0, tsave, exp_ops, options)
-    solver = SOLVER_CLASS(*args)
+    tmeas = torch.empty(0)
+    solver = SOLVER_CLASS(H, psi0, tsave, tmeas, exp_ops, options)
 
     # compute the result
-    solver.run()
+    result = solver.run()
 
     # get saved tensors and restore correct batching
-    result = solver.result
     result.ysave = result.ysave.squeeze(0, 1)
     if result.exp_save is not None:
         result.exp_save = result.exp_save.squeeze(0, 1)

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -267,20 +267,22 @@ def smesolve(
     generator.seed() if seed is None else generator.manual_seed(seed)
 
     # define the solver
-    args = (H, rho0, tsave, exp_ops, options)
-    kwargs = dict(
+    solver = SOLVER_CLASS(
+        H,
+        rho0,
+        tsave,
+        tmeas,
+        exp_ops,
+        options,
         jump_ops=jump_ops,
         etas=etas,
         generator=generator,
-        tmeas=tmeas,
     )
-    solver = SOLVER_CLASS(*args, **kwargs)
 
     # compute the result
-    solver.run()
+    result = solver.run()
 
     # get saved tensors and restore correct batching
-    result = solver.result
     result.ysave = result.ysave.squeeze(0, 1)
     if result.exp_save is not None:
         result.exp_save = result.exp_save.squeeze(0, 1)

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -26,11 +26,17 @@ class FixedSolver(AutogradSolver):
             step inside `solver` and the time step inside the iteration loop. A small
             error can thus buildup throughout the ODE integration. TODO Fix this.
         """
-        # assert that `tstop` values are multiples of `dt`
-        if not torch.allclose(torch.round(self.tstop / self.dt), self.tstop / self.dt):
+        # assert that `tsave` values are multiples of `dt`
+        if not torch.allclose(torch.round(self.tsave / self.dt), self.tsave / self.dt):
             raise ValueError(
-                'Every value of `tsave` (and `tmeas` for SME solvers) must be a'
-                ' multiple of the time step `dt` for fixed time step ODE solvers.'
+                'Every value of `tsave` must be a multiple of the time step `dt` for '
+                'fixed time step ODE solvers.'
+            )
+        # assert that `tmeas` values are multiples of `dt`
+        if not torch.allclose(torch.round(self.tmeas / self.dt), self.tmeas / self.dt):
+            raise ValueError(
+                'Every value of `tmeas` must be a multiple of the time step `dt` for '
+                'fixed time step ODE solvers.'
             )
 
         # define time values
@@ -138,10 +144,10 @@ class AdjointFixedAutograd(torch.autograd.Function):
         solver.run_nograd()
 
         # save results and model parameters
-        ctx.save_for_backward(solver.result.ysave)
+        ctx.save_for_backward(solver.ysave)
 
         # returning `ysave` is required for custom backward functions
-        return solver.result.ysave, solver.result.exp_save
+        return solver.ysave, solver.exp_save
 
     @staticmethod
     def backward(ctx: FunctionCtx, *grad_y: Tensor) -> tuple[None, Tensor, Tensor]:

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -44,7 +44,7 @@ class Solver(ABC):
         self.device = self.options.device
 
         # initialize time logic
-        self.tstop = torch.cat((self.tsave, self.tmeas)).unique().sort()[0]
+        self.tstop = torch.cat((self.tsave, self.tmeas)).unique()
         self.tsave_mask = torch.isin(self.tstop, self.tsave)
         self.tmeas_mask = torch.isin(self.tstop, self.tmeas)
         self.tstop_counter = 0

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -46,7 +46,7 @@ class Solver(ABC):
         # initialize time logic
         self.tstop = torch.cat((self.tsave, self.tmeas)).unique().sort()[0]
         self.tsave_mask = torch.isin(self.tstop, self.tsave)
-        self.tmeas_mask = torch.isin(self.tstop, self.tsave)
+        self.tmeas_mask = torch.isin(self.tstop, self.tmeas)
         self.tstop_counter = 0
         self.tsave_counter = 0
         self.tmeas_counter = 0

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from math import inf
 from time import time
 
 import torch
@@ -9,7 +10,7 @@ from torch import Tensor
 from .options import Options
 from .result import Result
 from .utils.td_tensor import TDTensor
-from .utils.utils import bexpect
+from .utils.utils import bexpect, iteraxis
 
 
 class Solver(ABC):
@@ -18,6 +19,7 @@ class Solver(ABC):
         H: TDTensor,
         y0: Tensor,
         tsave: Tensor,
+        tmeas: Tensor,
         exp_ops: Tensor,
         options: Options,
     ):
@@ -33,6 +35,7 @@ class Solver(ABC):
         self.H = H
         self.y0 = y0
         self.tsave = tsave
+        self.tmeas = tmeas
         self.exp_ops = exp_ops
         self.options = options
 
@@ -41,45 +44,46 @@ class Solver(ABC):
         self.rdtype = self.options.rdtype
         self.device = self.options.device
 
-        # initialize saving logic
-        self._init_time_logic()
+        # initialize time logic
+        self.tstop = torch.cat((self.tsave, self.tmeas)).unique().sort()[0]
+        self.tstop_counter = 0
+        self.tsave_counter = 0
+        self.tmeas_counter = 0
 
         # initialize save tensors
         batch_sizes, (m, n) = y0.shape[:-2], y0.shape[-2:]
 
         if self.options.save_states:
             # ysave: (..., len(tsave), m, n)
-            ysave = torch.zeros(
+            self.ysave = torch.zeros(
                 *batch_sizes, len(tsave), m, n, dtype=self.cdtype, device=self.device
             )
+            self.ysave_iter = iteraxis(self.ysave, axis=-3)
         else:
-            ysave = None
+            self.ysave = None
 
         if len(self.exp_ops) > 0:
             # exp_save: (..., len(exp_ops), len(tsave))
-            exp_save = torch.zeros(
+            self.exp_save = torch.zeros(
                 *batch_sizes,
                 len(exp_ops),
                 len(tsave),
                 dtype=self.cdtype,
                 device=self.device,
             )
+            self.exp_save_iter = iteraxis(self.exp_save, axis=-1)
         else:
-            exp_save = None
+            self.exp_save = None
 
-        self.result = Result(options, ysave, tsave, exp_save)
-
-    def _init_time_logic(self):
-        self.tstop = self.tsave
-        self.tstop_counter = 0
-
-        self.tsave_mask = torch.isin(self.tstop, self.tsave)
-        self.tsave_counter = 0
-
-    def run(self):
-        self.result.start_time = time()
+    def run(self) -> Result:
+        start_time = time()
         self._run()
-        self.result.end_time = time()
+        end_time = time()
+
+        result = Result(self.options, self.ysave, self.tsave, self.exp_save)
+        result.start_time = start_time
+        result.end_time = end_time
+        return result
 
     def _run(self):
         if self.options.gradient_alg is None:
@@ -89,29 +93,42 @@ class Solver(ABC):
     def run_nograd(self):
         pass
 
+    def next_tsave(self) -> float:
+        if self.tsave_counter == len(self.tsave):
+            return inf
+        return self.tsave[self.tsave_counter].item()
+
+    def next_tmeas(self) -> float:
+        if self.tmeas_counter == len(self.tmeas):
+            return inf
+        return self.tmeas[self.tmeas_counter].item()
+
     def next_tstop(self) -> float:
         return self.tstop[self.tstop_counter].item()
 
     def save(self, y: Tensor):
-        self._save(y)
-        self.tstop_counter += 1
-
-    def _save(self, y: Tensor):
-        if self.tsave_mask[self.tstop_counter]:
+        if self.next_tstop() == self.next_tsave():
             self._save_y(y)
             self._save_exp_ops(y)
             self.tsave_counter += 1
+        if self.next_tstop() == self.next_tmeas():
+            self._save_meas()
+            self.tmeas_counter += 1
+        self.tstop_counter += 1
 
     def _save_y(self, y: Tensor):
         if self.options.save_states:
-            self.result.ysave[..., self.tsave_counter, :, :] = y
+            next(self.ysave_iter)[:] = y
         # otherwise only save the state if it is the final state
-        elif self.tsave_counter == len(self.tsave) - 1:
-            self.result.ysave = y
+        elif self.next_tsave() is inf:
+            self.ysave = y
 
     def _save_exp_ops(self, y: Tensor):
         if len(self.exp_ops) > 0:
-            self.result.exp_save[..., self.tsave_counter] = bexpect(self.exp_ops, y)
+            next(self.exp_save_iter)[:] = bexpect(self.exp_ops, y)
+
+    def _save_meas(self):
+        pass
 
 
 class AutogradSolver(Solver):

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from functools import partial, wraps
 from math import sqrt
+from typing import Iterator
 
 import torch
 from methodtools import lru_cache
@@ -154,3 +155,8 @@ def cache(func):
         return grad_cached_func(*args, grad_enabled=torch.is_grad_enabled(), **kwargs)
 
     return wrapper
+
+
+def iteraxis(x: Tensor, axis: int = 0) -> Iterator[Tensor]:
+    for i in range(x.size(axis)):
+        yield x.select(axis, i)


### PR DESCRIPTION
- directly integrate  `tmeas` in the base `Solver` class, it will just be an unused field for `sesolve` and `mesolve`
- simplify solver saving using `iteraxis`
- create result object after running the solver