### PR TITLE
Fix cavity tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,11 @@ $$
 $$
 \nabla_\theta l(t) =
 \begin{pmatrix}
+    \frac{\partial l(t)}{\partial \Delta} \\
+    \frac{\partial l(t)}{\partial \alpha_0} \\
+    \frac{\partial l(t)}{\partial \kappa}
+\end{pmatrix} =
+\begin{pmatrix}
   0.0 \\
   2 \alpha_0 e^{-\kappa t} \\
   -\alpha_0^2 t e^{-\kappa t}
@@ -53,11 +58,21 @@ $$
 \begin{aligned}
     \nabla_\theta \braket{O^{(1)}}(t) &=
     \begin{pmatrix}
+        \frac{\partial \braket{O^{(1)}}(t)}{\partial \Delta} \\
+        \frac{\partial \braket{O^{(1)}}(t)}{\partial \alpha_0} \\
+        \frac{\partial \braket{O^{(1)}}(t)}{\partial \kappa}
+    \end{pmatrix} =
+    \begin{pmatrix}
         -\alpha_0 t \sin(\Delta t) e^{-\kappa t/2} \\
         \cos(\Delta t) e^{-\kappa t/2} \\
         - \frac12 \alpha_0 t \cos(\Delta t) e^{-\kappa t/2}
     \end{pmatrix} \\
     \nabla_\theta \braket{O^{(2)}}(t) &=
+    \begin{pmatrix}
+        \frac{\partial \braket{O^{(2)}}(t)}{\partial \Delta} \\
+        \frac{\partial \braket{O^{(2)}}(t)}{\partial \alpha_0} \\
+        \frac{\partial \braket{O^{(2)}}(t)}{\partial \kappa}
+    \end{pmatrix} =
     \begin{pmatrix}
         -\alpha_0 t \cos(\Delta t) e^{-\kappa t/2} \\
         -\sin(\Delta t) e^{-\kappa t/2} \\

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,58 +1,67 @@
 # Test systems
 
-We test our solvers on examples with analytical solutions.
+We test our solvers on systems with an analytical solution.
 
 ## `Cavity` and `OCavity`
 
 **Problem**
 
-- Hamiltonian: $H = \Delta a^\dag a$
+- Hamiltonian: $H = \Delta a^\dagger a$
 - Jump operators: $L = \sqrt{\kappa} a$
-- Expectation operators: $O^{(1)} = X = (a+a^\dag)/2$ and $O^{(2)} = P = i(a^\dag-a)/2$
-- Initial state: $\ket{\psi_0} = \ket{\alpha_0}$ with $\alpha_0\in\R$
-- Loss: $l_t = \braket{a^\dag a}_t$
+- Expectation operators: $O^{(1)} = X = (a+a^\dagger)/2$ and $O^{(2)} = P = i(a^\dagger-a)/2$
+- Initial state: $\ket{\psi_0} = \ket{\alpha_0}$ with $\alpha_0\in\mathbb{R}$
+- Loss: $l(t) = \braket{a^\dagger a}(t)$
 - Gradient parameters: $\theta=(\Delta, \alpha_0, \kappa)$
 
 **Solution at time $t$**
 
