### PR TITLE
Fix adjoint memory usage

### DIFF
--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -205,9 +205,12 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointODESolver):
             y, a = new_leaf_tensor(y), new_leaf_tensor(a)
 
             with torch.enable_grad():
+                # compute derivatives
+                fyt, fat = self.odefun_backward(t, y), self.odefun_adjoint(t, a)
+
                 # perform a single step of size dt
-                fyt_new, y_new, y_err = self.step(t, y, fyt, dt, self.odefun_backward)
-                fat_new, a_new, a_err = self.step(t, a, fat, dt, self.odefun_adjoint)
+                _, y_new, y_err = self.step(t, y, fyt, dt, self.odefun_backward)
+                _, a_new, a_err = self.step(t, a, fat, dt, self.odefun_adjoint)
 
                 # compute estimated error of this step
                 error_a = self.get_error(a_err, a, a_new)
@@ -216,25 +219,20 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointODESolver):
 
                 # update if step is accepted
                 if error <= 1:
+                    t, y, a = t + dt, y_new, a_new
 
                     # compute g(t-dt)
                     # note: we set `retain_graph=True` to keep tracking operations on
                     # `self.options.params` in the graph
                     dg = torch.autograd.grad(
-                        a_new,
+                        a,
                         self.options.params,
-                        y_new,
+                        y,
                         allow_unused=True,
                         retain_graph=True,
                     )
                     dg = none_to_zeros_like(dg, self.options.params)
                     g = add_tuples(g, dg)
-
-                    # detach derivatives
-                    fyt, fat = new_leaf_tensor(fyt), new_leaf_tensor(fat)
-
-                    # update state
-                    t, y, a, fyt, fat = t + dt, y_new, a_new, fyt_new, fat_new
 
                     # update the progress bar
                     self.pbar.update(dt)

--- a/dynamiqs/solvers/ode/adaptive_solver.py
+++ b/dynamiqs/solvers/ode/adaptive_solver.py
@@ -216,20 +216,25 @@ class AdjointAdaptiveSolver(AdaptiveSolver, AdjointODESolver):
 
                 # update if step is accepted
                 if error <= 1:
-                    t, y, a, fyt, fat = t + dt, y_new, a_new, fyt_new, fat_new
 
                     # compute g(t-dt)
                     # note: we set `retain_graph=True` to keep tracking operations on
                     # `self.options.params` in the graph
                     dg = torch.autograd.grad(
-                        a,
+                        a_new,
                         self.options.params,
-                        y,
+                        y_new,
                         allow_unused=True,
                         retain_graph=True,
                     )
                     dg = none_to_zeros_like(dg, self.options.params)
                     g = add_tuples(g, dg)
+
+                    # detach derivatives
+                    fyt, fat = new_leaf_tensor(fyt), new_leaf_tensor(fat)
+
+                    # update state
+                    t, y, a, fyt, fat = t + dt, y_new, a_new, fyt_new, fat_new
 
                     # update the progress bar
                     self.pbar.update(dt)

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -22,4 +22,4 @@ class TestMEAdaptive(OpenSolverTester):
     @pytest.mark.parametrize('system', [gocavity, gotdqubit])
     def test_adjoint(self, system):
         gradient = Adjoint(params=system.params)
-        self._test_gradient(system, Dopri5(), gradient, atol=3e-3)
+        self._test_gradient(system, Dopri5(), gradient)


### PR DESCRIPTION
Following up on this comment https://github.com/dynamiqs/dynamiqs/pull/351#discussion_r1399121270. There was still a bug in the adjoint which follows from a poor management of the computation graph. We were backpropagating through the entire graph every time step (and the graph was increasing in size at each time step), so backprop was exploding.

This fixes the bug, and also the tests now pass really cleanly (even with `atol=rtol=1e-6`). 

However, the fix is not entirely satisfying because it requires recomputing the functions f(y, t) and f(a, t) twice at each time step during the backward pass. This is not a big overhead so it's a good enough fix for now, but still quite annoying.  Happy to hear other solutions.