### PR TITLE
[4/6] Default time to Solver class

### DIFF
--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -28,13 +28,12 @@ class AdaptiveSolver(AutogradSolver):
         self.step_counter = 0
 
         # initialize the ODE routine
-        t0 = 0.0
-        f0 = self.odefun(t0, self.y0)
-        dt = self.init_tstep(t0, self.y0, f0, self.odefun)
+        f0 = self.odefun(self.t0, self.y0)
+        dt = self.init_tstep(self.t0, self.y0, f0, self.odefun)
         error = 1.0
 
         # run the ODE routine
-        t, y, ft = t0, self.y0, f0
+        t, y, ft = self.t0, self.y0, f0
         for ts in self.tstop.cpu().numpy():
             y, ft, dt, error = self.integrate(t, ts, y, ft, dt, error)
             self.save(y)

--- a/dynamiqs/solvers/ode/adjoint_autograd.py
+++ b/dynamiqs/solvers/ode/adjoint_autograd.py
@@ -66,7 +66,7 @@ class AdjointFixedAutograd(torch.autograd.Function):
             # initialize time: time is negative-valued and sorted ascendingly during
             # backward integration.
             tstop_bwd = (-solver.tstop).flip(dims=(0,))
-            if tstop_bwd[-1] != 0.0:
+            if tstop_bwd[-1] != solver.t0:
                 tstop_bwd = torch.cat((tstop_bwd, torch.zeros(1).to(tstop_bwd)))
             t0 = tstop_bwd[0].item()
 

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -47,8 +47,7 @@ class FixedSolver(AutogradSolver):
         self.pbar = tqdm(total=self.tstop[-1].item(), disable=not self.options.verbose)
 
         # initialize time and state
-        t0 = 0.0
-        t, y = t0, self.y0
+        t, y = self.t0, self.y0
 
         # run the ode routine
         for ts in self.tstop.cpu().numpy():

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -32,12 +32,12 @@ class Propagator(AutogradSolver):
             raise TypeError(
                 'Solver `Propagator` requires a time-independent Hamiltonian.'
             )
-        self.H = self.H(0.0)
+        self.H = self.H(self.t0)
 
     def run_autograd(self):
-        y, t1 = self.y0, 0.0
+        t1, y = self.t0, self.y0
         for t2 in tqdm(self.tstop.cpu().numpy(), disable=not self.options.verbose):
-            if t2 != 0.0:
+            if t2 != self.t0:
                 # round time difference to avoid numerical errors when comparing floats
                 delta_t = round_truncate(t2 - t1)
                 y = self.forward(t1, delta_t, y)

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -33,6 +33,7 @@ class Solver(ABC):
             options:
         """
         self.H = H
+        self.t0 = 0.0
         self.y0 = y0
         self.tsave = tsave
         self.tmeas = tmeas


### PR DESCRIPTION
Add a `self.t0 = 0.0` to the Solver class, to avoid passing `0.0` throughout the code. A bit cleaner, and may be useful some day if we want to modify t0. 

PR stack:

1. #266 
2. #267 
3. #268 
4. This PR.
5. #270 
6. #272 
