### PR TITLE
Minor doc improvements (zoomable images, remove warning)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,15 @@ extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/contrib/auto-render.min.js
 watch:
   - dynamiqs
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    absolute_links: ignore
+    unrecognized_links: warn
 nav:
   - Home: index.md
   - Getting started:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,6 +49,12 @@ extra_css:
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.css
 plugins:
   - search
+  - glightbox:
+      effect: fade
+      slide_effect: slide
+      width: 70%
+      zoomable: false
+      draggable: false
   - mkdocs-simple-hooks:
       hooks:
           on_env: "docs.hooks:on_env"
@@ -80,6 +86,7 @@ markdown_extensions:
   - pymdownx.caret
   - attr_list
   - footnotes
+  - md_in_html
 extra_javascript:
   - javascripts/katex.js
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/katex.min.js

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,7 +57,7 @@ plugins:
       draggable: false
   - mkdocs-simple-hooks:
       hooks:
-          on_env: "docs.hooks:on_env"
+        on_env: "docs.hooks:on_env"
   - gen-files:
       scripts:
         - docs/generate_python_api.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
     "mkdocs-literate-nav",
     "mkdocs-section-index",
     "mkdocs-simple-hooks",
+    "mkdocs-glightbox",
     "sybil",
 ]
 


### PR DESCRIPTION
Finally no more warnings 😅 (update all mkdocs related package and you should have the same when using `task docserve`)
<img width="669" alt="Screenshot 2023-11-09 at 22 05 49" src="https://github.com/dynamiqs/dynamiqs/assets/38159029/b843810f-48d2-4d32-a12e-f06680334f73">

I added a package to zoom on image, tell me if you like it, I think it's nice to show plots in HD during a presentation (e.g. the beautiful incoming benchmark plot)
![Screenshot 2023-11-09 at 22 02 07 (2)](https://github.com/dynamiqs/dynamiqs/assets/38159029/59c143d8-1c82-49e7-aac5-d810c204e5a1)
And when you click the image:
![Screenshot 2023-11-09 at 22 02 11 (2)](https://github.com/dynamiqs/dynamiqs/assets/38159029/7214a3da-18ad-4787-ba0d-1f5252e759f7)

