### PR TITLE
Fix documentation hook to filter lines

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -23,7 +23,7 @@ def mplstyle():
 
 # doctest fixture
 @pytest.fixture()
-def render():
+def renderfig():
     def savefig_docs(figname):
         filename = f'docs/figs-docs/{figname}.png'
         plt.gcf().savefig(filename, bbox_inches='tight', dpi=300)
@@ -39,5 +39,5 @@ pytest_collect_file = Sybil(
         SkipParser(),
     ],
     patterns=['*.md'],
-    fixtures=['render'],
+    fixtures=['renderfig'],
 ).pytest()

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,23 +1,21 @@
 import re
 
+# The following regex will match any line containing 'renderfig', 'skip: start' or
+# 'skip: end':
+# - '^' matches the start of a line
+# - '.*' matches any character (except for line terminators) zero or more times
+# - '$' matches the end of a line
+# - '\n?' optionally matches the newline character at the end of the line
+regex = r'^.*(renderfig|skip: start|skip: end).*$\n?'
+# `flags=re.MULTILINE` is necessary to match the start and end of each line
+pattern = re.compile(regex, flags=re.MULTILINE)
 
-def replace_render(text):
-    # this regex will match
-    # - the word 'render' followed by anything inside parentheses
-    # - the line '% skip: start'
-    # - the line '% skip: end'
-    regex1 = (
-        r'(<span class="gp">&gt;&gt;&gt; </span>)?<span'
-        r' class="n">render<\/span><span class="p">\(<\/span><span'
-        r' class="s1">[^\']*<\/span><span class="p">\)<\/span>\n'
-    )
-    regex2 = r'<p>% skip: start</p>\n'
-    regex3 = r'<p>% skip: end</p>\n'
-    pattern = re.compile(f'{regex1}|{regex2}|{regex3}')
-    # Replace the matched text with an empty string (or whatever you want)
+
+def filter_lines(text):
+    # replace the matched text with an empty string
     return pattern.sub('', text)
 
 
 def on_env(env, config, files, **kwargs):
-    env.filters['replace_render'] = replace_render
+    env.filters['filter_lines'] = filter_lines
     return env

--- a/docs/overrides/partials/content.html
+++ b/docs/overrides/partials/content.html
@@ -5,7 +5,7 @@
 {% if "\x3ch1" not in page.content %}
   <h1>{{ page.title | d(config.site_name, true)}}</h1>
 {% endif %}
-{{ page.content | replace_render }}
+{{ page.content | filter_lines }}
 {% if page.meta and (
   page.meta.git_revision_date_localized or
   page.meta.revision_date

--- a/docs/tutorials/workflow.md
+++ b/docs/tutorials/workflow.md
@@ -120,7 +120,7 @@ plt.ylabel(r'$\langle \sigma_z \rangle$')
 plt.xlim(0, 10)
 plt.ylim(-1, 1)
 plt.legend(('Analytical', 'dynamiqs'))
-render('workflow')
+renderfig('workflow')
 ```
 
 ![workflow](/figs-docs/workflow.png){.center .full-width}

--- a/dynamiqs/conftest.py
+++ b/dynamiqs/conftest.py
@@ -28,7 +28,7 @@ def mplstyle():
 
 # doctest fixture
 @pytest.fixture()
-def render():
+def renderfig():
     def savefig_code(figname):
         filename = f'docs/figs-code/{figname}.png'
         plt.gcf().savefig(filename, bbox_inches='tight', dpi=300)
@@ -43,5 +43,5 @@ pytest_collect_file = Sybil(
     ],
     patterns=['*.py'],
     setup=sybil_setup,
-    fixtures=['render'],
+    fixtures=['renderfig'],
 ).pytest()

--- a/dynamiqs/plots/misc.py
+++ b/dynamiqs/plots/misc.py
@@ -34,7 +34,7 @@ def plot_pwc_pulse(
         >>> times = np.linspace(0, 1.0, n+1)
         >>> values = dq.rand_complex(n, seed=42)
         >>> dq.plot_pwc_pulse(times, values)
-        >>> render('plot_pwc_pulse')
+        >>> renderfig('plot_pwc_pulse')
 
         ![plot_pwc_pulse](/figs-code/plot_pwc_pulse.png){.center .full-width}
     """
@@ -85,7 +85,7 @@ def plot_fock(
     Examples:
         >>> psi = dq.coherent(16, 2.0)
         >>> dq.plot_fock(psi)
-        >>> render('plot_fock')
+        >>> renderfig('plot_fock')
 
         ![plot_fock](/figs-code/plot_fock.png){.center .full-width}
     """
@@ -129,13 +129,13 @@ def plot_fock_evolution(
         >>> tsave = np.linspace(0, 1.0, 11)
         >>> result = dq.sesolve(H, psi0, tsave)
         >>> dq.plot_fock_evolution(result.states)
-        >>> render('plot_fock_evolution')
+        >>> renderfig('plot_fock_evolution')
 
         ![plot_fock_evolution](/figs-code/plot_fock_evolution.png){.center .full-width}
 
         Use the log scale option to visualise low populations:
         >>> dq.plot_fock_evolution(result.states, logscale=True, logvmin=1e-5)
-        >>> render('plot_fock_evolution_log')
+        >>> renderfig('plot_fock_evolution_log')
 
         ![plot_fock_evolution_log](/figs-code/plot_fock_evolution_log.png){.center .full-width}
     """  # noqa: E501


### PR DESCRIPTION
The previous implementation is bugged, see e.g. https://www.dynamiqs.org/python_api/plots/misc/plot_fock_evolution.html where the first code block completely disappears. This is more robust.

I renamed `render` to `renderfig` to avoid any potential conflict with HTML/JS/CSS code which would use a line with such a name.