### PR TITLE
[3/6] Refactor fixed solver

### DIFF
--- a/dynamiqs/mesolve/euler.py
+++ b/dynamiqs/mesolve/euler.py
@@ -16,6 +16,7 @@ class MEEuler(MESolver, AdjointFixedSolver):
     ) -> tuple[Tensor, Tensor]:
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
-        rho = rho - self.dt * self.lindbladian(t, rho)
-        phi = phi + self.dt * self.adjoint_lindbladian(t, phi)
+        # t is passed in as negative time
+        rho = rho - self.dt * self.lindbladian(-t, rho)
+        phi = phi + self.dt * self.adjoint_lindbladian(-t, phi)
         return rho, phi

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -90,7 +90,7 @@ class MERouchon1(MERouchon):
         r"""Compute $\rho(t-dt)$ and $\phi(t-dt)$ using a Rouchon method of order 1.
 
         Args:
-            t: Time.
+            t: Time (negative-valued).
             rho: Density matrix of shape `(b_H, b_rho, n, n)`.
             phi: Adjoint state matrix of shape `(b_H, b_rho, n, n)`.
 
@@ -101,7 +101,8 @@ class MERouchon1(MERouchon):
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        H = self.H(t)
+        # t is passed in as negative time
+        H = self.H(-t)
         Hnh = self.Hnh(H)
 
         # === reverse time
@@ -182,7 +183,7 @@ class MERouchon2(MERouchon):
             \dot{H}`.
 
         Args:
-            t: Time.
+            t: Time (negative-valued).
             rho: Density matrix of shape `(b_H, b_rho, n, n)`.
             phi: Adjoint state matrix of shape `(b_H, b_rho, n, n)`.
 
@@ -193,7 +194,8 @@ class MERouchon2(MERouchon):
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        H = self.H(t)
+        # t is passed in as negative time
+        H = self.H(-t)
         Hnh = self.Hnh(H)
 
         # === reverse time

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -86,7 +86,7 @@ class AdjointFixedSolver(FixedSolver, AdjointSolver):
     def integrate_augmented(
         self, t0: float, t1: float, y: Tensor, a: Tensor, g: tuple[Tensor, ...]
     ) -> tuple[Tensor, Tensor, tuple[Tensor, ...]]:
-        """Integrate the augmented ODE from time `t0` to `t1`."""
+        """Integrate the augmented ODE from time `t0` to `t1`, with `t0` < `t1` < 0."""
         # define time values
         num_times = round((t1 - t0) / self.dt) + 1
         times = torch.linspace(t0, t1, num_times)


### PR DESCRIPTION
Similar to #267, refactor fixed solvers in the forward and adjoint backward pass. Note in particular that, in preparation for the adjoint adaptive solver, `t` is now passed in as negative time during the backward pass. This way, time is always increasing. 

PR stack:

1. #266
2. #267 
3. This PR.
4. #269 
5. #270 
6. #272 
