### PR TITLE
Refactor rouchon ME solver

### DIFF
--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -24,14 +24,14 @@ class MERouchon(MESolver, AdjointFixedSolver):
 
 
 class MERouchon1(MERouchon):
-    @cache
+    @cache(maxsize=2)
     def R(self, M0: Tensor, dt: float) -> Tensor:
         # `R` is close to identity but not exactly, we inverse it to normalize the
         # Kraus map in order to have a trace-preserving scheme
         # -> (b_H, 1, n, n)
         return M0.mH @ M0 + dt * self.sum_LdagL
 
-    @cache
+    @cache(maxsize=2)
     def Ms(self, Hnh: Tensor, dt: float) -> tuple(Tensor, Tensor):
         # Kraus operators
         # -> (b_H, 1, n, n), (1, len(L), n, n)
@@ -48,7 +48,7 @@ class MERouchon1(MERouchon):
 
         return M0, M1s
 
-    @cache
+    @cache(maxsize=2)
     def T(self, R: Tensor) -> Tensor:
         # we normalize the map at each time step by inverting `R` using its Cholesky
         # decomposition `R = T @ T.mT`

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -130,21 +130,13 @@ class MERouchon1(MERouchon):
 
 
 class MERouchon2(MERouchon):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # define cached operators
-        # self.M0, self.M0dag, self.M0rev: (b_H, 1, n, n)
-        # self.M1s, self.M1sdag: (b_H, len(L), n, n)
-        self.M0 = cache(
-            lambda Hnh: self.I - 1j * self.dt * Hnh - 0.5 * self.dt**2 * Hnh @ Hnh
-        )
-        self.M0dag = cache(lambda M0: M0.mH)
-        self.M0rev = cache(
-            lambda Hnh: self.I + 1j * self.dt * Hnh - 0.5 * self.dt**2 * Hnh @ Hnh
-        )
-        self.M1s = cache(lambda M0: 0.5 * sqrt(self.dt) * (self.L @ M0 + M0 @ self.L))
-        self.M1sdag = cache(lambda M1s: M1s.mH)
+    @cache(maxsize=2)
+    def Ms(self, Hnh: Tensor, dt: float) -> tuple(Tensor, Tensor):
+        # Kraus operators
+        # -> (b_H, 1, n, n), (b_H, len(L), n, n)
+        M0 = self.I - 1j * dt * Hnh - 0.5 * dt**2 * Hnh @ Hnh  # (b_H, 1, n, n)
+        M1s = 0.5 * sqrt(self.dt) * (self.L @ M0 + M0 @ self.L)  # (b_H, len(L), n, n)
+        return M0, M1s
 
     def forward(self, t: float, rho: Tensor) -> Tensor:
         r"""Compute $\rho(t+dt)$ using a Rouchon method of order 2.
@@ -164,12 +156,9 @@ class MERouchon2(MERouchon):
         """
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        # compute cached operators
-        # H, Hnh, M0: (b_H, 1, n, n)
-        H = self.H(t)
-        Hnh = self.Hnh(H)
-        M0 = self.M0(Hnh)
-        M1s = self.M1s(M0)  # (b_H, len(L), n, n)
+        H = self.H(t)  # (b_H, 1, n, n)
+        Hnh = self.Hnh(H)  # (b_H, 1, n, n)
+        M0, M1s = self.Ms(Hnh, self.dt)  # (b_H, 1, n, n), (b_H, len(L), n, n)
 
         # compute rho(t+dt)
         tmp = kraus_map(rho, M1s)  # (b_H, b_rho, n, n)
@@ -201,24 +190,22 @@ class MERouchon2(MERouchon):
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        # compute cached operators
-        # H, Hnh, M0, M0dag, M0rev: (b_H, 1, n, n)
-        # M1s, M1sdag: (b_H, len(L), n, n)
         H = self.H(t)
         Hnh = self.Hnh(H)
