### PR TITLE
Refactor adjoint: minor fixes to adjoint solver [1/4]

### DIFF
--- a/dynamiqs/mesolve/adaptive.py
+++ b/dynamiqs/mesolve/adaptive.py
@@ -13,20 +13,17 @@ class MEAdaptive(MESolver, AdaptiveSolver):
 
     def odefun_backward(self, t: float, rho: Tensor) -> Tensor:
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
-        # t is passed in as negative time
-        return -self.lindbladian(-t, rho)
+        return -self.lindbladian(t, rho)
 
     def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
-        # t is passed in as negative time
-        return self.adjoint_lindbladian(-t, phi)
+        return self.adjoint_lindbladian(t, phi)
 
     def odefun_augmented(
         self, t: float, rho: Tensor, phi: Tensor
     ) -> tuple[Tensor, Tensor]:
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
-        # t is passed in as negative time
         return self.odefun_backward(t, rho), self.odefun_adjoint(t, phi)
 
 

--- a/dynamiqs/mesolve/adaptive.py
+++ b/dynamiqs/mesolve/adaptive.py
@@ -19,13 +19,6 @@ class MEAdaptive(MESolver, AdaptiveSolver):
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         return self.adjoint_lindbladian(t, phi)
 
-    def odefun_augmented(
-        self, t: float, rho: Tensor, phi: Tensor
-    ) -> tuple[Tensor, Tensor]:
-        # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
-        # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
-        return self.odefun_backward(t, rho), self.odefun_adjoint(t, phi)
-
 
 class MEDormandPrince5(MEAdaptive, DormandPrince5):
     pass