-- State at time $t$:
-  $$
-      \ket{\psi_t} = \ket{\alpha_t}\ \text{with}\ \alpha_t = \alpha_0 e^{-i\Delta t - \kappa t/2}
-  $$
-- Expectation values at time $t$:
-  $$
-  \begin{aligned}
-      \braket{O^{(1)}}_t &= \mathrm{Re}[\alpha_t] = \alpha_0 \cos(\Delta t) e^{-\kappa t/2}\\
-      \braket{O^{(2)}}_t &= \mathrm{Im}[\alpha_t] = -\alpha_0 \sin(\Delta t) e^{-\kappa t/2}\\
-  \end{aligned}
-  $$
-- Loss at time $t$:
-  $$
-      l_t = |\alpha_t|^2 = \alpha_0^2 e^{-\kappa t}
-  $$
-- Gradient of the loss at time $t$:
-  $$
-      \nabla_\theta l_t =
-      \begin{pmatrix}
-        0.0 \\
-        2 \alpha_0 e^{-\kappa t} \\
-        -\alpha_0^2 t e^{-\kappa t}
-      \end{pmatrix}
-  $$
-- Gradients of the expectation values at time $t$:
-  $$
-  \begin{aligned}
-      \nabla_\theta \braket{O^{(1)}}_t &=
-      \begin{pmatrix}
-            -\alpha_0 t \sin(\Delta t) e^{-\kappa t/2} \\
-            \cos(\Delta t) e^{-\kappa t/2} \\
-            - \frac12 \alpha_0 t \cos(\Delta t) e^{-\kappa t/2}\\
-      \end{pmatrix} \\
-      \nabla_\theta \braket{O^{(2)}}_t &=
-      \begin{pmatrix}
-            -\alpha_0 t \cos(\Delta t) e^{-\kappa t/2} \\
-            -\sin(\Delta t) e^{-\kappa t/2} \\
-            \frac12 \alpha_0 t \sin(\Delta t) e^{-\kappa t/2}
-      \end{pmatrix}
-  \end{aligned}
-  $$
+- State:
+
+$$
+\ket{\psi(t)} = \ket{\alpha(t)}\ \text{with}\ \alpha(t) = \alpha_0 e^{-i\Delta t - \kappa t/2}
+$$
+
+- Expectation values:
+
+$$
+\begin{aligned}
+    \braket{O^{(1)}}(t) &= \mathrm{Re}[\alpha(t)] = \alpha_0 \cos(\Delta t) e^{-\kappa t/2}\\
+    \braket{O^{(2)}}(t) &= \mathrm{Im}[\alpha(t)] = -\alpha_0 \sin(\Delta t) e^{-\kappa t/2}
+\end{aligned}
+$$
+
+- Loss:
+
+$$
+l(t) = |\alpha(t)|^2 = \alpha_0^2 e^{-\kappa t}
+$$
+
+- Gradient of the loss:
+
+$$
+\nabla_\theta l(t) =
+\begin{pmatrix}
+  0.0 \\
+  2 \alpha_0 e^{-\kappa t} \\
+  -\alpha_0^2 t e^{-\kappa t}
+\end{pmatrix}
+$$
+
+- Gradients of the expectation values:
+
+$$
+\begin{aligned}
+    \nabla_\theta \braket{O^{(1)}}(t) &=
+    \begin{pmatrix}
+        -\alpha_0 t \sin(\Delta t) e^{-\kappa t/2} \\
+        \cos(\Delta t) e^{-\kappa t/2} \\
+        - \frac12 \alpha_0 t \cos(\Delta t) e^{-\kappa t/2}
+    \end{pmatrix} \\
+    \nabla_\theta \braket{O^{(2)}}(t) &=
+    \begin{pmatrix}
+        -\alpha_0 t \cos(\Delta t) e^{-\kappa t/2} \\
+        -\sin(\Delta t) e^{-\kappa t/2} \\
+        \frac12 \alpha_0 t \sin(\Delta t) e^{-\kappa t/2}
+    \end{pmatrix}
+\end{aligned}
+$$

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,58 @@
+# Test systems
+
+We test our solvers on examples with analytical solutions.
+
+## `Cavity` and `OCavity`
+
+**Problem**
+
+- Hamiltonian: $H = \Delta a^\dag a$
+- Jump operators: $L = \sqrt{\kappa} a$
+- Expectation operators: $O^{(1)} = X = (a+a^\dag)/2$ and $O^{(2)} = P = i(a^\dag-a)/2$
+- Initial state: $\ket{\psi_0} = \ket{\alpha_0}$ with $\alpha_0\in\R$
+- Loss: $l_t = \braket{a^\dag a}_t$
+- Gradient parameters: $\theta=(\Delta, \alpha_0, \kappa)$
+
+**Solution at time $t$**
+
+- State at time $t$:
+  $$
+      \ket{\psi_t} = \ket{\alpha_t}\ \text{with}\ \alpha_t = \alpha_0 e^{-i\Delta t - \kappa t/2}
+  $$
+- Expectation values at time $t$:
+  $$
+  \begin{aligned}
+      \braket{O^{(1)}}_t &= \mathrm{Re}[\alpha_t] = \alpha_0 \cos(\Delta t) e^{-\kappa t/2}\\
+      \braket{O^{(2)}}_t &= \mathrm{Im}[\alpha_t] = -\alpha_0 \sin(\Delta t) e^{-\kappa t/2}\\
+  \end{aligned}
+  $$
+- Loss at time $t$:
+  $$
+      l_t = |\alpha_t|^2 = \alpha_0^2 e^{-\kappa t}
+  $$
+- Gradient of the loss at time $t$:
+  $$
+      \nabla_\theta l_t =
+      \begin{pmatrix}
+        0.0 \\
+        2 \alpha_0 e^{-\kappa t} \\
+        -\alpha_0^2 t e^{-\kappa t}
+      \end{pmatrix}
+  $$
+- Gradients of the expectation values at time $t$:
+  $$
+  \begin{aligned}
+      \nabla_\theta \braket{O^{(1)}}_t &=
+      \begin{pmatrix}
+            -\alpha_0 t \sin(\Delta t) e^{-\kappa t/2} \\
+            \cos(\Delta t) e^{-\kappa t/2} \\
+            - \frac12 \alpha_0 t \cos(\Delta t) e^{-\kappa t/2}\\
+      \end{pmatrix} \\
+      \nabla_\theta \braket{O^{(2)}}_t &=
+      \begin{pmatrix}
+            -\alpha_0 t \cos(\Delta t) e^{-\kappa t/2} \\
+            -\sin(\Delta t) e^{-\kappa t/2} \\
+            \frac12 \alpha_0 t \sin(\Delta t) e^{-\kappa t/2}
+      \end{pmatrix}
+  \end{aligned}
+  $$

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from math import cos, exp, sin
+from math import cos, exp, pi, sin
 from typing import Any
 
 import torch