-        M0 = self.M0(Hnh)
-        M0dag = self.M0dag(M0)
-        M0rev = self.M0rev(Hnh)
-        M1s = self.M1s(M0)
-        M1sdag = self.M1sdag(M1s)
+
+        # === reverse time
+        M0rev, M1srev = self.Ms(Hnh, -self.dt)
 
         # compute rho(t-dt)
-        tmp = kraus_map(rho, M1s)
-        rho = kraus_map(rho, M0rev) - tmp + 0.5 * kraus_map(tmp, M1s)
+        tmp = kraus_map(rho, M1srev)
+        rho = kraus_map(rho, M0rev) - tmp + 0.5 * kraus_map(tmp, M1srev)
         rho = unit(rho)
 
+        # === forward time
+        M0, M1s = self.Ms(Hnh, self.dt)
+
         # compute phi(t-dt)
-        tmp = kraus_map(phi, M1sdag)
-        phi = kraus_map(phi, M0dag) + tmp + 0.5 * kraus_map(tmp, M1sdag)
+        tmp = kraus_map(phi, M1s.mH)
+        phi = kraus_map(phi, M0.mH) + tmp + 0.5 * kraus_map(tmp, M1s.mH)
 
         return rho, phi

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -24,49 +24,36 @@ class MERouchon(MESolver, AdjointFixedSolver):
 
 
 class MERouchon1(MERouchon):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    @cache
+    def R(self, M0: Tensor, dt: float) -> Tensor:
+        # `R` is close to identity but not exactly, we inverse it to normalize the
+        # Kraus map in order to have a trace-preserving scheme
+        # -> (b_H, 1, n, n)
+        return M0.mH @ M0 + dt * self.sum_LdagL
 
-        # forward time operators
-        # M0: (b_H, 1, n, n)
-        # M1s: (1, len(L), n, n)
-        self.M0 = cache(lambda Hnh: self.I - 1j * self.dt * Hnh)
-        self.M1s = sqrt(self.dt) * self.L
+    @cache
+    def Ms(self, Hnh: Tensor, dt: float) -> tuple(Tensor, Tensor):
+        # Kraus operators
+        # -> (b_H, 1, n, n), (1, len(L), n, n)
+        M0 = self.I - 1j * dt * Hnh  # (b_H, 1, n, n)
+        M1s = sqrt(self.dt) * self.L  # (1, len(L), n, n)
 
-        # reverse time operators
-        # M0rev: (b_H, 1, n, n)
-        # M1srev: (1, len(L), n, n)
-        self.M0rev = cache(lambda Hnh: self.I + 1j * self.dt * Hnh)
-        self.M1srev = self.M1s
+        if self.options.normalize == 'sqrt':
+            R = self.R(M0, dt)
+            # we normalize the operators by computing `S = sqrt(R)^-1` and applying it
+            # to the `Ms` operators
+            S = inv_sqrtm(R)
+            M0 = M0 @ S if dt >= 0 else S @ M0
+            M1s = M1s @ S if dt >= 0 else S @ M1s
 
-        if self.options.normalize:
-            # `R` is close to identity but not exactly, we inverse it to normalize the
-            # Kraus map in order to have a trace-preserving scheme
-            self.R = cache(lambda M0: M0.mH @ M0 + self.dt * self.sum_LdagL)
-            self.Rrev = cache(lambda M0rev: M0rev.mH @ M0rev - self.dt * self.sum_LdagL)
+        return M0, M1s
 
