### PR TITLE
Fix batching all around, and replace einsums with matmuls

### DIFF
--- a/dynamiqs/mesolve/me_solver.py
+++ b/dynamiqs/mesolve/me_solver.py
@@ -8,16 +8,15 @@ from ..solvers.utils import cache, kraus_map
 class MESolver(Solver):
     def __init__(self, *args, jump_ops: Tensor):
         super().__init__(*args)
-        self.L = jump_ops  # (len(L), 1, b_L, 1, n, n)
-        # self.sum_LdagL = (self.L.mH @ self.L).squeeze(0).sum(dim=0)  # (n, n)
-        self.sum_LdagL = torch.einsum('l...ik,l...kj->...ij', self.L.mH, self.L)
+        self.L = jump_ops  # (1, b_L, 1, len(L), n, n)
+        self.sum_LdagL = torch.sum(self.L.mH @ self.L, dim=0)  # (1, b_L, 1, n, n)
 
-        # define cached operator
-        # non-hermitian Hamiltonian
-        self.Hnh = cache(lambda H: H - 0.5j * self.sum_LdagL)  # (b_H, 1, 1, n, n)
-
+        # define identity operator
         n = self.H.size(-1)
         self.I = torch.eye(n, device=self.device, dtype=self.cdtype)  # (n, n)