@@ -237,8 +237,13 @@ class OTDQubit(OpenSystem):
         ]).detach()
 
 
-ocavity = OCavity(n=8, kappa=1.0, delta=2.0, alpha0=0.5, t_end=1.0)
-gocavity = OCavity(n=8, kappa=1.0, delta=2.0, alpha0=0.5, t_end=1.0, requires_grad=True)
+# we choose `t_end` not coinciding with a full period (`t_end=1.0`) to avoid null
+# gradients
+Hz = 2 * pi
+ocavity = OCavity(n=8, kappa=1.0 * Hz, delta=1.0 * Hz, alpha0=0.5, t_end=0.3)
+gocavity = OCavity(
+    n=8, kappa=1.0 * Hz, delta=1.0 * Hz, alpha0=0.5, t_end=0.3, requires_grad=True
+)
 
 otdqubit = OTDQubit(eps=3.0, omega=10.0, gamma=1.0, t_end=1.0)
 gotdqubit = OTDQubit(eps=3.0, omega=10.0, gamma=1.0, t_end=1.0, requires_grad=True)

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from math import cos, exp, pi, sin, sqrt
+from math import cos, exp, sin
 from typing import Any
 
 import torch
@@ -83,7 +83,7 @@ class OCavity(OpenSystem):
         self.H = self.delta * adag @ a
         self.H_batched = [0.5 * self.H, self.H, 2 * self.H]
         self.jump_ops = [torch.sqrt(self.kappa) * a, dq.eye(self.n)]
-        self.exp_ops = [(a + adag) / sqrt(2), 1j * (adag - a) / sqrt(2)]
+        self.exp_ops = [dq.position(self.n), dq.momentum(self.n)]
 
         # prepare initial states
         self.y0 = dq.coherent_dm(self.n, self.alpha0)
@@ -98,37 +98,34 @@ class OCavity(OpenSystem):
         return torch.linspace(0.0, self.t_end.item(), n)
 
     def _alpha(self, t: float) -> Tensor:
-        return (
-            self.alpha0
-            * torch.exp(-1j * self.delta * t)
-            * torch.exp(-0.5 * self.kappa * t)
-        )
+        return self.alpha0 * torch.exp(-1j * self.delta * t - 0.5 * self.kappa * t)
 
     def state(self, t: float) -> Tensor:
         return dq.coherent_dm(self.n, self._alpha(t))
 
     def expect(self, t: float) -> Tensor:
         alpha_t = self._alpha(t)