-            if self.H.is_constant:
-                # if H is constant, we normalize the operators once by computing
-                # `S = sqrt(R)^-1` and applying is to the `Ms` operators
-                H = self.H(0.0)
-                Hnh = self.Hnh(H)
-                M0 = self.M0(Hnh)
-                M0rev = self.M0rev(Hnh)
-
-                S = inv_sqrtm(self.R(M0))
-                Srev = inv_sqrtm(self.Rrev(M0rev))
-
-                self.M0 = cache(lambda Hnh: M0 @ S)
-                self.M1s = self.M1s @ S
-                self.M0rev = cache(lambda Hnh: Srev @ M0rev)
-                self.M1srev = Srev @ self.M1s
-            else:
-                # if `H` is time-dependent, we normalize the map at each time step by
-                # inverting `R` using its Cholesky decomposition `R = T @ T.mT`
-                self.T = cache(lambda R: cholesky(R)[0])  # lower triangular
-                self.Trev = cache(lambda Rrev: cholesky(Rrev)[0])  # lower triangular
-
-        self.cholesky_normalization = self.options.normalize and not self.H.is_constant
+    @cache
+    def T(self, R: Tensor) -> Tensor:
+        # we normalize the map at each time step by inverting `R` using its Cholesky
+        # decomposition `R = T @ T.mT`
+        # -> (b_H, 1, n, n)
+        return cholesky(R)[0]  # lower triangular
 
     def forward(self, t: float, rho: Tensor) -> Tensor:
         r"""Compute $\rho(t+dt)$ using a Rouchon method of order 1.
@@ -80,21 +67,18 @@ class MERouchon1(MERouchon):
         """
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        # compute cached operators
-        # H, Hnh, M0: (b_H, 1, n, n)
-        H = self.H(t)
-        Hnh = self.Hnh(H)
-        M0 = self.M0(Hnh)
+        H = self.H(t)  # (b_H, 1, n, n)
+        Hnh = self.Hnh(H)  # (b_H, 1, n, n)
+        M0, M1s = self.Ms(Hnh, self.dt)  # (b_H, 1, n, n), (1, len(L), n, n)
 
         # normalize the Kraus Map
-        if self.cholesky_normalization:
-            # R, T: (b_H, 1, n, n)
-            R = self.R(M0)
-            T = self.T(R)
+        if self.options.normalize == 'cholesky':
+            R = self.R(M0, self.dt)  # (b_H, 1, n, n)
+            T = self.T(R)  # (b_H, 1, n, n)
             rho = inv_kraus_matmul(T.mH, rho, upper=True)  # T.mH^-1 @ rho @ T^-1
 
         # compute rho(t+dt)
-        rho = kraus_map(rho, M0) + kraus_map(rho, self.M1s)  # (b_H, b_rho, n, n)
+        rho = kraus_map(rho, M0) + kraus_map(rho, M1s)  # (b_H, b_rho, n, n)
 
         return unit(rho)
 
@@ -115,29 +99,30 @@ class MERouchon1(MERouchon):
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        # compute cached operators
-        # H, Hnh, M0, M0rev: (b_H, 1, n, n)
         H = self.H(t)
         Hnh = self.Hnh(H)
-        M0 = self.M0(Hnh)
-        M0rev = self.M0rev(Hnh)
+
+        # === reverse time
+        M0rev, M1srev = self.Ms(Hnh, -self.dt)
 
         # normalize the Kraus Map
-        if self.cholesky_normalization:
-            # Rrev, Trev: (b_H, 1, n, n)
-            Rrev = self.Rrev(M0rev)
-            Trev = self.Trev(Rrev)
+        if self.options.normalize == 'cholesky':
+            Rrev = self.R(M0rev, -self.dt)
+            Trev = self.T(Rrev)
             rho = inv_kraus_matmul(Trev.mH, rho, upper=True)  # Tr.mH^-1 @ rho @ Tr^-1
 
         # compute rho(t-dt)
-        rho = kraus_map(rho, M0rev) - kraus_map(rho, self.M1srev)
+        rho = kraus_map(rho, M0rev) - kraus_map(rho, M1srev)
+
+        # === forward time
+        M0, M1s = self.Ms(Hnh, self.dt)
 
         # compute phi(t-dt)
-        phi = kraus_map(phi, M0.mH) + kraus_map(phi, self.M1s.mH)
+        phi = kraus_map(phi, M0.mH) + kraus_map(phi, M1s.mH)
 