+
+        # define cached non-hermitian Hamiltonian
+        self.Hnh = cache(lambda H: H - 0.5j * self.sum_LdagL)  # (b_H, b_L, 1, n, n)
 
     def lindbladian(self, t: float, rho: Tensor) -> Tensor:
         """Compute the action of the Lindbladian on the density matrix.

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -19,34 +19,6 @@ def inv_kraus_matmul(A: Tensor, B: Tensor, upper: bool) -> Tensor:
     return B
 
 
-def batched_mult_left(x, y):
-    r"""Computes the batched matrix product of two tensors where the left tensor
-    has one more dimension than the right one.
-
-     Args:
-         x _(N, ..., n, k)_: Left tensor.
-         y _(..., k, m)_: Right tensor.
-
-     Returns:
-        _(N, ..., n, m)_ The batched product of `x @ y`.
-    """
-    return torch.einsum("n...ik,...kj->n...ij", x, y)
-
-
-def batched_mult_right(x, y):
-    r"""Computes the batched matrix product of two tensors where the right tensor
-    has one more dimension than the left one.
-
-     Args:
-         x _(N, ..., n, k)_: Left tensor.
-         y _(..., k, m)_: Right tensor.
-
-     Returns:
-        _(N, ..., n, m)_ The batched product of `x @ y`.
-    """
-    return torch.einsum("...ik,n...kj->n...ij", x, y)
-
-
 class MERouchon(MESolver, AdjointFixedSolver):
     pass
 
@@ -168,9 +140,7 @@ class MERouchon2(MERouchon):
         M0 = self.I - 1j * dt * Hnh - 0.5 * dt**2 * Hnh @ Hnh  # (b_H, b_L, 1, n, n)
 
         M1s = (
-            0.5
-            * sqrt(abs(dt))
-            * (batched_mult_left(self.L, M0) + batched_mult_right(M0, self.L))
+            0.5 * sqrt(abs(dt)) * (self.L @ M0 + M0 @ self.L)
         )  # (len(L), b_H, b_L, 1, n, n)
 
         return M0, M1s

--- a/dynamiqs/mesolve/rouchon.py
+++ b/dynamiqs/mesolve/rouchon.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from torch.linalg import cholesky_ex as cholesky
 
 from ..solvers.ode.fixed_solver import AdjointFixedSolver
-from ..solvers.utils import cache, inv_sqrtm, kraus_map
+from ..solvers.utils import cache, inv_sqrtm
 from ..utils.utils import unit
 from .me_solver import MESolver
 
@@ -80,7 +80,7 @@ class MERouchon1(MERouchon):
             rho = inv_kraus_matmul(T.mH, rho, upper=True)  # T.mH^-1 @ rho @ T^-1
 
         # compute rho(t+dt)
-        rho = M0 @ rho @ M0.mH + kraus_map(rho, M1s)  # (b_H, b_L, b_rho, n, n)
+        rho = M0 @ rho @ M0.mH + (M1s @ rho @ M1s.mH).sum(0)  # (b_H, b_L, b_rho, n, n)
 
         return unit(rho)
 
@@ -114,13 +114,13 @@ class MERouchon1(MERouchon):
             rho = inv_kraus_matmul(Trev.mH, rho, upper=True)  # Tr.mH^-1 @ rho @ Tr^-1
 
         # compute rho(t-dt)
-        rho = M0rev @ rho @ M0rev.mH - kraus_map(rho, M1srev)
+        rho = M0rev @ rho @ M0rev.mH - (M1srev @ rho @ M1srev.mH).sum(0)
 
         # === forward time
         M0, M1s = self.Ms(Hnh)
 
         # compute phi(t-dt)
-        phi = M0.mH @ phi @ M0 + kraus_map(phi, M1s.mH)
+        phi = M0.mH @ phi @ M0 + (M1s.mH @ phi @ M1s).sum(0)
 
         # normalize the Kraus Map
         if self.options.normalize == 'cholesky':
@@ -135,13 +135,11 @@ class MERouchon2(MERouchon):
     @cache(maxsize=2)
     def Ms(self, Hnh: Tensor, fwd: bool = True) -> tuple(Tensor, Tensor):
         # Kraus operators
-        # -> (b_H, b_L, 1, n, n), (len(L), b_H, b_L, 1, n, n)
+        # M0: (b_H, b_L, 1, n, n)
+        # M1s: (len(L), b_H, b_L, 1, n, n)
         dt = self.dt if fwd else -self.dt
-        M0 = self.I - 1j * dt * Hnh - 0.5 * dt**2 * Hnh @ Hnh  # (b_H, b_L, 1, n, n)
-
-        M1s = (
-            0.5 * sqrt(abs(dt)) * (self.L @ M0 + M0 @ self.L)
-        )  # (len(L), b_H, b_L, 1, n, n)
+        M0 = self.I - 1j * dt * Hnh - 0.5 * dt**2 * Hnh @ Hnh
+        M1s = 0.5 * sqrt(abs(dt)) * (self.L @ M0 + M0 @ self.L)
 
         return M0, M1s
 
@@ -169,10 +167,8 @@ class MERouchon2(MERouchon):
         M0, M1s = self.Ms(Hnh)  # (b_H, b_L, 1, n, n), (len(L), b_H, b_L, 1, n, n)
 
         # compute rho(t+dt)
-        tmp = kraus_map(rho, M1s)  # (b_H, b_L, b_rho, n, n)
-        rho = (
-            M0 @ rho @ M0.mH + tmp + 0.5 * kraus_map(tmp, M1s)
-        )  # (b_H, b_L, b_rho, n, n)
+        tmp = (M1s @ rho @ M1s.mH).sum(0)  # (b_H, b_L, b_rho, n, n)
+        rho = M0 @ rho @ M0.mH + tmp + 0.5 * (M1s @ tmp @ M1s.mH).sum(0)
         rho = unit(rho)  # (b_H, b_L, b_rho, n, n)
 
         return rho
@@ -207,15 +203,15 @@ class MERouchon2(MERouchon):
         M0rev, M1srev = self.Ms(Hnh, fwd=False)
 
         # compute rho(t-dt)
-        tmp = kraus_map(rho, M1srev)
-        rho = M0rev @ rho @ M0rev.mH - tmp + 0.5 * kraus_map(tmp, M1srev)
+        tmp = (M1srev @ rho @ M1srev.mH).sum(0)
+        rho = M0rev @ rho @ M0rev.mH - tmp + 0.5 * (M1srev @ tmp @ M1srev.mH).sum(0)
         rho = unit(rho)
 
         # === forward time
         M0, M1s = self.Ms(Hnh)
 
         # compute phi(t-dt)
-        tmp = kraus_map(phi, M1s.mH)
-        phi = M0.mH @ phi @ M0 + tmp + 0.5 * kraus_map(tmp, M1s.mH)
+        tmp = (M1s.mH @ phi @ M1s).sum(0)
+        phi = M0.mH @ phi @ M0 + tmp + 0.5 * (M1s.mH @ tmp @ M1s).sum(0)
 
         return rho, phi

--- a/dynamiqs/sesolve/adaptive.py
+++ b/dynamiqs/sesolve/adaptive.py
@@ -8,15 +8,15 @@ from ..solvers.ode.adaptive_solver import AdaptiveSolver, DormandPrince5
 class SEAdaptive(AdaptiveSolver):
     def odefun(self, t: float, psi: Tensor) -> Tensor:
         """Compute dpsi / dt = -1j * H(psi) at time t."""
-        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
+        # psi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
         return -1j * self.H(t) @ psi
 
     def odefun_backward(self, t: float, psi: Tensor) -> Tensor:
-        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
+        # psi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
         raise NotImplementedError
 
     def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
-        # phi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
+        # phi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
         raise NotImplementedError
 
 

--- a/dynamiqs/sesolve/euler.py
+++ b/dynamiqs/sesolve/euler.py
@@ -5,5 +5,5 @@ from ..solvers.ode.fixed_solver import FixedSolver
 
 class SEEuler(FixedSolver):
     def forward(self, t: float, psi: Tensor) -> Tensor:
-        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
+        # psi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
         return psi - self.dt * 1j * self.H(t) @ psi

--- a/dynamiqs/sesolve/propagator.py
+++ b/dynamiqs/sesolve/propagator.py
@@ -8,9 +8,9 @@ from ..solvers.utils import cache
 class SEPropagator(Propagator):
     @cache
     def propagator(self, delta_t: float) -> Tensor:
-        # -> (b_H, 1, n, n)
+        # -> (b_H, 1, 1, n, n)
         return torch.matrix_exp(-1j * self.H * delta_t)
 
     def forward(self, t: float, delta_t: float, psi: Tensor) -> Tensor:
-        # psi: (b_H, b_psi, n, 1) -> (b_H, b_psi, n, 1)
+        # psi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
         return self.propagator(delta_t) @ psi

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -157,7 +157,7 @@ def sesolve(
     # compute the result
     result = solver.run()
 
-    # get saved tensors and restore correct batching
+    # get saved tensors and restore initial batching
     if result.ysave is not None:
         result.ysave = result.ysave.squeeze(0, 1, 2)
     if result.exp_save is not None:

--- a/dynamiqs/smesolve/rouchon.py
+++ b/dynamiqs/smesolve/rouchon.py
@@ -6,7 +6,7 @@ import torch
 from torch import Tensor
 
 from ..solvers.ode.fixed_solver import FixedSolver
-from ..solvers.utils import cache, kraus_map
+from ..solvers.utils import cache
 from ..utils.utils import unit
 from .sme_solver import SMESolver
 
@@ -53,6 +53,6 @@ class SMERouchon1(SMERouchon):
         M0 = M0_tmp + (seta_dy[..., None, None] * self.Lm).sum(0)
 
         # update state
-        rho = M0 @ rho @ M0.mH + kraus_map(rho, self.M1s)
+        rho = M0 @ rho @ M0.mH + (self.M1s @ rho @ self.M1s.mH).sum(0)
 
         return unit(rho)

--- a/dynamiqs/smesolve/rouchon.py
+++ b/dynamiqs/smesolve/rouchon.py
@@ -20,17 +20,17 @@ class SMERouchon1(SMERouchon):
         super().__init__(*args, **kwargs)
 
         # define cached operators
-        # self.M0 (b_H, b_L, 1, n, n)
+        # self.M0 (b_H, b_L, 1, 1, n, n)
         self.M0_tmp = cache(lambda Hnh: self.I - 1j * self.dt * Hnh)
 
         # define M1s
-        # self.M1s: # (len(L), 1, b_L, 1, n, n)
+        # self.M1s: # (len(L), 1, b_L, 1, 1, n, n)
         self.M1s = torch.cat(
             [
                 sqrt(self.dt) * self.Lc,
                 torch.sqrt(self.dt * (1 - self.etas))[..., None, None] * self.Lm,
             ],
-        )[None, ...]
+        )
 
     def forward(self, t: float, rho: Tensor) -> Tensor:
         # rho: (b_H, b_L, b_rho, ntrajs, n, n) -> (b_H, b_L, b_rho, ntrajs, n, n)
@@ -42,15 +42,17 @@ class SMERouchon1(SMERouchon):
         M0_tmp = self.M0_tmp(Hnh)
 
         # sample Wiener process
-        dw = self.sample_wiener(self.dt)
+        dw = self.sample_wiener(self.dt)  # (len(Lm), b_H, b_L, b_rho, ntrajs)
 
         # update measured signal
-        dy = self.update_meas(dw, rho)
+        dy = self.update_meas(dw, rho)  # (len(Lm), b_H, b_L, b_rho, ntrajs)
+
+        # compute M0
+        # M0: (b_H, b_L, 1, ntrajs, n, n)
+        seta_dy = self.etas.sqrt() * dy  # (len(Lm), b_H, b_L, b_rho, ntrajs)
+        M0 = M0_tmp + (seta_dy[..., None, None] * self.Lm).sum(0)
 
         # update state
-        # M0: (b_H, b_L, 1, ntrajs, n, n)
-        M0 = M0_tmp + ((self.etas.sqrt() * dy)[..., None, None] * self.Lm).sum(-3)
         rho = M0 @ rho @ M0.mH + kraus_map(rho, self.M1s)
-        rho = unit(rho)
 
-        return rho
+        return unit(rho)

--- a/dynamiqs/smesolve/sme_solver.py
+++ b/dynamiqs/smesolve/sme_solver.py
@@ -24,7 +24,7 @@ class SMESolver(MESolver):
 
         # split jump operators between purely dissipative (eta = 0) and
         # monitored (eta != 0)
-        mask = etas == 0.0
+        mask = etas.squeeze() == 0.0
         self.Lc = jump_ops[mask]  # (len(Lc), 1, b_L, 1, 1, n, n) purely dissipative
         self.Lm = jump_ops[~mask]  # (len(Lm), 1, b_L, 1, 1, n, n) monitored
         self.etas = etas[~mask]  # (len(Lm), 1, 1, 1, 1)

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -9,9 +9,9 @@ from ..gradient import Gradient
 from ..solver import Euler, Rouchon1, Solver
 from ..solvers.options import Options
 from ..solvers.result import Result
-from ..solvers.utils import batch_H, batch_jump_ops, batch_y0, to_td_tensor
+from ..solvers.utils import batch_H, batch_jump_ops, batch_y0
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
-from ..utils.utils import isket, todm
+from ..utils.utils import todm
 from .euler import SMEEuler
 from .rouchon import SMERouchon1
 
@@ -170,11 +170,6 @@ def smesolve(
         feature, we would be glad to discuss it, please
         [open an issue on GitHub](https://github.com/dynamiqs/dynamiqs/issues/new).
     """  # noqa: E501
