### PR TITLE
Fix `pwc_pulse()` index

### DIFF
--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -130,7 +130,7 @@ def pwc_pulse(times: Tensor, values: Tensor) -> callable[[float], Tensor]:
             return torch.zeros(batch_sizes, dtype=values.dtype, device=values.device)
         else:
             # find the index $k$ such that $t \in [t_k, t_{k+1})$
-            idx = torch.searchsorted(times, t)
+            idx = torch.searchsorted(times, t, side='right') - 1
             return values[..., idx]
 
     return pulse


### PR DESCRIPTION
I think it's finally correct.

```python
times = torch.linspace(0, 10.0, 11)

for t in [0.0, 0.1, 1.0, 1.1, 9.9]:
    idx = torch.searchsorted(times, t, side='right') - 1
    print(f't={t} > idx={idx}')
```
```
t=0.0 > idx=0
t=0.1 > idx=0
t=1.0 > idx=1
t=1.1 > idx=1
t=9.9 > idx=9
```