-        if self.cholesky_normalization:
-            # R, T: (b_H, 1, n, n)
-            R = self.R(M0)
+        # normalize the Kraus Map
+        if self.options.normalize == 'cholesky':
+            R = self.R(M0, self.dt)
             T = self.T(R)
             phi = inv_kraus_matmul(T, phi, upper=False)  # T^-1 @ phi @ T.mH^-1
 

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Literal
+
 from .gradient import Adjoint, Autograd, Gradient
 
 
@@ -53,13 +57,18 @@ class Euler(_ODEFixedStep):
 class Rouchon1(_ODEFixedStep):
     SUPPORTED_GRADIENT = (Autograd, Adjoint)
 
-    def __init__(self, *, dt: float, normalize: bool = True):
-        # normalize: If `True`, the scheme is made trace-preserving (up to machine
-        # precision) by renormalizing the Kraus map applied at each time step. Ideal
-        # for stiff problems. For time-independent problem the Kraus map is normalized
-        # with a matrix square root. For time-dependent problems the Kraus map is
-        # normalized with a Cholesky decomposition at every time step.
-        # at every step to preserve the trace of the density matrix.
+    def __init__(
+        self, *, dt: float, normalize: Literal['sqrt', 'cholesky'] | None = None
+    ):
+        # normalize: The default scheme is trace-preserving at first order only. This
+        # parameter sets the normalisation behaviour:
+        # - `None`: The scheme is not normalized.
+        # - `'sqrt'`: The Kraus map is renormalized with a matrix square root. Ideal
+        #   for stiff problems, recommended for time-independent problems.
+        # - `cholesky`: The Kraus map is renormalized at each time step using a Cholesky
+        #   decomposition. Ideal for stiff problems, recommended for time-dependent
+        #   problems.
+
         super().__init__(dt=dt)
         self.normalize = normalize
 

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -106,13 +106,17 @@ def hairer_norm(x: Tensor) -> Tensor:
     return torch.linalg.matrix_norm(x) / sqrt(x.size(-1) * x.size(-2))
 
 
-def cache(func):
-    """Cache a function returning a tensor by memoizing its most recent call.
+def cache(func=None, *, maxsize: int = 1):
+    """Cache a function returning a tensor by memoizing its most recent calls.
 
-    This decorator extends `methodtools.lru_cache` to also cache a function on PyTorch
-    grad mode status (enabled or disabled). This prevents cached tensors detached from
-    the graph (for example computed within a `with torch.no_grad()` block) from being
-    used by mistake by later code which requires tensors attached to the graph.
+    This decorator extends `methodtools.lru_cache` to also cache a function on
+    PyTorch grad mode status (enabled or disabled). This prevents cached tensors
+    detached from the graph (for example computed within a `with torch.no_grad()`
+    block) from being used by mistake by later code which requires tensors attached
+    to the graph.
+
+    By default, the cache size is `1`, which means that only the most recent call is
+    cached. Use the `maxsize` keyword argument to change the maximum cache size.
 
     Warning:
         This decorator should only be used for PyTorch tensors.
@@ -137,15 +141,42 @@ def cache(func):
         tensor([1, 4, 9])
         tensor([1, 4, 9])
 