-        exp_x = sqrt(2) * alpha_t.real
-        exp_p = sqrt(2) * alpha_t.imag
+        exp_x = alpha_t.real
+        exp_p = alpha_t.imag
         return torch.tensor([exp_x, exp_p], dtype=alpha_t.dtype)
 
     def grads_state(self, t: float) -> Tensor:
         grad_delta = 0.0
         grad_alpha0 = 2 * self.alpha0 * exp(-self.kappa * t)
-        grad_kappa = self.alpha0**2 * -t * exp(-self.kappa * t)
+        grad_kappa = -self.alpha0**2 * t * exp(-self.kappa * t)
         return torch.tensor([grad_delta, grad_alpha0, grad_kappa]).detach()
 
-    # flake8: noqa: E501 line too long
     def grads_expect(self, t: float) -> Tensor:
-        # fmt: off
-        grad_x_delta = sqrt(2) * self.alpha0 * -t * sin(-self.delta * t) * exp(-0.5 * self.kappa * t)
-        grad_p_delta = sqrt(2) * self.alpha0 * -t * cos(-self.delta * t) * exp(-0.5 * self.kappa * t)
-        grad_x_alpha0 = sqrt(2) * cos(-self.delta * t) * exp(-0.5 * self.kappa * t)
-        grad_p_alpha0 = sqrt(2) * sin(-self.delta * t) * exp(-0.5 * self.kappa * t)
-        grad_x_kappa = sqrt(2) * self.alpha0 * cos(-self.delta * t) * -0.5 * t * exp(-0.5 * self.kappa * t)
-        grad_p_kappa = sqrt(2) * self.alpha0 * sin(-self.delta * t) * -0.5 * t * exp(-0.5 * self.kappa * t)
-        # fmt: on
+        cdt = cos(self.delta * t)
+        sdt = sin(self.delta * t)
+        emkt = exp(-0.5 * self.kappa * t)
+
+        grad_x_delta = -self.alpha0 * t * sdt * emkt
+        grad_p_delta = -self.alpha0 * t * cdt * emkt
+        grad_x_alpha0 = cdt * emkt
+        grad_p_alpha0 = -sdt * emkt
+        grad_x_kappa = -0.5 * self.alpha0 * t * cdt * emkt
+        grad_p_kappa = 0.5 * self.alpha0 * t * sdt * emkt
 
         return torch.tensor([
             [grad_x_delta, grad_x_alpha0, grad_x_kappa],
@@ -240,10 +237,8 @@ class OTDQubit(OpenSystem):
         ]).detach()
 
 
-ocavity = OCavity(n=8, kappa=2 * pi, delta=2 * pi, alpha0=1.0, t_end=1.0)
-gocavity = OCavity(
-    n=8, kappa=2 * pi, delta=2 * pi, alpha0=1.0, t_end=1.0, requires_grad=True
-)
+ocavity = OCavity(n=8, kappa=1.0, delta=2.0, alpha0=0.5, t_end=1.0)
+gocavity = OCavity(n=8, kappa=1.0, delta=2.0, alpha0=0.5, t_end=1.0, requires_grad=True)
 
 otdqubit = OTDQubit(eps=3.0, omega=10.0, gamma=1.0, t_end=1.0)
 gotdqubit = OTDQubit(eps=3.0, omega=10.0, gamma=1.0, t_end=1.0, requires_grad=True)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from math import cos, sin
+from math import cos, pi, sin
 from typing import Any
 
 import torch
@@ -197,8 +197,11 @@ class TDQubit(ClosedSystem):
         ]).detach()
 
 
-cavity = Cavity(n=8, delta=2.0, alpha0=0.5, t_end=1.0)
-gcavity = Cavity(n=8, delta=2.0, alpha0=0.5, t_end=1.0, requires_grad=True)
+# we choose `t_end` not coinciding with a full period (`t_end=1.0`) to avoid null
+# gradients
+Hz = 2 * pi
+cavity = Cavity(n=8, delta=1.0 * Hz, alpha0=0.5, t_end=0.3)
+gcavity = Cavity(n=8, delta=1.0 * Hz, alpha0=0.5, t_end=0.3, requires_grad=True)
 
 tdqubit = TDQubit(eps=3.0, omega=10.0, t_end=1.0)
 gtdqubit = TDQubit(eps=3.0, omega=10.0, t_end=1.0, requires_grad=True)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from math import cos, pi, sin, sqrt
