### PR TITLE
Change readme `Let's discuss` -> `Let's talk`

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ gradient wrt to kappa  : tensor([-0.9048])
 gradient wrt to alpha0 : tensor([1.8097])
 ```
 
-## Let's discuss
+## Let's talk
 
 If you're curious, have questions or suggestions, wish to contribute or simply want to say hello, please don't hesitate to engage with us, we're always happy to chat! You can join the community on Slack via [this invite link](https://join.slack.com/t/dynamiqs-org/shared_invite/zt-1z4mw08mo-qDLoNx19JBRtKzXlmlFYLA), open an issue on GitHub, or contact the lead developer via email at <pierreguilmin@gmail.com>.
 


### PR DESCRIPTION
`discuss` is used to talk about an issue so it's not very idiomatic for inviting people to chat
https://fr.linkedin.com/pulse/talk-discuss-feriel-temmar
