### PR TITLE
Experimental implementation of time-dependent `jump_ops`

### DIFF
--- a/dynamiqs/mesolve/adaptive_t.py
+++ b/dynamiqs/mesolve/adaptive_t.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import torch
+from torch import Tensor
+
+from ..solvers.ode.adaptive_solver import AdjointAdaptiveSolver, DormandPrince5
+from ..solvers.solver import Solver
+from ..solvers.utils import cache
+
+
+class METSolver(Solver):
+    def __init__(self, *args, L: Tensor):
+        super().__init__(*args)
+        self.L = L  # (nL, ..., n, n)
+
+        # define cached sum of LdagL
+        self.sum_LdagL = cache(lambda L: (L.mH @ L).sum(dim=0))  # (..., n, n)
+
+        # define identity operator
+        n = self.H.size(-1)
+        self.I = torch.eye(n, device=self.device, dtype=self.cdtype)  # (n, n)
+
+        # define cached non-hermitian Hamiltonian
+        self.Hnh = cache(lambda H, sum_LdagL: H - 0.5j * sum_LdagL)  # (..., n, n)
+
+    def lindbladian(self, t: float, rho: Tensor) -> Tensor:
+        """Compute the action of the Lindbladian on the density matrix.
+
+        Notes:
+            Hermiticity of the output is enforced to avoid numerical instability
+            with Runge-Kutta solvers.
+        """
+        # rho: (..., n, n) -> (..., n, n)
+        H = self.H(t)
+        L = self.L(t)
+        sum_LdagL = self.sum_LdagL(L)
+        Hnh = self.Hnh(H, sum_LdagL)
+        out = -1j * Hnh @ rho + 0.5 * (L @ rho @ L.mH).sum(0)
+        return out + out.mH
+
+    def adjoint_lindbladian(self, t: float, phi: Tensor) -> Tensor:
+        """Compute the action of the adjoint Lindbladian on an operator.
+
+        Notes:
+            Hermiticity of the output is enforced to avoid numerical instability
+            with Runge-Kutta solvers.
+        """
+        # phi: (..., n, n) -> (..., n, n)
+        H = self.H(t)
+        L = self.L(t)
+        sum_LdagL = self.sum_LdagL(L)
+        Hnh = self.Hnh(H, sum_LdagL)
+        out = 1j * Hnh.mH @ phi + 0.5 * (L.mH @ phi @ L).sum(0)
+        return out + out.mH
+
+
+class METAdaptive(METSolver, AdjointAdaptiveSolver):
+    def odefun(self, t: float, rho: Tensor) -> Tensor:
+        # rho: (..., n, n) -> (..., n, n)
+        return self.lindbladian(t, rho)
+
+    def odefun_backward(self, t: float, rho: Tensor) -> Tensor:
+        # rho: (..., n, n) -> (..., n, n)
+        # t is passed in as negative time
+        return -self.lindbladian(-t, rho)
+
+    def odefun_adjoint(self, t: float, phi: Tensor) -> Tensor:
+        # phi: (..., n, n) -> (..., n, n)
+        # t is passed in as negative time
+        return self.adjoint_lindbladian(-t, phi)
+
+
+class METDormandPrince5(METAdaptive, DormandPrince5):
+    pass


### PR DESCRIPTION
This should not be merged with `main`, it's just a patch.

If one of the `jump_ops` is a function with signature `(t: float) -> Tensor`, this PR picks a modified adaptive solver that supports time-dependent `jump_ops`. No support for batched `jump_ops`.

@AnilMurani and @Tzekh there you go, if you pull this branch you can use time-dependent jump operators, while we find time to implement proper support for it.

Related to DYN-19.

Example:
```python
import dynamiqs as dq
import numpy as np

n = 32
alpha0 = np.sqrt(2)
alpha1 = 2
k2 = 4
a = dq.destroy(n)
H = dq.zero(n)

def L(t):
    if t <= 1/3:
        return dq.zero(n)
    elif 1/3 <= t <= 2/3:
        return np.sqrt(k2) * (a @ a - alpha0**2 * dq.eye(n))
    else:
        return np.sqrt(k2) * (a @ a - alpha1**2 * dq.eye(n))

jump_ops = [L]

psi0 = dq.coherent(n, 0.0)
tsave = np.linspace(0, 1, 12)
result = dq.mesolve(H, jump_ops, psi0, tsave)
```
```python
dq.plot_wigner_mosaic(result.states, n=12, nrows=3, cross=True)
```
![cdcefacc-1265-4184-9f5f-a8324d6b3afc](https://github.com/dynamiqs/dynamiqs/assets/38159029/f6ae8709-ee54-4ef1-94b3-2f553250bcac)

