### PR TITLE
Better documentation of the choice for `rand_complex()`

### DIFF
--- a/dynamiqs/conftest.py
+++ b/dynamiqs/conftest.py
@@ -6,6 +6,7 @@ import torch
 from matplotlib import pyplot as plt
 from sybil import Sybil
 from sybil.parsers.doctest import DocTestParser
+from sybil.parsers.markdown import PythonCodeBlockParser
 
 import dynamiqs
 
@@ -40,7 +41,7 @@ def renderfig():
 
 # sybil configuration
 pytest_collect_file = Sybil(
-    parsers=[DocTestParser(optionflags=ELLIPSIS)],
+    parsers=[DocTestParser(optionflags=ELLIPSIS), PythonCodeBlockParser()],
     patterns=['*.py'],
     setup=sybil_setup,
     fixtures=['renderfig'],

--- a/dynamiqs/plots/utils.py
+++ b/dynamiqs/plots/utils.py
@@ -168,7 +168,7 @@ def mplstyle(*, latex: bool = True):
         # other
         'savefig.facecolor': 'white',
         'font.size': 12,
-        'scatter.marker': 'x',
+        'scatter.marker': 'o',
         'lines.linewidth': 2.0,
     })
     if latex:

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -36,10 +36,33 @@ def rand_complex(
     $$
     where $\texttt{rand(0,1)}$ is a random number uniformly distributed between 0 and 1.
 
-    Notes:
+    Notes-: Why using a square root in the definition of the magnitude?
         The square root in the definition of the magnitude $r$ ensures that the
         resulting complex numbers are uniformly distributed in the disc of the complex
-        plane with a radius of `rmax`.
+        plane with a radius of `rmax`. Here are three common options to generate random
+        complex numbers, dynamiqs choice is the third one:
+
+        ```python
+        _, (ax0, ax1, ax2) = dq.gridplot(3, sharex=True, sharey=True)
+        ax0.set(xlim=(-1.1, 1.1), ylim=(-1.1, 1.1))
+
+        n = 10_000
+
+        # option 1: uniformly distributed real and imaginary part
+        x = torch.rand(n) * 2 - 1 + 1j * (torch.rand(n) * 2 - 1)
+        ax0.scatter(x.real, x.imag, s=1.0)
+
+        # option 2: uniformly distributed magnitude and phase
+        x = torch.rand(n) * torch.exp(1j * 2 * torch.pi * torch.rand(n))
+        ax1.scatter(x.real, x.imag, s=1.0)
+
+        # option 3: uniformly distributed on the unit disk (dynamiqs choice)
+        x = dq.rand_complex(n)
+        ax2.scatter(x.real, x.imag, s=1.0)
+        renderfig('rand_complex')
+        ```
+
+        ![rand_complex](/figs-code/rand_complex.png){.fig}
 
     Args:
         size _(int or tuple of ints)_: Size of the returned tensor.

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -97,7 +97,7 @@ def rand_complex(
         The square root in the definition of the magnitude $r$ ensures that the
         resulting complex numbers are uniformly distributed in the disc of the complex
         plane with a radius of `rmax`. Here are three common options to generate random
-        complex numbers, dynamiqs choice is the third one:
+        complex numbers, `dq.rand_complex()` returns the last one:
 
         ```python
         _, (ax0, ax1, ax2) = dq.gridplot(3, sharex=True, sharey=True)
@@ -113,7 +113,7 @@ def rand_complex(
         x = torch.rand(n) * torch.exp(1j * 2 * torch.pi * torch.rand(n))
         ax1.scatter(x.real, x.imag, s=1.0)
 
-        # option 3: uniformly distributed on the unit disk (dynamiqs choice)
+        # option 3: uniformly distributed on the unit disk (in dynamiqs)
         x = dq.rand_complex(n)
         ax2.scatter(x.real, x.imag, s=1.0)
         renderfig('rand_complex')


### PR DESCRIPTION
Added a foldable explanation (folded by default) with a plot.

![Screenshot 2023-11-25 at 11 49 07](https://github.com/dynamiqs/dynamiqs/assets/38159029/2ca4c6e0-b890-4415-94bc-0149432facac)
