### PR TITLE
Fix pycon lexer not recognised by sybil

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -4,7 +4,12 @@ import pytest
 import torch
 from matplotlib import pyplot as plt
 from sybil import Sybil
-from sybil.parsers.myst import DocTestDirectiveParser, PythonCodeBlockParser, SkipParser
+from sybil.parsers.myst import (
+    CodeBlockParser,
+    DocTestDirectiveParser,
+    PythonCodeBlockParser,
+    SkipParser,
+)
 
 import dynamiqs
 
@@ -31,11 +36,16 @@ def renderfig():
     return savefig_docs
 
 
+class PyconCodeBlockParser(PythonCodeBlockParser):
+    language = 'pycon'
+
+
 # sybil configuration
 pytest_collect_file = Sybil(
     parsers=[
         DocTestDirectiveParser(optionflags=ELLIPSIS),
         PythonCodeBlockParser(),
+        PyconCodeBlockParser(),
         SkipParser(),
     ],
     patterns=['*.md'],

--- a/docs/getting_started/sharp-bits.md
+++ b/docs/getting_started/sharp-bits.md
@@ -14,6 +14,11 @@ Here's a short summary of the different sections for the fast-paced reader:
 - [**RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn**](#runtimeerror-element-0-of-tensors-does-not-require-grad-and-does-not-have-a-grad_fn): the tensor on which you want to compute the gradient is not attached to the computation graph.
 - [**Using a for loop**](#using-a-for-loop): use batching rather than a `for` loop to simulate multiple Hamiltonians or initial states.
 
+```python
+import dynamiqs as dq
+import torch
+```
+
 ## Main differences with QuTiP
 
 <!-- If modifications are made in this section, ensure to also update the tutorials/defining-hamiltonians.md document to reflect these changes in the "Differences with QuTiP" warning admonition at the top of the file. -->


### PR DESCRIPTION
On top of #345.

We were not testing the examples under the `pycon` fences. ~@gautierronan can we juste use `python` as proposed in this PR, or should we try an find a workaround to keep `pycon`?~ --> Added the `pycon` parser to sybil.