+from math import cos, sin
 from typing import Any
 
 import torch
@@ -74,7 +74,7 @@ class Cavity(ClosedSystem):
         # prepare quantum operators
         self.H = self.delta * adag @ a
         self.H_batched = [0.5 * self.H, self.H, 2 * self.H]
-        self.exp_ops = [(a + adag) / sqrt(2), 1j * (adag - a) / sqrt(2)]
+        self.exp_ops = [dq.position(self.n), dq.momentum(self.n)]
 
         # prepare initial states
         self.y0 = dq.coherent(self.n, self.alpha0)
@@ -96,8 +96,8 @@ class Cavity(ClosedSystem):
 
     def expect(self, t: float) -> Tensor:
         alpha_t = self._alpha(t)
-        exp_x = sqrt(2) * alpha_t.real
-        exp_p = sqrt(2) * alpha_t.imag
+        exp_x = alpha_t.real
+        exp_p = alpha_t.imag
         return torch.tensor([exp_x, exp_p], dtype=alpha_t.dtype)
 
     def grads_state(self, t: float) -> Tensor:
@@ -106,10 +106,13 @@ class Cavity(ClosedSystem):
         return torch.tensor([grad_delta, grad_alpha0]).detach()
 
     def grads_expect(self, t: float) -> Tensor:
-        grad_x_delta = sqrt(2) * self.alpha0 * -t * sin(-self.delta * t)
-        grad_p_delta = sqrt(2) * self.alpha0 * -t * cos(-self.delta * t)
-        grad_x_alpha0 = sqrt(2) * cos(-self.delta * t)
-        grad_p_alpha0 = sqrt(2) * sin(-self.delta * t)
+        cdt = cos(self.delta * t)
+        sdt = sin(self.delta * t)
+
+        grad_x_delta = -self.alpha0 * t * sdt
+        grad_p_delta = -self.alpha0 * t * cdt
+        grad_x_alpha0 = cdt
+        grad_p_alpha0 = -sdt
 
         return torch.tensor([
             [grad_x_delta, grad_x_alpha0],
@@ -194,8 +197,8 @@ class TDQubit(ClosedSystem):
         ]).detach()
 
 
-cavity = Cavity(n=8, delta=2 * pi, alpha0=1.0, t_end=1.0)
-gcavity = Cavity(n=8, delta=2 * pi, alpha0=1.0, t_end=1.0, requires_grad=True)
+cavity = Cavity(n=8, delta=2.0, alpha0=0.5, t_end=1.0)
+gcavity = Cavity(n=8, delta=2.0, alpha0=0.5, t_end=1.0, requires_grad=True)
 
 tdqubit = TDQubit(eps=3.0, omega=10.0, t_end=1.0)
 gtdqubit = TDQubit(eps=3.0, omega=10.0, t_end=1.0, requires_grad=True)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -12,14 +12,12 @@ class TestSEEuler(SolverTester):
         solver = Euler(dt=1e-2)
         self._test_batching(cavity, solver)
 
-    @pytest.mark.parametrize('system,tol', [(cavity, 1e-2), (tdqubit, 1e-3)])
-    def test_correctness(self, system, tol):
+    @pytest.mark.parametrize('system', [cavity, tdqubit])
+    def test_correctness(self, system):
         solver = Euler(dt=1e-4)
-        self._test_correctness(
-            system, solver, ysave_atol=tol, esave_rtol=tol, esave_atol=tol
-        )
+        self._test_correctness(system, solver, esave_atol=1e-3)
 
-    @pytest.mark.parametrize('system,rtol', [(gcavity, 5e-2), (gtdqubit, 1e-2)])
-    def test_autograd(self, system, rtol):
+    @pytest.mark.parametrize('system', [gcavity, gtdqubit])
+    def test_autograd(self, system):
         solver = Euler(dt=1e-4)
-        self._test_gradient(system, solver, Autograd(), rtol=rtol, atol=1e-2)
+        self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
Long story short, the tests for cavity were bugged:
- better time now so gradients are not all null at the end of the evolution
- changed `exp_ops` to simplify expressions
- fixed a truncature issue which cause both `Propagator` and `Dopri5` to fail (fixed by taking a smaller alpha)

I think we need to be more careful with the tests, I've started a note to make this a bit more clean.