-    # H: (b_H?, n, n), rho0: (b_rho0?, n, n) -> (ysave, exp_save, meas_save) with
-    #    - ysave: (b_H?, b_rho0?, ntrajs, len(tsave), n, n)
-    #    - exp_save: (b_H?, b_rho0?, ntrajs, len(exp_ops), len(tsave))
-    #    - meas_save: (b_H?, b_rho0?, ntrajs, len(meas_ops), len(tmeas) - 1)
-
     # default solver
     if solver is None:
         raise ValueError(
@@ -218,24 +213,30 @@ def smesolve(
 
     # format and batch all tensors
     # H: (b_H, 1, 1, 1, n, n)
+    # jump_ops: (len(L), 1, b_L, 1, 1, n, n)
     # rho0: (b_H, b_L, b_rho0, ntrajs, n, n)
-    # exp_ops: (len(exp_ops), n, n)
-    # jump_ops: (len(jump_ops), b_L, n, n)
-    H = to_td_tensor(H, dtype=options.cdtype, device=options.device)
-    rho0 = to_tensor(rho0, dtype=options.cdtype, device=options.device)
-    H = batch_H(H).unsqueeze(2)
-    jump_ops = batch_jump_ops(jump_ops, dtype=options.cdtype, device=options.device)
-    rho0 = batch_y0(rho0, H, jump_ops).unsqueeze(2).repeat(1, 1, ntrajs, 1, 1)
-    if isket(rho0):
-        rho0 = todm(rho0)
-    exp_ops = to_tensor(exp_ops, dtype=options.cdtype, device=options.device)
+    # exp_ops: (len(E), n, n)
+    ops_kwargs = dict(dtype=options.cdtype, device=options.device)
+    H = batch_H(H, **ops_kwargs)
+    H = H.unsqueeze(3)
+    jump_ops = batch_jump_ops(jump_ops, **ops_kwargs)
+    jump_ops = jump_ops.unsqueeze(4)
+    rho0 = batch_y0(rho0, b_H=H.size(0), b_L=jump_ops.size(2), **ops_kwargs)
+    rho0 = rho0.unsqueeze(3).repeat(1, 1, 1, ntrajs, 1, 1)
+    exp_ops = to_tensor(exp_ops, **ops_kwargs)
+
+    # convert rho0 to a density matrix
+    rho0 = todm(rho0)
 
     # convert tsave to a tensor
-    tsave = to_tensor(tsave, dtype=options.rdtype, device='cpu')
+    time_kwargs = dict(dtype=options.rdtype, device='cpu')
+    tsave = to_tensor(tsave, **time_kwargs)
     check_time_tensor(tsave, arg_name='tsave')
 
     # convert etas to a tensor and check
-    etas = to_tensor(etas, dtype=options.rdtype, device='cpu')
+    # etas: (len(L), 1, 1, 1, 1)
+    etas = to_tensor(etas, **time_kwargs)
+    etas = etas[..., None, None, None, None]
     if len(etas) != len(jump_ops):
         raise ValueError(
             'Argument `etas` must have the same length as `jump_ops` of length'

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -282,6 +282,7 @@ def smesolve(
     if result.exp_save is not None:
         result.exp_save = result.exp_save.squeeze(0, 1, 2)
     if result.meas_save is not None:
+        result.meas_save = result.meas_save.permute(1, 2, 3, 4, 0, 5)
         result.meas_save = result.meas_save.squeeze(0, 1, 2)
 
     return result

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -276,7 +276,7 @@ def smesolve(
     # compute the result
     result = solver.run()
 
-    # get saved tensors and restore correct batching
+    # get saved tensors and restore initial batching
     if result.ysave is not None:
         result.ysave = result.ysave.squeeze(0, 1, 2)
     if result.exp_save is not None:

--- a/dynamiqs/solvers/utils/batching.py
+++ b/dynamiqs/solvers/utils/batching.py
@@ -9,8 +9,8 @@ from .td_tensor import TDTensor, to_td_tensor
 
 def batch_H(
     H: TDArrayLike,
-    dtype: torch.dtype | None = None,
-    device: str | torch.device | None = None,
+    dtype: torch.complex64 | torch.complex128,
+    device: torch.device,
 ) -> TDTensor:
     # H: (b_H?, n, n) ->  (b_H, 1, 1, n, n)
 
@@ -27,8 +27,8 @@ def batch_H(
 
 def batch_jump_ops(
     jump_ops: list[ArrayLike],
-    dtype: torch.dtype | None = None,
-    device: str | torch.device | None = None,
+    dtype: torch.complex64 | torch.complex128,
+    device: torch.device,
 ) -> Tensor:
     # L: [(b_L?, n, n)] ->  (len(L), 1, b_L, 1, n, n)
 
@@ -83,10 +83,10 @@ def batch_jump_ops(
 
 def batch_y0(
     y0: ArrayLike,
+    dtype: torch.complex64 | torch.complex128,
+    device: torch.device,
     b_H: int = 1,
     b_L: int = 1,
-    dtype: torch.dtype | None = None,
-    device: str | torch.device | None = None,
 ) -> Tensor:
     # y0: (b_y0?, m, n) ->  (b_H, b_L, b_y0, m, n)
 

--- a/dynamiqs/solvers/utils/td_tensor.py
+++ b/dynamiqs/solvers/utils/td_tensor.py
@@ -19,17 +19,12 @@ def to_td_tensor(
     """Convert a `TDArrayLike` object to a `TDTensor` object."""
     device = to_device(device)
 
-    if isinstance(x, get_args(ArrayLike)):
-        # convert to tensor
+    if isinstance(x, get_args(ArrayLike)):  # constant tensor
         x = to_tensor(x, dtype=dtype, device=device)
         return ConstantTDTensor(x)
-    elif callable(x):
+    elif callable(x):  # time-dependent tensor
         dtype = get_rdtype(dtype) if dtype is None else dtype  # assume real by default
-
-        # compute initial value of the callable
         x0 = x(0.0)
-
-        # check callable
         check_callable(x0, dtype, device)
 
         return CallableTDTensor(x, shape=x0.shape, dtype=dtype, device=device)

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -21,21 +21,14 @@ tqdm = partial(std_tqdm, bar_format=PBAR_FORMAT)
 def kraus_map(rho: Tensor, O: Tensor) -> Tensor:
     """Compute the application of a Kraus map on an input density matrix.
 
-    This is equivalent to `torch.sum(operators @ rho[None,...] @ operators.mH, dim=0)`.
-    The use of einsum yields better performances on large matrices, but may cause a
-    small overhead on smaller matrices (N <~ 50).
-
-    TODO Fix documentation
-
     Args:
         rho: Density matrix of shape `(..., n, n)`.
-        operators: Kraus operators of shape `(a, ..., n, n)`.
+        operators: Kraus operators of shape `(m, ..., n, n)`.
 
     Returns:
         Density matrix of shape `(..., n, n)` with the Kraus map applied.
     """
-
-    return torch.einsum('n...ik,...kl,n...lj->...ij', O, rho, O.mH)
+    return (O @ rho @ O.mH).sum(0)  # (..., n, n)
 
 
 def inv_sqrtm(mat: Tensor) -> Tensor:

--- a/dynamiqs/solvers/utils/utils.py
+++ b/dynamiqs/solvers/utils/utils.py
@@ -18,19 +18,6 @@ PBAR_FORMAT = '|{bar}| {percentage:4.1f}% - time {elapsed}/{remaining}'
 tqdm = partial(std_tqdm, bar_format=PBAR_FORMAT)
 
 
-def kraus_map(rho: Tensor, O: Tensor) -> Tensor:
-    """Compute the application of a Kraus map on an input density matrix.
-
-    Args:
-        rho: Density matrix of shape `(..., n, n)`.
-        operators: Kraus operators of shape `(m, ..., n, n)`.
-
-    Returns:
-        Density matrix of shape `(..., n, n)` with the Kraus map applied.
-    """
-    return (O @ rho @ O.mH).sum(0)  # (..., n, n)
-
-
 def inv_sqrtm(mat: Tensor) -> Tensor:
     """Compute the inverse square root of a complex Hermitian or real symmetric matrix
     using its eigendecomposition.


### PR DESCRIPTION
Follow up to https://github.com/dynamiqs/dynamiqs/pull/325, closes DYN-93.

All around simplifications, and make all batching consistent throughout the code. Replaces all einsums with matmuls for performance.

Left to-do:

- [ ] Documentation for batching inside sesolve, mesolve, smesolve
- [ ] Fix batching tutorial
- [ ] Fix `slindbladian API`
- [x] Check that `smesolve` is not broken @pierreguilmin 