### PR TITLE
Fix cuda and cuda:0 bug

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -21,16 +21,21 @@ def obj_type_str(x: Any) -> str:
 
 def to_device(device: str | torch.device | None) -> torch.device:
     if device is None:
-        return torch.ones(1).device  # default device
+        torch_device = torch.ones(1).device  # default device
     elif isinstance(device, str):
-        return torch.device(device)
+        torch_device = torch.device(device)
     elif isinstance(device, torch.device):
-        return device
+        torch_device = device
     else:
         raise TypeError(
             'Argument `device` must be a string, a `torch.device` or `None` but has'
             f' type {obj_type_str(device)}.'
         )
+
+    if torch_device.index:
+        return torch_device
+    else:
+        return torch.device(torch_device.type, 0)  # default device index to 0
 
 
 def hdim(x: Tensor) -> int:

--- a/dynamiqs/solvers/utils/td_tensor.py
+++ b/dynamiqs/solvers/utils/td_tensor.py
@@ -41,7 +41,6 @@ def check_callable(
     expected_device: torch.device,
 ):
     # check type, dtype and device match
-
     if not isinstance(x0, Tensor):
         raise TypeError(
             f'The time-dependent operator must be a {type_str(Tensor)}, but has type'


### PR DESCRIPTION
Fix this quite annoying bug that arises from:
```python
import torch
x = torch.randn(3, device='cuda')
print(x.device == torch.device('cuda')) # False
print(x.device == torch.device('cuda:0')) # True
```
Typically occurs when we do `H.to('cuda')` instead of `H.to('cuda:0')`