### PR TITLE
[6/6] Merge fixed and adaptive adjoint

### DIFF
--- a/dynamiqs/solvers/ode/adjoint_autograd.py
+++ b/dynamiqs/solvers/ode/adjoint_autograd.py
@@ -12,106 +12,7 @@ from ..solver import AdjointSolver
 from ..utils.utils import tqdm
 
 
-class AdjointFixedAutograd(torch.autograd.Function):
-    """Class for ODE integration with a custom adjoint method backward pass."""
-
-    @staticmethod
-    def forward(
-        ctx: FunctionCtx,
-        solver: AdjointSolver,
-        y0: Tensor,
-        *params: tuple[nn.Parameter, ...],
-    ) -> tuple[Tensor, Tensor]:
-        """Forward pass of the ODE integrator."""
-        # save into context for backward pass
-        ctx.solver = solver
-
-        # integrate the ODE forward without storing the graph of operations
-        solver.run_nograd()
-
-        # save results and model parameters
-        ctx.save_for_backward(solver.ysave)
-
-        # returning `ysave` is required for custom backward functions
-        return solver.ysave, solver.exp_save
-
-    @staticmethod
-    def backward(ctx: FunctionCtx, *grad_y: Tensor) -> tuple[None, Tensor, Tensor]:
-        """Backward pass of the ODE integrator.
-
-        An augmented ODE is integrated backwards starting from the final state computed
-        during the forward pass. Integration is done in multiple sequential runs
-        between every checkpoint of the forward pass, as defined by `tstop`. This
-        helps with the stability of the backward integration.
-
-        Throughout this function, `y` is the state, `a = dL/dy` is the adjoint state,
-        and `g = dL/dp` is the gradient w.r.t. the parameters, where `L` is the loss
-        function and `p` the parameters.
-        """
-        # unpack context
-        solver = ctx.solver
-        ysave = ctx.saved_tensors[0]
-
-        # locally disable gradient computation
-        with torch.no_grad():
-            # initialize state, adjoint and gradients
-            if solver.options.save_states:
-                y = ysave[..., -1, :, :]
-                a = grad_y[0][..., -1, :, :]
-            else:
-                y = ysave[..., :, :]
-                a = grad_y[0][..., :, :]
-            if len(solver.exp_ops) > 0:
-                a += (grad_y[1][..., :, -1, None, None] * solver.exp_ops.mH).sum(dim=-3)
-
-            g = tuple(torch.zeros_like(p).to(y) for p in solver.options.params)
-
-            # initialize time: time is negative-valued and sorted ascendingly during
-            # backward integration.
-            tstop_bwd = (-solver.tstop).flip(dims=(0,))
-            if tstop_bwd[-1] != solver.t0:
-                tstop_bwd = torch.cat((tstop_bwd, torch.zeros(1).to(tstop_bwd)))
-            t0 = tstop_bwd[0].item()
-
-            # initialize progress bar
-            solver.pbar = tqdm(total=-t0, disable=not solver.options.verbose)
-
-            # integrate the augmented equation backward between every saved state
-            t = t0
-            for i, ts in enumerate(tstop_bwd.cpu().numpy()[1:]):
-                y, a, g = solver.integrate_augmented(t, ts, y, a, g)
-
-                if solver.options.save_states:
-                    # replace y with its checkpointed version
-                    y = ysave[..., -i - 2, :, :]
-                    # update adjoint wrt this time point by adding dL / dy(t)
-                    a += grad_y[0][..., -i - 2, :, :]
-
-                # update adjoint wrt this time point by adding dL / de(t)
-                if len(solver.exp_ops) > 0:
-                    a += (
-                        grad_y[1][..., :, -i - 2, None, None] * solver.exp_ops.mH
-                    ).sum(dim=-3)
-
-                # iterate time
-                t = ts
-
-        # close progress bar
-        with warnings.catch_warnings():  # ignore tqdm precision overflow
-            warnings.simplefilter('ignore', TqdmWarning)
-            solver.pbar.close()
-
-        # convert gradients of real-valued parameters to real-valued gradients
-        g = tuple(
-            _g.real if _p.is_floating_point() else _g
-            for (_g, _p) in zip(g, solver.options.params)
-        )
-
-        # return the computed gradients w.r.t. each argument in `forward`
-        return None, a, *g
-
-
-class AdjointAdaptiveAutograd(torch.autograd.Function):
+class AdjointAutograd(torch.autograd.Function):
     """Class for ODE integration with a custom adjoint method backward pass."""
 
     @staticmethod
@@ -176,18 +77,12 @@ class AdjointAdaptiveAutograd(torch.autograd.Function):
             solver.pbar = tqdm(total=-t0, disable=not solver.options.verbose)
 
             # initialize the ODE routine
-            f0, l0 = solver.odefun_augmented(t0, y, a)
-            dt_y = solver.init_tstep(t0, y, f0, solver.odefun_backward)
-            dt_a = solver.init_tstep(t0, a, l0, solver.odefun_adjoint)
-            dt = min(dt_y, dt_a)
-            error = 1.0
+            (*args,) = solver.init_augmented(t0, y, a)
 
             # integrate the augmented equation backward between every saved state
-            t, ft, lt = t0, f0, l0
+            t = t0
             for i, ts in enumerate(tstop_bwd.cpu().numpy()[1:]):
-                y, a, g, ft, lt, dt, error = solver.integrate_augmented(
-                    t, ts, y, a, g, ft, lt, dt, error
-                )
+                y, a, g, *args = solver.integrate_augmented(t, ts, y, a, g, *args)
 
                 if solver.options.save_states:
                     # replace y with its checkpointed version

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -28,6 +28,13 @@ class FixedSolver(AutogradSolver):
     def __init__(self, *args):
         super().__init__(*args)
         self.dt = self.options.dt
+        if isinstance(self.dt, Tensor):
+            if self.dt.numel() == 1:
+                self.dt = self.dt.item()
+            else:
+                raise ValueError(
+                    f"`dt` should be a number or a 0-d tensor, but is {self.dt}."
+                )
 
     def run_autograd(self):
         """Integrate a quantum ODE with a fixed time step custom integrator.

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -9,7 +9,7 @@ from tqdm.std import TqdmWarning
 
 from ..solver import AdjointSolver, AutogradSolver
 from ..utils.utils import add_tuples, none_to_zeros_like, tqdm
-from .adjoint_autograd import AdjointFixedAutograd
+from .adjoint_autograd import AdjointAutograd
 
 
 def _assert_multiple_of_dt(dt: float, times: Tensor, name: str):
@@ -80,7 +80,10 @@ class FixedSolver(AutogradSolver):
 
 class AdjointFixedSolver(FixedSolver, AdjointSolver):
     def run_adjoint(self):
-        AdjointFixedAutograd.apply(self, self.y0, *self.options.params)
+        AdjointAutograd.apply(self, self.y0, *self.options.params)
+
+    def init_augmented(self, t0: float, y: Tensor, a: Tensor) -> tuple:
+        return ()
 
     def integrate_augmented(
         self, t0: float, t1: float, y: Tensor, a: Tensor, g: tuple[Tensor, ...]


### PR DESCRIPTION
Merge `AdjointFixedAutograd` and `AdjointAdaptiveAutograd` into a single class `AdjointAutograd` and move the specific adaptive/fixed logic to the `FixedSolver` and `AdaptiveSolver` classes. This greatly simplifies the code.

PR stack:

1. #266 
2. #267 
3. #268 
4. #269 
5. #270 
6. This PR.