--- a/dynamiqs/mesolve/euler.py
+++ b/dynamiqs/mesolve/euler.py
@@ -16,7 +16,6 @@ class MEEuler(MESolver, AdjointFixedSolver):
     ) -> tuple[Tensor, Tensor]:
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
-        # t is passed in as negative time
-        rho = rho - self.dt * self.lindbladian(-t, rho)
-        phi = phi + self.dt * self.adjoint_lindbladian(-t, phi)
+        rho = rho - self.dt * self.lindbladian(t, rho)
+        phi = phi + self.dt * self.adjoint_lindbladian(t, phi)
         return rho, phi

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -182,11 +182,11 @@ def mesolve(
     jump_ops = to_tensor(jump_ops, dtype=options.cdtype, device=options.device)
 
     # convert tsave to a tensor
-    tsave = to_tensor(tsave, dtype=options.rdtype, device=options.device)
+    tsave = to_tensor(tsave, dtype=options.rdtype, device='cpu')
     check_time_tensor(tsave, arg_name='tsave')
 
     # define the solver
-    tmeas = torch.empty(0, dtype=options.rdtype, device=options.device)
+    tmeas = torch.empty(0, dtype=options.rdtype, device='cpu')
     solver = SOLVER_CLASS(H, rho0, tsave, tmeas, exp_ops, options, jump_ops=jump_ops)
 
     # compute the result

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -101,8 +101,7 @@ class MERouchon1(MERouchon):
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        # t is passed in as negative time
-        H = self.H(-t)
+        H = self.H(t)
         Hnh = self.Hnh(H)
 
         # === reverse time
@@ -194,8 +193,7 @@ class MERouchon2(MERouchon):
         # rho: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
         # phi: (b_H, b_rho, n, n) -> (b_H, b_rho, n, n)
 
-        # t is passed in as negative time
-        H = self.H(-t)
+        H = self.H(t)
         Hnh = self.Hnh(H)
 
         # === reverse time

--- a/dynamiqs/sesolve/adaptive.py
+++ b/dynamiqs/sesolve/adaptive.py
@@ -11,15 +11,12 @@ class SEAdaptive(AdaptiveSolver):
         # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
         return -1j * self.H(t) @ psi
 
-    def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
-        raise NotImplementedError
-
     def odefun_backward(self, t: float, psi: Tensor) -> Tensor:
+        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
         raise NotImplementedError
 
-    def odefun_augmented(
-        self, t: float, psi: Tensor, phi: Tensor
-    ) -> tuple[Tensor, Tensor]:
+    def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
+        # phi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
         raise NotImplementedError
 
 

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -151,11 +151,11 @@ def sesolve(
     exp_ops = to_tensor(exp_ops, dtype=options.cdtype, device=options.device)
 
     # convert tsave to tensor
-    tsave = to_tensor(tsave, dtype=options.rdtype, device=options.device)
+    tsave = to_tensor(tsave, dtype=options.rdtype, device='cpu')
     check_time_tensor(tsave, arg_name='tsave')
 
     # define the solver
-    tmeas = torch.empty(0, dtype=options.rdtype, device=options.device)
+    tmeas = torch.empty(0, dtype=options.rdtype, device='cpu')
     solver = SOLVER_CLASS(H, psi0, tsave, tmeas, exp_ops, options)
 
     # compute the result

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -231,11 +231,11 @@ def smesolve(
     jump_ops = to_tensor(jump_ops, dtype=options.cdtype, device=options.device)
 
     # convert tsave to a tensor
-    tsave = to_tensor(tsave, dtype=options.rdtype, device=options.device)
+    tsave = to_tensor(tsave, dtype=options.rdtype, device='cpu')
     check_time_tensor(tsave, arg_name='tsave')
 
     # convert etas to a tensor and check
-    etas = to_tensor(etas, dtype=options.rdtype, device=options.device)
+    etas = to_tensor(etas, dtype=options.rdtype, device='cpu')
     if len(etas) != len(jump_ops):
         raise ValueError(
             'Argument `etas` must have the same length as `jump_ops` of length'

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Literal
 
+from torch import Tensor
+
 from .gradient import Adjoint, Autograd, Gradient
 
 
@@ -22,6 +24,9 @@ class _ODEFixedStep(Solver):
     SUPPORTED_GRADIENT = (Autograd,)
 
     def __init__(self, *, dt: float):
+        # convert `dt` in case a tensor was passed instead of a float
+        if isinstance(dt, Tensor):
+            dt = dt.item()
         self.dt = dt
 
 

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -51,7 +51,7 @@ class AdaptiveSolver(AutogradSolver):
         `self.tstop`."""
 
         # initialize the progress bar
-        self.pbar = tqdm(total=self.tstop[-1].item(), disable=not self.options.verbose)
+        self.pbar = tqdm(total=self.tstop[-1], disable=not self.options.verbose)
 
         # initialize the step counter
         self.step_counter = 0
@@ -63,7 +63,7 @@ class AdaptiveSolver(AutogradSolver):
 
         # run the ODE routine
         t, y, ft = self.t0, self.y0, f0
-        for tnext in self.tstop.cpu().numpy():
+        for tnext in self.tstop:
             y, ft, dt, error = self.integrate(t, tnext, y, ft, dt, error)
             self.save(y)
             t = tnext

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -23,6 +23,15 @@ class AdaptiveSolver(AutogradSolver):
         Series in Computational Mathematics.
     """
 
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        # initialize the progress bar
+        self.pbar = tqdm(total=self.tstop[-1], disable=not self.options.verbose)
+
+        # initialize the step counter
+        self.step_counter = 0
+
     @property
     @abstractmethod
     def order(self) -> int:
@@ -49,12 +58,6 @@ class AdaptiveSolver(AutogradSolver):
         """Integrates the ODE forward from time `self.t0` to time `self.tstop[-1]`
         starting from initial state `self.y0`, and save the state for each time in
         `self.tstop`."""
-
-        # initialize the progress bar
-        self.pbar = tqdm(total=self.tstop[-1], disable=not self.options.verbose)
-
-        # initialize the step counter
-        self.step_counter = 0
 
         # initialize the ODE routine
         f0 = self.odefun(self.t0, self.y0)

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -168,6 +168,17 @@ class AdaptiveSolver(AutogradSolver):
 
 
 class AdjointAdaptiveSolver(AdaptiveSolver, AdjointSolver):
+    @abstractmethod
+    def odefun_backward(self, t: float, y: Tensor) -> Tensor:
+        pass
+
+    @abstractmethod
+    def odefun_adjoint(self, t: float, a: Tensor) -> Tensor:
+        pass
+
+    def odefun_augmented(self, t: float, y: Tensor, a: Tensor) -> tuple[Tensor, Tensor]:
+        return self.odefun_backward(t, y), self.odefun_adjoint(t, a)
+
     def run_adjoint(self):
         AdjointAutograd.apply(self, self.y0, *self.options.params)
 
@@ -239,10 +250,6 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointSolver):
 
         dt, error = cache
         return y, a, g, ft, lt, dt, error
-
-    @abstractmethod
-    def odefun_augmented(self, t: float, y: Tensor, a: Tensor) -> tuple[Tensor, Tensor]:
-        pass
 
 
 class DormandPrince5(AdjointAdaptiveSolver):

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -63,10 +63,10 @@ class AdaptiveSolver(AutogradSolver):
 
         # run the ODE routine
         t, y, ft = self.t0, self.y0, f0
-        for ts in self.tstop.cpu().numpy():
-            y, ft, dt, error = self.integrate(t, ts, y, ft, dt, error)
+        for tnext in self.tstop.cpu().numpy():
+            y, ft, dt, error = self.integrate(t, tnext, y, ft, dt, error)
             self.save(y)
-            t = ts
+            t = tnext
 
         # close the progress bar
         with warnings.catch_warnings():  # ignore tqdm precision overflow

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -14,18 +14,46 @@ from .adjoint_autograd import AdjointAutograd
 
 
 class AdaptiveSolver(AutogradSolver):
-    def run_autograd(self):
-        """Integrate a quantum ODE with an adaptive time step ODE integrator.
+    """Integrate an ODE of the form $dy / dt = f(y, t)$ in forward time with initial
+    condition $y(t_0)$ using an adaptive step-size integrator.
 
-        This function integrates an ODE of the form `dy / dt = f(t, y)` with
-        `y(0) = y0`. For details about the integration method, see Chapter II.4 of
-        `Hairer et al., Solving Ordinary Differential Equations I (1993), Springer
-        Series in Computational Mathematics`.
-        """
+    For details about the integration method, see Chapter II.4 of [1].
+
+    [1] Hairer et al., Solving Ordinary Differential Equations I (1993), Springer
+        Series in Computational Mathematics.
+    """
+
+    @property
+    @abstractmethod
+    def order(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def tableau(self) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        pass
+
+    @abstractmethod
+    def odefun(self, t: float, y: Tensor) -> Tensor:
+        """Returns $f(y, t)$."""
+        pass
+
+    @abstractmethod
+    def step(
+        self, t0: float, y0: Tensor, f0: Tensor, dt: float, fun: callable
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Compute a single step of the ODE integration."""
+        pass
+
+    def run_autograd(self):
+        """Integrates the ODE forward from time `self.t0` to time `self.tstop[-1]`
+        starting from initial state `self.y0`, and save the state for each time in
+        `self.tstop`."""
+
         # initialize the progress bar
         self.pbar = tqdm(total=self.tstop[-1].item(), disable=not self.options.verbose)
 
-        # initialize step counter
+        # initialize the step counter
         self.step_counter = 0
 
         # initialize the ODE routine
@@ -40,7 +68,7 @@ class AdaptiveSolver(AutogradSolver):
             self.save(y)
             t = ts
 
-        # close progress bar
+        # close the progress bar
         with warnings.catch_warnings():  # ignore tqdm precision overflow
             warnings.simplefilter('ignore', TqdmWarning)
             self.pbar.close()
@@ -48,7 +76,8 @@ class AdaptiveSolver(AutogradSolver):
     def integrate(
         self, t0: float, t1: float, y: Tensor, ft: Tensor, dt: float, error: float
     ) -> tuple[Tensor, Tensor, float, float]:
-        """Integrate the ODE forward from time `t0` to time `t1`."""
+        """Integrates the ODE forward from time `t0` to time `t1` with initial state
+        `y`."""
         cache = (dt, error)
         t = t0
         while t < t1:
@@ -59,7 +88,7 @@ class AdaptiveSolver(AutogradSolver):
                 cache = (dt, error)
                 dt = t1 - t
 
-            # compute next step
+            # compute the next step
             ft_new, y_new, y_err = self.step(t, y, ft, dt, self.odefun)
             error = self.get_error(y_err, y, y_new)
             if error <= 1:
@@ -83,33 +112,11 @@ class AdaptiveSolver(AutogradSolver):
                 ' maximum number of steps, or use a different solver.'
             )
 
-    @property
-    @abstractmethod
-    def order(self) -> int:
-        pass
-
-    @property
-    @abstractmethod
-    def tableau(self) -> tuple[Tensor, Tensor, Tensor, Tensor]:
-        pass
-
-    @abstractmethod
-    def odefun(self, t: float, y: Tensor) -> Tensor:
-        pass
-
-    @abstractmethod
-    def step(
-        self, t0: float, y0: Tensor, f0: Tensor, dt: float, fun: callable
-    ) -> tuple[Tensor, Tensor, Tensor]:
-        """Compute a single step of the ODE integration."""
-        pass
-
     @torch.no_grad()
     def get_error(self, y_err: Tensor, y0: Tensor, y1: Tensor) -> float:
         """Compute the error of a given solution.
 
-        See Equation (4.11) of `Hairer et al., Solving Ordinary Differential Equations I
-        (1993), Springer Series in Computational Mathematics`.
+        See Equation (4.11) of [1].
         """
         scale = self.options.atol + self.options.rtol * torch.max(y0.abs(), y1.abs())
         return hairer_norm(y_err / scale).max().item()
@@ -118,9 +125,8 @@ class AdaptiveSolver(AutogradSolver):
     def init_tstep(self, t0: float, y0: Tensor, f0: Tensor, fun: callable) -> float:
         """Initialize the time step of an adaptive step size integrator.
 
-        See Equation (4.14) of `Hairer et al., Solving Ordinary Differential Equations I
-        (1993), Springer Series in Computational Mathematics` for the detailed steps.
-        For this function, we keep the same notations as in the book.
+        See Equation (4.14) of [1] for the detailed steps. For this function, we keep
+        the same notations as in the book.
         """
         sc = self.options.atol + torch.abs(y0) * self.options.rtol
         d0, d1 = hairer_norm(y0 / sc).max().item(), hairer_norm(f0 / sc).max().item()
@@ -144,9 +150,7 @@ class AdaptiveSolver(AutogradSolver):
     def update_tstep(self, dt: float, error: float) -> float:
         """Update the time step of an adaptive step size integrator.
 
-        See Equation (4.12) and (4.13) of `Hairer et al., Solving Ordinary Differential
-        Equations I (1993), Springer Series in Computational Mathematics` for the
-        detailed steps.
+        See Equation (4.12) and (4.13) of [1] for the detailed steps.
         """
         if error == 0:  # no error -> maximally increase the time step
             return dt * self.options.max_factor
@@ -168,15 +172,22 @@ class AdaptiveSolver(AutogradSolver):
 
 
 class AdjointAdaptiveSolver(AdaptiveSolver, AdjointSolver):
+    """Integrate an augmented ODE of the form $(1) dy / dt = fy(y, t),
+    $(2) da / dt = fa(a, y)$ in backward time with initial condition $y(t_0)$ using an
+    adaptive step-size integrator."""
+
     @abstractmethod
     def odefun_backward(self, t: float, y: Tensor) -> Tensor:
+        """Returns $fy(y, t)$."""
         pass
 
     @abstractmethod
     def odefun_adjoint(self, t: float, a: Tensor) -> Tensor:
+        """Returns $fa(a, t)$."""
         pass
 
     def odefun_augmented(self, t: float, y: Tensor, a: Tensor) -> tuple[Tensor, Tensor]:
+        """Returns $fy(y, t)$ and $fa(a, t)$."""
         return self.odefun_backward(t, y), self.odefun_adjoint(t, a)
 
     def run_adjoint(self):
@@ -204,7 +215,8 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointSolver):
         dt: float,
         error: float,
     ) -> tuple[Tensor, Tensor, tuple[Tensor, ...], Tensor, Tensor, float, float]:
-        """Integrate the augmented ODE from time `t0` to `t1`, with `t0` < `t1` < 0."""
+        """Integrates the augmented ODE forward from time `t0` to `t1` (with
+        `t0` < `t1` < 0) starting from initial state `(y, a)`."""
         cache = (dt, error)
 
         t = t0

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -175,8 +175,8 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointSolver):
         self, t0: float, y: Tensor, a: Tensor
     ) -> tuple[Tensor, Tensor, float, float]:
         f0, l0 = self.odefun_augmented(t0, y, a)
-        dt_y = self.init_tstep(t0, y, f0, self.odefun_backward)
-        dt_a = self.init_tstep(t0, a, l0, self.odefun_adjoint)
+        dt_y = self.init_tstep(-t0, y, f0, self.odefun_backward)
+        dt_a = self.init_tstep(-t0, a, l0, self.odefun_adjoint)
         dt = min(dt_y, dt_a)
         error = 1.0
         return f0, l0, dt, error
@@ -208,8 +208,8 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointSolver):
 
             with torch.enable_grad():
                 # perform a single step of size dt
-                ft_new, y_new, y_err = self.step(t, y, ft, dt, self.odefun_backward)
-                lt_new, a_new, a_err = self.step(t, a, lt, dt, self.odefun_adjoint)
+                ft_new, y_new, y_err = self.step(-t, y, ft, dt, self.odefun_backward)
+                lt_new, a_new, a_err = self.step(-t, a, lt, dt, self.odefun_adjoint)
 
                 # compute estimated error of this step
                 error_a = self.get_error(a_err, a, a_new)

--- a/dynamiqs/solvers/ode/adjoint_autograd.py
+++ b/dynamiqs/solvers/ode/adjoint_autograd.py
@@ -82,8 +82,8 @@ class AdjointAutograd(torch.autograd.Function):
 
             # integrate the augmented equation backward between every saved state
             t = t0
-            for i, ts in enumerate(tstop_bwd.cpu().numpy()[1:]):
-                y, a, g, *args = solver.integrate_augmented(t, ts, y, a, g, *args)
+            for i, tnext in enumerate(tstop_bwd[1:]):
+                y, a, g, *args = solver.integrate_augmented(t, tnext, y, a, g, *args)
 
                 if solver.options.save_states and (i < len(tstop_bwd) - 2 or saved_ini):
                     # replace y with its checkpointed version
@@ -98,7 +98,7 @@ class AdjointAutograd(torch.autograd.Function):
                     ).sum(dim=-3)
 
                 # iterate time
-                t = ts
+                t = tnext
 
         # close progress bar
         with warnings.catch_warnings():  # ignore tqdm precision overflow

--- a/dynamiqs/solvers/ode/adjoint_autograd.py
+++ b/dynamiqs/solvers/ode/adjoint_autograd.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 
+import numpy as np
 import torch
 import torch.nn as nn
 from torch import Tensor
@@ -68,11 +69,11 @@ class AdjointAutograd(torch.autograd.Function):
 
             # initialize time: time is negative-valued and sorted ascendingly during
             # backward integration.
-            tstop_bwd = (-solver.tstop).flip(dims=(0,))
+            tstop_bwd = np.flip(-solver.tstop, axis=0)
             saved_ini = tstop_bwd[-1] == solver.t0
             if not saved_ini:
-                tstop_bwd = torch.cat((tstop_bwd, torch.zeros(1).to(tstop_bwd)))
-            t0 = tstop_bwd[0].item()
+                tstop_bwd = np.append(tstop_bwd, 0)
+            t0 = tstop_bwd[0]
 
             # initialize progress bar
             solver.pbar = tqdm(total=-t0, disable=not solver.options.verbose)

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -66,10 +66,10 @@ class FixedSolver(AutogradSolver):
         t, y = self.t0, self.y0
 
         # run the ODE routine
-        for ts in self.tstop.cpu().numpy():
-            y = self.integrate(t, ts, y)
+        for tnext in self.tstop.cpu().numpy():
+            y = self.integrate(t, tnext, y)
             self.save(y)
-            t = ts
+            t = tnext
 
         # close the progress bar
         with warnings.catch_warnings():  # ignore tqdm precision overflow

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -25,6 +25,9 @@ def _assert_multiple_of_dt(dt: float, times: Tensor, name: str):
 
 
 class FixedSolver(AutogradSolver):
+    """Integrate an ODE of the form $dy / dt = f(y, t)$ in forward time with initial
+    condition $y(t_0)$ using a fixed step-size integrator."""
+
     def __init__(self, *args):
         super().__init__(*args)
         self.dt = self.options.dt
@@ -36,16 +39,22 @@ class FixedSolver(AutogradSolver):
                     f'`dt` should be a number or a 0-d tensor, but is {self.dt}.'
                 )
 
-    def run_autograd(self):
-        """Integrate a quantum ODE with a fixed time step custom integrator.
+    @abstractmethod
+    def forward(self, t: float, y: Tensor) -> Tensor:
+        """Returns $y(t+dt)$."""
+        pass
 
-        Notes:
-            The solver times are defined using `torch.linspace` which ensures that the
-            overall solution is evolved from the user-defined time (up to an error of
-            `rtol=1e-5`). However, this may induce a small mismatch between the time
-            step inside `solver` and the time step inside the iteration loop. A small
-            error can thus buildup throughout the ODE integration. TODO Fix this.
-        """
+    def run_autograd(self):
+        """Integrates the ODE forward from time `self.t0` to time `self.tstop[-1]`
+        starting from initial state `self.y0`, and save the state for each time in
+        `self.tstop`."""
+
+        # TODO: The solver times are defined using `torch.linspace` which ensures that
+        # the overall solution is evolved from the user-defined time (up to an error of
+        # `rtol=1e-5`). However, this may induce a small mismatch between the time step
+        # inside `solver` and the time step inside the iteration loop. A small error
+        # can thus buildup throughout the ODE integration.
+
         # assert that `tsave` and `tmeas` values are multiples of `dt`
         _assert_multiple_of_dt(self.dt, self.tsave, 'tsave')
         _assert_multiple_of_dt(self.dt, self.tmeas, 'tmeas')
@@ -56,36 +65,44 @@ class FixedSolver(AutogradSolver):
         # initialize time and state
         t, y = self.t0, self.y0
 
-        # run the ode routine
+        # run the ODE routine
         for ts in self.tstop.cpu().numpy():
             y = self.integrate(t, ts, y)
             self.save(y)
             t = ts
 
-        # close progress bar
+        # close the progress bar
         with warnings.catch_warnings():  # ignore tqdm precision overflow
             warnings.simplefilter('ignore', TqdmWarning)
             self.pbar.close()
 
     def integrate(self, t0: float, t1: float, y: Tensor) -> Tensor:
-        """Integrate the ODE forward from time `t0` to time `t1`."""
+        """Integrates the ODE forward from time `t0` to time `t1` with initial state
+        `y`."""
         # define time values
         num_times = round((t1 - t0) / self.dt) + 1
         times = torch.linspace(t0, t1, num_times)
 
-        # run the ode routine
+        # run the ODE routine
         for t in times[:-1].cpu().numpy():
             y = self.forward(t, y)
             self.pbar.update(self.dt)
 
         return y
 
-    @abstractmethod
-    def forward(self, t: float, y: Tensor) -> Tensor:
-        pass
-
 
 class AdjointFixedSolver(FixedSolver, AdjointSolver):
+    """Integrate an augmented ODE of the form $(1) dy / dt = fy(y, t)$ and
+    $(2) da / dt = fa(a, y)$ in backward time with initial condition $y(t_0)$ using a
+    fixed step-size integrator."""
+
+    @abstractmethod
+    def backward_augmented(
+        self, t: float, y: Tensor, a: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        """Returns $y(t-dt)$ and $a(t-dt)$."""
+        pass
+
     def run_adjoint(self):
         AdjointAutograd.apply(self, self.y0, *self.options.params)
 
@@ -95,7 +112,8 @@ class AdjointFixedSolver(FixedSolver, AdjointSolver):
     def integrate_augmented(
         self, t0: float, t1: float, y: Tensor, a: Tensor, g: tuple[Tensor, ...]
     ) -> tuple[Tensor, Tensor, tuple[Tensor, ...]]:
-        """Integrate the augmented ODE from time `t0` to `t1`, with `t0` < `t1` < 0."""
+        """Integrates the augmented ODE forward from time `t0` to `t1` (with
+        `t0` < `t1` < 0) starting from initial state `(y, a)`."""
         # define time values
         num_times = round((t1 - t0) / self.dt) + 1
         times = torch.linspace(t0, t1, num_times)
@@ -123,9 +141,3 @@ class AdjointFixedSolver(FixedSolver, AdjointSolver):
 
         # save final augmented state to the solver
         return y, a, g
-
-    @abstractmethod
-    def backward_augmented(
-        self, t: float, y: Tensor, a: Tensor
-    ) -> tuple[Tensor, Tensor]:
-        pass

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -33,7 +33,7 @@ class FixedSolver(AutogradSolver):
                 self.dt = self.dt.item()
             else:
                 raise ValueError(
-                    f"`dt` should be a number or a 0-d tensor, but is {self.dt}."
+                    f'`dt` should be a number or a 0-d tensor, but is {self.dt}.'
                 )
 
     def run_autograd(self):

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -106,7 +106,7 @@ class AdjointFixedSolver(FixedSolver, AdjointSolver):
 
             with torch.enable_grad():
                 # compute y(t-dt) and a(t-dt)
-                y, a = self.backward_augmented(t, y, a)
+                y, a = self.backward_augmented(-t, y, a)
 
                 # compute g(t-dt)
                 dg = torch.autograd.grad(

--- a/dynamiqs/solvers/ode/fixed_solver.py
+++ b/dynamiqs/solvers/ode/fixed_solver.py
@@ -31,14 +31,8 @@ class FixedSolver(AutogradSolver):
 
     def __init__(self, *args):
         super().__init__(*args)
+
         self.dt = self.options.dt
-        if isinstance(self.dt, Tensor):
-            if self.dt.numel() == 1:
-                self.dt = self.dt.item()
-            else:
-                raise ValueError(
-                    f'`dt` should be a number or a 0-d tensor, but is {self.dt}.'
-                )
 
         # assert that `tsave` and `tmeas` values are multiples of `dt`
         _assert_multiple_of_dt(self.dt, self.tsave, 'tsave')

--- a/dynamiqs/solvers/propagator.py
+++ b/dynamiqs/solvers/propagator.py
@@ -36,7 +36,7 @@ class Propagator(AutogradSolver):
 
     def run_autograd(self):
         t1, y = self.t0, self.y0
-        for t2 in tqdm(self.tstop.cpu().numpy(), disable=not self.options.verbose):
+        for t2 in tqdm(self.tstop, disable=not self.options.verbose):
             if t2 != self.t0:
                 # round time difference to avoid numerical errors when comparing floats
                 delta_t = round_truncate(t2 - t1)

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from time import time
 
+import numpy as np
 import torch
 from torch import Tensor
 
@@ -35,8 +36,8 @@ class Solver(ABC):
         self.H = H
         self.t0 = 0.0
         self.y0 = y0
-        self.tsave = tsave
-        self.tmeas = tmeas
+        self.tsave = tsave.numpy()
+        self.tmeas = tmeas.numpy()
         self.exp_ops = exp_ops
         self.options = options
 
@@ -46,9 +47,9 @@ class Solver(ABC):
         self.device = self.options.device
 
         # initialize time logic
-        self.tstop = torch.cat((self.tsave, self.tmeas)).unique()
-        self.tsave_mask = torch.isin(self.tstop, self.tsave)
-        self.tmeas_mask = torch.isin(self.tstop, self.tmeas)
+        self.tstop = np.unique(np.concatenate((self.tsave, self.tmeas)))
+        self.tsave_mask = np.isin(self.tstop, self.tsave)
+        self.tmeas_mask = np.isin(self.tstop, self.tmeas)
         self.tstop_counter = 0
         self.tsave_counter = 0
         self.tmeas_counter = 0
@@ -97,7 +98,7 @@ class Solver(ABC):
         pass
 
     def next_tstop(self) -> float:
-        return self.tstop[self.tstop_counter].item()
+        return self.tstop[self.tstop_counter]
 
     def save(self, y: Tensor):
         if self.tsave_mask[self.tstop_counter]:


### PR DESCRIPTION
This is the first of a stack of PR that aims at clarifying and re-organising the ODE solvers code, notably the part related to the adjoint.

**This PR**: A bunch of minor fixes, to read commit by commit, notably:
- 6093471b2f48949b5a926c18db797055263dda5a > `AdjointAutograd` needs `odefun_backward` and `odefun_adjoint` which are not defined by the `solver` class in use
- ef1bd35281271aa3f66b07eea733cab77b4069ac > @abocquet why did we add this? in any case if we want to add it back, this should happen as upstream as possible in the code, i.e. directly in the options class

We slowly start moving things around to make a smooth transition to the new code.