+        Increasing the maximum cache size:
+        >>> @cache(maxsize=2)
+        ... def square(x):
+        ...     print('compute square')
+        ...     return x**2
+        ...
+        >>> square(1)
+        compute square
+        1
+        >>> square(2)
+        compute square
+        4
+        >>> square(1)
+        1
+        >>> square(2)
+        4
+        >>> square(3)
+        compute square
+        9
+        >>> square(2)
+        4
+        >>> square(1)
+        compute square
+        1
+
     Args:
         func: Function returning a tensor, can take any number of arguments.
 
     Returns:
         Cached function.
     """
+    if func is None:
+        return partial(cache, maxsize=maxsize)
 
     # define a function cached on its arguments and also on PyTorch grad mode status
-    @lru_cache(maxsize=1)
+    @lru_cache(maxsize=maxsize)
     def grad_cached_func(*args, grad_enabled, **kwargs):
         return func(*args, **kwargs)
 

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -12,7 +12,7 @@ class TestMERouchon1(SolverTester):
         solver = Rouchon1(dt=1e-2)
         self._test_batching(leaky_cavity_8, solver)
 
-    @pytest.mark.parametrize('normalize', [False, True])
+    @pytest.mark.parametrize('normalize', [None, 'sqrt', 'cholesky'])
     def test_correctness(self, normalize):
         solver = Rouchon1(dt=1e-3, normalize=normalize)
         self._test_correctness(
@@ -24,7 +24,7 @@ class TestMERouchon1(SolverTester):
             exp_save_atol=1e-2,
         )
 
-    @pytest.mark.parametrize('normalize', [False, True])
+    @pytest.mark.parametrize('normalize', [None, 'sqrt', 'cholesky'])
     def test_autograd(self, normalize):
         solver = Rouchon1(dt=1e-3, normalize=normalize)
         self._test_gradient(
@@ -36,7 +36,7 @@ class TestMERouchon1(SolverTester):
             atol=1e-2,
         )
 
-    @pytest.mark.parametrize('normalize', [False, True])
+    @pytest.mark.parametrize('normalize', [None, 'sqrt', 'cholesky'])
     def test_adjoint(self, normalize):
         solver = Rouchon1(dt=1e-3, normalize=normalize)
         gradient = Adjoint(parameters=grad_leaky_cavity_8.parameters)


### PR DESCRIPTION
I wasn't very satisfied with what we ended with for the Rouchon solver, the caching felt like a burden while we should actually use it properly to make the code as transparent as possible to the Hamiltonian (constant or time-dependent). I think the main reason was that we sticked with inline lambdas to define what are actually control-flow dependent objects (`M0` and `M1`).

- Now we can use the argument `dt: float` to define `M0` or `M0rev` directly from the forward and backward pass (without creating a bunch of `...rev` objects in the `__init__`).
- I realised we actually need the `sqrtm` normalisation also for time-dependent tensors, because for PWC Hamiltonian it's sometimes better suited than `cholesky` (you just renormalize once for each PWC part). Also they are qualitatively quite different on the tests I made, so `sqrtm` might also be nice for true time-dependent problem where you want to ensure precision.
- The `normalize` option is either `None`, `'sqrt'` or `'cholesky'`. The only "bad case" is if someone chooses `'cholesky'` for a constant tensor, because in this case we should renormalize the Kraus map once, and not the state at every time. But if we document that it's better to use `'sqrtm'` for constant tensors I think it's fine. If you think its' necessary @gautierronan we can also implement back the constant Hamiltonian cholesky normalisation, it will be easier with this structure.
- I had to rework the `@cache` decorator (for the best!) to allow caching on more than one arguments combination (to cache during the backward pass both `M0` on `self.dt` and `M0rev` on `-self.dt`).
- I removed all tensors shapes comments from the bwd pass, I think having them in the fwd pass is enough.
- It should be much easier now to implement cleanly the normalisation for `Rouchon2`.

⚠️ If I'm not mistaken, the only difference with the code on main is https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/mesolve/rouchon.py#L161 > @gautierronan  should `M1srev` use `M0` (code on main) or `M0rev` (this PR code)?

```python
# code on main
self.M1s = cache(lambda M0: 0.5 * sqrt(self.dt) * (self.L @ M0 + M0 @ self.L))
self.M1srev = self.M1s

# this PR code
self.M1s = cache(lambda M0: 0.5 * sqrt(self.dt) * (self.L @ M0 + M0 @ self.L))
self.M1srev = cache(lambda M0: 0.5 * sqrt(self.dt) * (self.L @ M0rev + M0rev @ self.L))
```