### PR TITLE
Add basis, alias of fock

### DIFF
--- a/docs/templates/python/material/table.html
+++ b/docs/templates/python/material/table.html
@@ -33,9 +33,9 @@
                   {% with docstring_sections = function.docstring.parsed %}
                     {% with section = (docstring_sections|selectattr('kind.value', 'eq', "text")|first) %}
                       {% set text = section.value|convert_markdown(heading_level, html_id) %}
-                      {% set first_sentence = text.split('.')[0] %}
+                      {% set first_sentence = text.split('</p>')[0] %}
                         <td class="fixed_height">
-                          {{ first_sentence }}.
+                          {{ first_sentence }}
                         </td>
                     {% endwith %}
                   {% endwith %}

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -10,7 +10,7 @@ from .operators import displace
 from .tensor_types import ArrayLike, Number, get_cdtype, to_tensor
 from .utils import tensprod, todm
 
-__all__ = ['fock', 'fock_dm', 'coherent', 'coherent_dm']
+__all__ = ['fock', 'fock_dm', 'basis', 'basis_dm', 'coherent', 'coherent_dm']
 
 
 def fock(
@@ -95,6 +95,28 @@ def fock_dm(
                 [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
     """
     return todm(fock(dim, number, dtype=dtype, device=device))
+
+
+def basis(
+    dim: int | tuple[int, ...],
+    number: int | tuple[int, ...],
+    *,
+    dtype: torch.complex64 | torch.complex128 | None = None,
+    device: str | torch.device | None = None,
+):
+    """Alias for [`dq.fock()`](/python_api/utils/states/fock.html)."""
+    return fock(dim, number, dtype=dtype, device=device)
+
+
+def basis_dm(
+    dim: int | tuple[int, ...],
+    number: int | tuple[int, ...],
+    *,
+    dtype: torch.complex64 | torch.complex128 | None = None,
+    device: str | torch.device | None = None,
+):
+    """Alias for [`dq.fock_dm()`](/python_api/utils/states/fock_dm.html)."""
+    return fock_dm(dim, number, dtype=dtype, device=device)
 
 
 def coherent(

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -104,7 +104,7 @@ def basis(
     dtype: torch.complex64 | torch.complex128 | None = None,
     device: str | torch.device | None = None,
 ):
-    """Alias for [`dq.fock()`](/python_api/utils/states/fock.html)."""
+    """Alias for [`dq.fock()`][dynamiqs.fock]."""
     return fock(dim, number, dtype=dtype, device=device)
 
 
@@ -115,7 +115,7 @@ def basis_dm(
     dtype: torch.complex64 | torch.complex128 | None = None,
     device: str | torch.device | None = None,
 ):
-    """Alias for [`dq.fock_dm()`](/python_api/utils/states/fock_dm.html)."""
+    """Alias for [`dq.fock_dm()`][dynamiqs.fock_dm]."""
     return fock_dm(dim, number, dtype=dtype, device=device)
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,8 @@ nav:
           - States:
               - fock: python_api/utils/states/fock.md
               - fock_dm: python_api/utils/states/fock_dm.md
+              - basis: python_api/utils/states/basis.md
+              - basis_dm: python_api/utils/states/basis_dm.md
               - coherent: python_api/utils/states/coherent.md
               - coherent_dm: python_api/utils/states/coherent_dm.md
           - Quantum utilities:


### PR DESCRIPTION
Add `dq.basis` and `dq.basis_dm` to replicate the API of qutip. (I'm personally more used to using `qt.basis` so I keep making the mistake when using dynamiqs).