### PR TITLE
Fix adjoint

### DIFF
--- a/dynamiqs/mesolve/adaptive.py
+++ b/dynamiqs/mesolve/adaptive.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from torch import Tensor
 
-from ..solvers.ode.adaptive_solver import AdaptiveSolver, DormandPrince5
+from ..solvers.ode.adaptive_solver import AdjointAdaptiveSolver, DormandPrince5
 from .me_solver import MESolver
 
 
-class MEAdaptive(MESolver, AdaptiveSolver):
+class MEAdaptive(MESolver, AdjointAdaptiveSolver):
     def odefun(self, t: float, rho: Tensor) -> Tensor:
         # rho: (b_H, b_L, b_rho, n, n) -> (b_H, b_L, b_rho, n, n)
         return self.lindbladian(t, rho)

--- a/dynamiqs/mesolve/adaptive.py
+++ b/dynamiqs/mesolve/adaptive.py
@@ -13,13 +13,11 @@ class MEAdaptive(MESolver, AdaptiveSolver):
 
     def odefun_backward(self, t: float, rho: Tensor) -> Tensor:
         # rho: (b_H, b_L, b_rho, n, n) -> (b_H, b_L, b_rho, n, n)
-        # t is passed in as negative time
-        return -self.lindbladian(-t, rho)
+        return -self.lindbladian(t, rho)
 
     def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
         # phi: (b_H, b_L, b_rho, n, n) -> (b_H, b_L, b_rho, n, n)
-        # t is passed in as negative time
-        return self.adjoint_lindbladian(-t, phi)
+        return self.adjoint_lindbladian(t, phi)
 
 
 class MEDormandPrince5(MEAdaptive, DormandPrince5):

--- a/dynamiqs/mesolve/adaptive.py
+++ b/dynamiqs/mesolve/adaptive.py
@@ -13,11 +13,13 @@ class MEAdaptive(MESolver, AdaptiveSolver):
 
     def odefun_backward(self, t: float, rho: Tensor) -> Tensor:
         # rho: (b_H, b_L, b_rho, n, n) -> (b_H, b_L, b_rho, n, n)
-        return -self.lindbladian(t, rho)
+        # t is passed in as negative time
+        return -self.lindbladian(-t, rho)
 
     def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
         # phi: (b_H, b_L, b_rho, n, n) -> (b_H, b_L, b_rho, n, n)
-        return self.adjoint_lindbladian(t, phi)
+        # t is passed in as negative time
+        return self.adjoint_lindbladian(-t, phi)
 
 
 class MEDormandPrince5(MEAdaptive, DormandPrince5):

--- a/dynamiqs/sesolve/adaptive.py
+++ b/dynamiqs/sesolve/adaptive.py
@@ -13,10 +13,12 @@ class SEAdaptive(AdaptiveSolver):
 
     def odefun_backward(self, t: float, psi: Tensor) -> Tensor:
         # psi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
+        # t is passed in as negative time
         raise NotImplementedError
 
     def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
         # phi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
+        # t is passed in as negative time
         raise NotImplementedError
 
 

--- a/dynamiqs/sesolve/adaptive.py
+++ b/dynamiqs/sesolve/adaptive.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from torch import Tensor
 
-from ..solvers.ode.adaptive_solver import AdaptiveSolver, DormandPrince5
+from ..solvers.ode.adaptive_solver import AdjointAdaptiveSolver, DormandPrince5
 
 
-class SEAdaptive(AdaptiveSolver):
+class SEAdaptive(AdjointAdaptiveSolver):
     def odefun(self, t: float, psi: Tensor) -> Tensor:
         """Compute dpsi / dt = -1j * H(psi) at time t."""
         # psi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)

--- a/dynamiqs/sesolve/adaptive.py
+++ b/dynamiqs/sesolve/adaptive.py
@@ -13,12 +13,10 @@ class SEAdaptive(AdaptiveSolver):
 
     def odefun_backward(self, t: float, psi: Tensor) -> Tensor:
         # psi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
-        # t is passed in as negative time
         raise NotImplementedError
 
     def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
         # phi: (b_H, 1, b_psi, n, 1) -> (b_H, 1, b_psi, n, 1)
-        # t is passed in as negative time
         raise NotImplementedError
 
 

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -165,19 +165,11 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointODESolver):
         """Returns $fa(a, t)$."""
         pass
 
-    def _odefun_backward(self, t: float, y: Tensor) -> Tensor:
-        # t is passed in as negative time
-        return self.odefun_backward(-t, y)
-
-    def _odefun_adjoint(self, t: float, y: Tensor) -> Tensor:
-        # t is passed in as negative time
-        return self.odefun_adjoint(-t, y)
-
     def init_augmented(self, t0: float, y0: Tensor, a0: Tensor) -> tuple:
-        fy0 = self._odefun_backward(t0, y0)
-        fa0 = self._odefun_adjoint(t0, a0)
-        dty0 = self.init_tstep(t0, y0, fy0, self._odefun_backward)
-        dta0 = self.init_tstep(t0, a0, fa0, self._odefun_adjoint)
+        fy0 = self.odefun_backward(t0, y0)
+        fa0 = self.odefun_adjoint(t0, a0)
+        dty0 = self.init_tstep(t0, y0, fy0, self.odefun_backward)
+        dta0 = self.init_tstep(t0, a0, fa0, self.odefun_adjoint)
         dt0 = min(dty0, dta0)
         error0 = 1.0
         return t0, y0, a0, fy0, fa0, dt0, error0
@@ -214,8 +206,8 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointODESolver):
 
             with torch.enable_grad():
                 # perform a single step of size dt
-                fyt_new, y_new, y_err = self.step(t, y, fyt, dt, self._odefun_backward)
-                fat_new, a_new, a_err = self.step(t, a, fat, dt, self._odefun_adjoint)
+                fyt_new, y_new, y_err = self.step(t, y, fyt, dt, self.odefun_backward)
+                fat_new, a_new, a_err = self.step(t, a, fat, dt, self.odefun_adjoint)
 
                 # compute estimated error of this step
                 error_a = self.get_error(a_err, a, a_new)

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -22,4 +22,4 @@ class TestMEAdaptive(OpenSolverTester):
     @pytest.mark.parametrize('system', [gocavity, gotdqubit])
     def test_adjoint(self, system):
         gradient = Adjoint(params=system.params)
-        self._test_gradient(system, Dopri5(), gradient, rtol=1e-1, atol=1e-2)
+        self._test_gradient(system, Dopri5(), gradient, atol=3e-3)


### PR DESCRIPTION
Adjoint tests were bugged for 2 reasons:

1. Time was not being evolved in the right direction inside `solver.step()` function
2. The graphs of `fy` and `fa` were being freed at every time step

Fixes DYN-77.