### PR TITLE
Fix sybil update

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,16 +1,11 @@
-from doctest import ELLIPSIS
+from typing import Sequence
 
 import pytest
 import torch
 from matplotlib import pyplot as plt
 from sybil import Sybil
 from sybil.evaluators.python import PythonEvaluator
-from sybil.parsers.myst import (
-    CodeBlockParser,
-    DocTestDirectiveParser,
-    PythonCodeBlockParser,
-    SkipParser,
-)
+from sybil.parsers.markdown import PythonCodeBlockParser, SkipParser
 
 import dynamiqs
 
@@ -39,15 +34,22 @@ def renderfig():
 
 # pycon code blocks parser
 class PyconCodeBlockParser(PythonCodeBlockParser):
-    def __init__(self):
-        super().__init__()
-        self.codeblock_parser = CodeBlockParser('pycon', PythonEvaluator())
+    def __init__(
+        self, future_imports: Sequence[str] = (), doctest_optionflags: int = 0
+    ) -> None:
+        super().__init__(
+            future_imports=future_imports, doctest_optionflags=doctest_optionflags
+        )
+
+        # override self.codeblock_parser
+        self.codeblock_parser = self.codeblock_parser_class(
+            'pycon', PythonEvaluator(future_imports)
+        )
 
 
 # sybil configuration
 pytest_collect_file = Sybil(
     parsers=[
-        DocTestDirectiveParser(optionflags=ELLIPSIS),
         PythonCodeBlockParser(),
         PyconCodeBlockParser(),
         SkipParser(),

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,12 +1,11 @@
 import re
 
-# The following regex will match any line containing 'renderfig', 'skip: start' or
-# 'skip: end':
+# The following regex will match any line containing 'renderfig':
 # - '^' matches the start of a line
 # - '.*' matches any character (except for line terminators) zero or more times
 # - '$' matches the end of a line
 # - '\n?' optionally matches the newline character at the end of the line
-regex = r'^.*(renderfig|skip: start|skip: end).*$\n?'
+regex = r'^.*renderfig.*$\n?'
 # `flags=re.MULTILINE` is necessary to match the start and end of each line
 pattern = re.compile(regex, flags=re.MULTILINE)
 

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -120,7 +120,7 @@ def run_batched(device):
 So we want to run a total of `11 * 11 = 121` simulations. Let's compare how long it takes to run them unbatched vs batched on CPU[^1]:
 [^1]: Apple M1 chip with 8-core CPU.
 
-% skip: start
+<!-- skip: start -->
 
 ```pycon
 >>> %timeit run_unbatched('cpu')
@@ -143,4 +143,4 @@ The result is even more striking on GPU[^2]:
 
 On the GPU, because we save costly data transfers with the CPU and do N-D matrices multiplications, we gain a **factor x75** in speedup!
 
-% skip: end
+<!-- skip: end -->

--- a/dynamiqs/conftest.py
+++ b/dynamiqs/conftest.py
@@ -40,9 +40,7 @@ def renderfig():
 
 # sybil configuration
 pytest_collect_file = Sybil(
-    parsers=[
-        DocTestParser(optionflags=ELLIPSIS),
-    ],
+    parsers=[DocTestParser(optionflags=ELLIPSIS)],
     patterns=['*.py'],
     setup=sybil_setup,
     fixtures=['renderfig'],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dev = [
     "mkdocs-section-index",
     "mkdocs-simple-hooks",
     "mkdocs-glightbox",
-    "sybil",
+    "sybil>=6",
 ]
 
 [tool.isort]


### PR DESCRIPTION
Minor fixes on top of #356.

- enforce sybil >= 6.0 (@abocquet you should update or tests won't pass locally)
- fixed the override for pycon lexer (see https://github.com/simplistix/sybil/blob/master/sybil/parsers/markdown/codeblock.py)
- use the new markdown parsers (see https://sybil.readthedocs.io/en/latest/changes.html)