### PR TITLE
Fix flat batching

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -10,7 +10,7 @@ from ..solver import Dopri5, Euler, Propagator, Rouchon1, Rouchon2, Solver
 from ..solvers.options import Options
 from ..solvers.result import Result
 from ..solvers.utils.td_tensor import to_td_tensor
-from ..solvers.utils.utils import format_L
+from ..solvers.utils.utils import common_batch_size, format_L
 from ..utils.tensor_types import ArrayLike, TDArrayLike, to_tensor
 from ..utils.utils import todm
 from .adaptive import MEDormandPrince5
@@ -174,44 +174,38 @@ def mesolve(
     # convert and batch H
     H = to_td_tensor(H, **kw)  # (bH?, n, n)
     n = H.size(-1)
+    H = H.view(-1, n, n)  # (bH, n, n)
+    bH = H.size(0)
 
     # convert and batch L
     L = [to_tensor(x, **kw) for x in jump_ops]  # [(??, n, n)]
     L = format_L(L)  # (nL, bL, n, n)
     nL = L.size(0)
+    bL = L.size(1)
 
     # convert and batch y0
     y0 = to_tensor(rho0, **kw)  # (by?, n, n)
     y0 = todm(y0)  # convert y0 to a density matrix
+    y0 = y0.view(-1, n, n)  # (by, n, n)
+    by = y0.size(0)
 
     if not options.flat_batching:
-        H = H.view(-1, 1, 1, n, n)  # (bH, 1, 1, n, n) with bH = 1 if not batched
-        bH = H.size(0)
-        L = L.view(
-            nL, 1, -1, 1, n, n
-        )  # (nL, 1, bL, 1, n, n) with bL = 1 if not batched
-        bL = L.size(2)
-
-        y0 = y0.view(1, 1, -1, n, n)  # (1, 1, by, n, n) with by = 1 if not batched
+        # cartesian product batching
+        H = H.view(bH, 1, 1, n, n)  # (bH, 1, 1, n, n)
+        L = L.view(nL, 1, bL, 1, n, n)  # (nL, 1, bL, 1, n, n)
+        y0 = y0.view(1, 1, by, n, n)  # (1, 1, by, n, n)
         y0 = y0.repeat(bH, bL, 1, 1, 1)  # (bH, bL, by, n, n)
+        dim_squeeze = (0, 1, 2)
     else:
-        H = H.view(-1, n, n)  # (bH, n, n)
-        bH = H.size(0)
-
-        bL = L.size(1)  # (nL, bL, n, n) at this point
-
-        y0 = y0.view(-1, n, n)  # (by, n, n)
-        by = y0.size(0)
-
-        if len({batch_dim for batch_dim in [bH, bL, by] if batch_dim > 1}) > 1:
+        b = common_batch_size([bH, bL, by])
+        if b is None:
             raise ValueError(
-                f"Expected all batch dimensions the same or 1, got bH={bH}, bL={bL},"
-                f" by={by}"
+                'Expected all batch dimensions to be the same, but got `H` batch size'
+                f' {bH}, `jump_ops` batch size {bL} and `rho0` batch size {by}.'
             )
-
-        b = max(bH, bL, by)
         if by == 1:
             y0 = y0.repeat(b, 1, 1)
+        dim_squeeze = (0,)
 
     # convert exp_ops
     exp_ops = to_tensor(exp_ops, **kw)  # (nE, n, n)
@@ -230,14 +224,8 @@ def mesolve(
 
     # === get saved tensors and restore initial batching
     if result.ysave is not None:
-        if not options.flat_batching:
-            result.ysave = result.ysave.squeeze(0, 1, 2)
-        else:
-            result.ysave = result.ysave.squeeze(0)
+        result.ysave = result.ysave.squeeze(*dim_squeeze)
     if result.exp_save is not None:
-        if not options.flat_batching:
-            result.exp_save = result.exp_save.squeeze(0, 1, 2)
-        else:
-            result.exp_save = result.exp_save.squeeze(0)
+        result.exp_save = result.exp_save.squeeze(*dim_squeeze)
 
     return result

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -10,7 +10,7 @@ import dynamiqs as dq
 from dynamiqs.gradient import Gradient
 from dynamiqs.solver import Solver
 from dynamiqs.solvers.result import Result
-from dynamiqs.utils.tensor_types import ArrayLike, dtype_real_to_complex
+from dynamiqs.utils.tensor_types import ArrayLike, TDArrayLike, dtype_real_to_complex
 
 from ..system import System
 
@@ -18,8 +18,8 @@ from ..system import System
 class OpenSystem(System):
     def __init__(self):
         super().__init__()
-        self.jump_ops = None
-        self.jump_ops_batched = None
+        self.L = None
+        self.Lb = None
 
     def run(
         self,
@@ -28,31 +28,16 @@ class OpenSystem(System):
         *,
         gradient: Gradient | None = None,
         options: dict[str, Any] | None = None,
+        H: TDArrayLike | None = None,
+        L: list[ArrayLike] | None = None,
+        y0: ArrayLike | None = None,
     ) -> Result:
-        return self._run(
-            self.H,
-            self.jump_ops,
-            self.y0,
-            tsave,
-            solver,
-            gradient=gradient,
-            options=options,
-        )
-
-    def _run(
-        self,
-        H: Tensor,
-        jump_ops: list[ArrayLike] | None,
-        y0: Tensor,
-        tsave: ArrayLike,
-        solver: Solver,
-        *,
-        gradient: Gradient | None = None,
-        options: dict[str, Any] | None = None,
-    ) -> Result:
+        H = self.H if H is None else H
+        L = self.L if L is None else L
+        y0 = self.y0 if y0 is None else y0
         return dq.mesolve(
             H,
-            jump_ops,
+            L,
             y0,
             tsave,
             exp_ops=self.exp_ops,
@@ -63,10 +48,10 @@ class OpenSystem(System):
 
 
 class OCavity(OpenSystem):
-    # `H_batched: (3, n, n)
-    # `jump_ops`: (2, n, n)
-    # `jump_ops_batched`: (2, 5, n, n)
-    # `y0_batched`: (4, n, n)
+    # `Hb: (3, n, n)
+    # `L`: (2, n, n)
+    # `Lb`: (2, 5, n, n)
+    # `y0b`: (4, n, n)
     # `exp_ops`: (2, n, n)
 
     def __init__(
@@ -98,16 +83,14 @@ class OCavity(OpenSystem):
 
         # prepare quantum operators
         self.H = self.delta * adag @ a
-        self.H_batched = [0.5 * self.H, self.H, 2 * self.H]
-        self.jump_ops = [torch.sqrt(self.kappa) * a, dq.eye(self.n)]
-        self.jump_ops_batched = [
-            L * torch.arange(5).view(5, 1, 1) for L in self.jump_ops
-        ]
+        self.Hb = [0.5 * self.H, self.H, 2 * self.H]
+        self.L = [torch.sqrt(self.kappa) * a, dq.eye(self.n)]
+        self.Lb = [L * torch.arange(5).view(5, 1, 1) for L in self.L]
         self.exp_ops = [dq.position(self.n), dq.momentum(self.n)]
 
         # prepare initial states
         self.y0 = dq.coherent_dm(self.n, self.alpha0)
-        self.y0_batched = [
+        self.y0b = [
             dq.coherent_dm(self.n, self.alpha0),
             dq.coherent_dm(self.n, 1j * self.alpha0),
             dq.coherent_dm(self.n, -self.alpha0),
@@ -179,7 +162,7 @@ class OTDQubit(OpenSystem):
 
         # prepare quantum operators
         self.H = lambda t: self.eps * torch.cos(self.omega * t) * dq.sigmax()
-        self.jump_ops = [torch.sqrt(self.gamma) * dq.sigmax()]
+        self.L = [torch.sqrt(self.gamma) * dq.sigmax()]
         self.exp_ops = [dq.sigmax(), dq.sigmay(), dq.sigmaz()]
 
         # prepare initial states

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -3,14 +3,13 @@ import pytest
 from dynamiqs.gradient import Adjoint, Autograd
 from dynamiqs.solver import Dopri5
 
-from ..solver_tester import OpenSolverTester
+from ..solver_tester import SolverTester
 from .open_system import gocavity, gotdqubit, ocavity, otdqubit
 
 
-class TestMEAdaptive(OpenSolverTester):
+class TestMEAdaptive(SolverTester):
     def test_batching(self):
         self._test_batching(ocavity, Dopri5())
-        self._test_flat_batching(ocavity, Dopri5())
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_correctness(self, system):

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -3,15 +3,14 @@ import pytest
 from dynamiqs.gradient import Adjoint, Autograd
 from dynamiqs.solver import Euler
 
-from ..solver_tester import OpenSolverTester
+from ..solver_tester import SolverTester
 from .open_system import gocavity, gotdqubit, ocavity, otdqubit
 
 
-class TestMEEuler(OpenSolverTester):
+class TestMEEuler(SolverTester):
     def test_batching(self):
         solver = Euler(dt=1e-2)
         self._test_batching(ocavity, solver)
-        self._test_flat_batching(ocavity, solver)
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_correctness(self, system):

--- a/tests/mesolve/test_propagator.py
+++ b/tests/mesolve/test_propagator.py
@@ -1,14 +1,13 @@
 from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Propagator
 
-from ..solver_tester import OpenSolverTester
+from ..solver_tester import SolverTester
 from .open_system import gocavity, ocavity
 
 
-class TestMEPropagator(OpenSolverTester):
+class TestMEPropagator(SolverTester):
     def test_batching(self):
         self._test_batching(ocavity, Propagator())
-        self._test_flat_batching(ocavity, Propagator())
 
     def test_correctness(self):
         self._test_correctness(ocavity, Propagator())

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -3,11 +3,11 @@ import pytest
 from dynamiqs.gradient import Adjoint, Autograd
 from dynamiqs.solver import Rouchon1, Rouchon2
 
-from ..solver_tester import OpenSolverTester
+from ..solver_tester import SolverTester
 from .open_system import gocavity, gotdqubit, ocavity, otdqubit
 
 
-class TestMERouchon1(OpenSolverTester):
+class TestMERouchon1(SolverTester):
     def test_batching(self):
         solver = Rouchon1(dt=1e-2)
         self._test_batching(ocavity, solver)
@@ -40,7 +40,7 @@ class TestMERouchon1(OpenSolverTester):
         self._test_gradient(system, solver, gradient, rtol=1e-4, atol=1e-2)
 
 
-class TestMERouchon2(OpenSolverTester):
+class TestMERouchon2(SolverTester):
     def test_batching(self):
         solver = Rouchon2(dt=1e-2)
         self._test_batching(ocavity, solver)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -10,7 +10,7 @@ import dynamiqs as dq
 from dynamiqs.gradient import Gradient
 from dynamiqs.solver import Solver
 from dynamiqs.solvers.result import Result
-from dynamiqs.utils.tensor_types import ArrayLike, dtype_real_to_complex
+from dynamiqs.utils.tensor_types import ArrayLike, TDArrayLike, dtype_real_to_complex
 
 from ..system import System
 
@@ -23,21 +23,11 @@ class ClosedSystem(System):
         *,
         gradient: Gradient | None = None,
         options: dict[str, Any] | None = None,
+        H: TDArrayLike | None = None,
+        y0: ArrayLike | None = None,
     ) -> Result:
-        return self._run(
-            self.H, self.y0, tsave, solver, gradient=gradient, options=options
-        )
-
-    def _run(
-        self,
-        H: Tensor,
-        y0: Tensor,
-        tsave: ArrayLike,
-        solver: Solver,
-        *,
-        gradient: Gradient | None = None,
-        options: dict[str, Any] | None = None,
-    ) -> Result:
+        H = self.H if H is None else H
+        y0 = self.y0 if y0 is None else y0
         return dq.sesolve(
             H,
             y0,
@@ -50,8 +40,8 @@ class ClosedSystem(System):
 
 
 class Cavity(ClosedSystem):
-    # `H_batched: (3, n, n)
-    # `y0_batched`: (4, n, n)
+    # `Hb: (3, n, n)
+    # `y0b`: (4, n, n)
     # `exp_ops`: (2, n, n)
 
     def __init__(
@@ -81,12 +71,12 @@ class Cavity(ClosedSystem):
 
         # prepare quantum operators
         self.H = self.delta * adag @ a
-        self.H_batched = [0.5 * self.H, self.H, 2 * self.H]
+        self.Hb = [0.5 * self.H, self.H, 2 * self.H]
         self.exp_ops = [dq.position(self.n), dq.momentum(self.n)]
 
         # prepare initial states
         self.y0 = dq.coherent(self.n, self.alpha0)
-        self.y0_batched = [
+        self.y0b = [
             dq.coherent(self.n, self.alpha0),
             dq.coherent(self.n, 1j * self.alpha0),
             dq.coherent(self.n, -self.alpha0),

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -3,11 +3,11 @@ import pytest
 from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Dopri5
 
-from ..solver_tester import ClosedSolverTester
+from ..solver_tester import SolverTester
 from .closed_system import cavity, gcavity, gtdqubit, tdqubit
 
 
-class TestSEAdaptive(ClosedSolverTester):
+class TestSEAdaptive(SolverTester):
     def test_batching(self):
         self._test_batching(cavity, Dopri5())
 

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -3,11 +3,11 @@ import pytest
 from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Euler
 
-from ..solver_tester import ClosedSolverTester
+from ..solver_tester import SolverTester
 from .closed_system import cavity, gcavity, gtdqubit, tdqubit
 
 
-class TestSEEuler(ClosedSolverTester):
+class TestSEEuler(SolverTester):
     def test_batching(self):
         solver = Euler(dt=1e-2)
         self._test_batching(cavity, solver)

--- a/tests/sesolve/test_propagator.py
+++ b/tests/sesolve/test_propagator.py
@@ -1,11 +1,11 @@
 from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Propagator
 
-from ..solver_tester import ClosedSolverTester
+from ..solver_tester import SolverTester
 from .closed_system import cavity, gcavity
 
 
-class TestSEPropagator(ClosedSolverTester):
+class TestSEPropagator(SolverTester):
     def test_batching(self):
         self._test_batching(cavity, Propagator())
 

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -98,10 +98,9 @@ class SolverTester(ABC):
         y0b = system.y0b[:b]
 
         if isinstance(system, ClosedSystem):
-            # result = system.run(tsave, solver, options=options, H=Hb, y0=y0b)
-            # assert result.ysave.shape == (b, nt, n, 1)
-            # assert result.exp_save.shape == (b, nE, nt)
-            pass
+            result = system.run(tsave, solver, options=options, H=Hb, y0=y0b)
+            assert result.ysave.shape == (b, nt, n, 1)
+            assert result.exp_save.shape == (b, nE, nt)
         elif isinstance(system, OpenSystem):
             Lb = [L[:b] for L in system.Lb]
             result = system.run(tsave, solver, options=options, H=Hb, L=Lb, y0=y0b)

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -4,7 +4,6 @@ import logging
 from abc import ABC
 from typing import Any
 
-import pytest
 import torch
 
 from dynamiqs.gradient import Gradient
@@ -18,6 +17,96 @@ from .system import System
 class SolverTester(ABC):
     def test_batching(self):
         pass
+
+    def _test_batching(
+        self,
+        system: ClosedSystem,
+        solver: Solver,
+        *,
+        options: dict[str, Any] | None = None,
+    ):
+        n = system.n
+        m = 1 if isinstance(system, ClosedSystem) else n
+        bH = len(system.Hb)
+        by = len(system.y0b)
+        nE = len(system.exp_ops)
+        nt = 11
+        tsave = system.tsave(nt)
+
+        def run(Hb, yb):
+            H = system.H if not Hb else system.Hb
+            y0 = system.y0 if not yb else system.y0b
+            return system.run(tsave, solver, options=options, H=H, y0=y0)
+
+        # === test regular batching (cartesian product)
+
+        # no batching
+        result = run(Hb=False, yb=False)
+        assert result.ysave.shape == (nt, n, m)
+        assert result.exp_save.shape == (nE, nt)
+
+        # batched H
+        result = run(Hb=True, yb=False)
+        assert result.ysave.shape == (bH, nt, n, m)
+        assert result.exp_save.shape == (bH, nE, nt)
+
+        # batched y0
+        result = run(Hb=False, yb=True)
+        assert result.ysave.shape == (by, nt, n, m)
+        assert result.exp_save.shape == (by, nE, nt)
+
+        # batched H and y0
+        result = run(Hb=True, yb=True)
+        assert result.ysave.shape == (bH, by, nt, n, m)
+        assert result.ysave.shape == (bH, by, nt, n, m)
+
+        if isinstance(system, OpenSystem):
+            bL = len(system.Lb[0])
+
+            def run(Hb, Lb, yb):
+                H = system.H if not Hb else system.Hb
+                L = system.L if not Lb else system.Lb
+                y0 = system.y0 if not yb else system.y0b
+                return system.run(tsave, solver, options=options, H=H, L=L, y0=y0)
+
+            # batched L
+            result = run(Hb=False, Lb=True, yb=False)
+            assert result.ysave.shape == (bL, nt, n, n)
+            assert result.exp_save.shape == (bL, nE, nt)
+
+            # batched H and L
+            result = run(Hb=True, Lb=True, yb=False)
+            assert result.ysave.shape == (bH, bL, nt, n, n)
+            assert result.exp_save.shape == (bH, bL, nE, nt)
+
+            # batched L and y0
+            result = run(Hb=False, Lb=True, yb=True)
+            assert result.ysave.shape == (bL, by, nt, n, n)
+            assert result.exp_save.shape == (bL, by, nE, nt)
+
+            # batched H and L and y0
+            result = run(Hb=True, Lb=True, yb=True)
+            assert result.ysave.shape == (bH, bL, by, nt, n, n)
+            assert result.exp_save.shape == (bH, bL, by, nE, nt)
+
+        # === test flat_batching
+        options = {} if options is None else options
+        options['flat_batching'] = True
+        b = 2
+
+        Hb = system.Hb[:b]
+        y0b = system.y0b[:b]
+
+        if isinstance(system, ClosedSystem):
+            # result = system.run(tsave, solver, options=options, H=Hb, y0=y0b)
+            # assert result.ysave.shape == (b, nt, n, 1)
+            # assert result.exp_save.shape == (b, nE, nt)
+            pass
+        elif isinstance(system, OpenSystem):
+            Lb = [L[:b] for L in system.Lb]
+            result = system.run(tsave, solver, options=options, H=Hb, L=Lb, y0=y0b)
+            assert result.ysave.shape == (b, nt, n, n)
+            assert result.exp_save.shape == (b, nE, nt)
 
     def _test_correctness(
         self,
@@ -88,209 +177,3 @@ class SolverTester(ABC):
 
         assert torch.allclose(grads_state, true_grads_state, rtol=rtol, atol=atol)
         assert torch.allclose(grads_expect, true_grads_expect, rtol=rtol, atol=atol)
-
-
-class ClosedSolverTester(SolverTester):
-    def _test_batching(
-        self,
-        system: ClosedSystem,
-        solver: Solver,
-        *,
-        options: dict[str, Any] | None = None,
-    ):
-        """Test the batching of `H` and `y0`, and the returned object sizes."""
-        n = system.n
-        n_exp_ops = len(system.exp_ops)
-        bH = len(system.H_batched)
-        by = len(system.y0_batched)
-        ntsave = 11
-        tsave = system.tsave(ntsave)
-
-        run = lambda H, y0: system._run(H, y0, tsave, solver, options=options)
-
-        # no batching
-        result = run(system.H, system.y0)
-        assert result.ysave.shape == (ntsave, n, 1)
-        assert result.exp_save.shape == (n_exp_ops, ntsave)
-
-        # batched H
-        result = run(system.H_batched, system.y0)
-        assert result.ysave.shape == (bH, ntsave, n, 1)
-        assert result.exp_save.shape == (bH, n_exp_ops, ntsave)
-
-        # batched y0
-        result = run(system.H, system.y0_batched)
-        assert result.ysave.shape == (by, ntsave, n, 1)
-        assert result.exp_save.shape == (by, n_exp_ops, ntsave)
-
-        # batched H and y0
-        result = run(system.H_batched, system.y0_batched)
-        assert result.ysave.shape == (bH, by, ntsave, n, 1)
-        assert result.exp_save.shape == (bH, by, n_exp_ops, ntsave)
-
-
-class OpenSolverTester(SolverTester):
-    def _test_batching(
-        self,
-        system: OpenSystem,
-        solver: Solver,
-        *,
-        options: dict[str, Any] | None = None,
-    ):
-        """Test the batching of `H` and `y0`, and the returned object sizes."""
-        n = system.n
-        n_exp_ops = len(system.exp_ops)
-        bH = len(system.H_batched)
-        bL = system.jump_ops_batched[0].shape[0]
-        by = len(system.y0_batched)
-        ntsave = 11
-        tsave = system.tsave(ntsave)
-
-        options = options or {}
-        options["flat_batching"] = False
-        run = lambda H, jump_ops, y0: system._run(
-            H, jump_ops, y0, tsave, solver, options=options
-        )
-
-        # no batching
-        result = run(system.H, system.jump_ops, system.y0)
-        assert result.ysave.shape == (ntsave, n, n)
-        assert result.exp_save.shape == (n_exp_ops, ntsave)
-
-        # batched H
-        result = run(system.H_batched, system.jump_ops, system.y0)
-        assert result.ysave.shape == (bH, ntsave, n, n)
-        assert result.exp_save.shape == (bH, n_exp_ops, ntsave)
-
-        # batched jump_ops
-        result = run(system.H, system.jump_ops_batched, system.y0)
-        assert result.ysave.shape == (bL, ntsave, n, n)
-        assert result.exp_save.shape == (bL, n_exp_ops, ntsave)
-
-        # batched y0
-        result = run(system.H, system.jump_ops, system.y0_batched)
-        assert result.ysave.shape == (by, ntsave, n, n)
-        assert result.exp_save.shape == (by, n_exp_ops, ntsave)
-
-        # batched H and jump_ops
-        result = run(system.H_batched, system.jump_ops_batched, system.y0)
-        assert result.ysave.shape == (bH, bL, ntsave, n, n)
-        assert result.exp_save.shape == (bH, bL, n_exp_ops, ntsave)
-
-        # batched H and y0
-        result = run(system.H_batched, system.jump_ops, system.y0_batched)
-        assert result.ysave.shape == (bH, by, ntsave, n, n)
-        assert result.exp_save.shape == (bH, by, n_exp_ops, ntsave)
-
-        # batched jump_ops and y0
-        result = run(system.H, system.jump_ops_batched, system.y0_batched)
-        assert result.ysave.shape == (bL, by, ntsave, n, n)
-        assert result.exp_save.shape == (bL, by, n_exp_ops, ntsave)
-
-        # batched H and jump_ops and y0
-        result = run(system.H_batched, system.jump_ops_batched, system.y0_batched)
-        assert result.ysave.shape == (bH, bL, by, ntsave, n, n)
-        assert result.exp_save.shape == (bH, bL, by, n_exp_ops, ntsave)
-
-        # batched second jump op but not the first one
-        result = run(
-            system.H_batched,
-            [system.jump_ops_batched[0]] + system.jump_ops[1:],
-            system.y0_batched,
-        )
-        assert result.ysave.shape == (bH, bL, by, ntsave, n, n)
-        assert result.exp_save.shape == (bH, bL, by, n_exp_ops, ntsave)
-
-    def _test_flat_batching(
-        self,
-        system: OpenSystem,
-        solver: Solver,
-        *,
-        options: dict[str, Any] | None = None,
-    ):
-        # === non cartesian product batching
-        n = system.n
-        n_exp_ops = len(system.exp_ops)
-
-        b = min(
-            len(system.H_batched),
-            system.jump_ops_batched[0].shape[0],
-            len(system.y0_batched),
-        )
-
-        H_batched = system.H_batched[:b]
-        jump_ops_batched = [jump_op[:b] for jump_op in system.jump_ops_batched]
-        y0_batched = system.y0_batched[:b]
-
-        ntsave = 11
-        tsave = system.tsave(ntsave)
-
-        options = options or {}
-        options["flat_batching"] = True
-        run = lambda H, jump_ops, y0: system._run(
-            H, jump_ops, y0, tsave, solver, options=options
-        )
-
-        # === Passing cases
-
-        # no batching
-        result = run(system.H, system.jump_ops, system.y0)
-        assert result.ysave.shape == (ntsave, n, n)
-        assert result.exp_save.shape == (n_exp_ops, ntsave)
-
-        # batched H
-        result = run(H_batched, system.jump_ops, system.y0)
-        assert result.ysave.shape == (b, ntsave, n, n)
-        assert result.exp_save.shape == (b, n_exp_ops, ntsave)
-
-        # batched jump_ops
-        result = run(system.H, jump_ops_batched, system.y0)
-        assert result.ysave.shape == (b, ntsave, n, n)
-        assert result.exp_save.shape == (b, n_exp_ops, ntsave)
-
-        # batched y0
-        result = run(system.H, system.jump_ops, y0_batched)
-        assert result.ysave.shape == (b, ntsave, n, n)
-        assert result.exp_save.shape == (b, n_exp_ops, ntsave)
-
-        # batched H and jump_ops
-        result = run(H_batched, jump_ops_batched, system.y0)
-        assert result.ysave.shape == (b, ntsave, n, n)
-        assert result.exp_save.shape == (b, n_exp_ops, ntsave)
-
-        # batched H and y0
-        result = run(H_batched, system.jump_ops, y0_batched)
-        assert result.ysave.shape == (b, ntsave, n, n)
-        assert result.exp_save.shape == (b, n_exp_ops, ntsave)
-
-        # batched jump_ops and y0
-        result = run(system.H, jump_ops_batched, y0_batched)
-        assert result.ysave.shape == (b, ntsave, n, n)
-        assert result.exp_save.shape == (b, n_exp_ops, ntsave)
-
-        # batched H and jump_ops and y0
-        result = run(H_batched, jump_ops_batched, y0_batched)
-        assert result.ysave.shape == (b, ntsave, n, n)
-        assert result.exp_save.shape == (b, n_exp_ops, ntsave)
-
-        # === crashing cases (e.g. different batching sizes)
-
-        H_batched = [system.H for _ in range(3)]
-        jump_ops_batched = [system.jump_ops for _ in range(7)]
-        y0_batched = [system.y0 for _ in range(13)]
-
-        # batched H and jump_ops
-        with pytest.raises(Exception):
-            run(H_batched, jump_ops_batched, system.y0)
-
-        # batched H and y0
-        with pytest.raises(Exception):
-            run(H_batched, system.jump_ops, y0_batched)
-
-        # batched jump_ops and y0
-        with pytest.raises(Exception):
-            run(system.H, jump_ops_batched, y0_batched)
-
-        # batched H and jump_ops and y0
-        with pytest.raises(Exception):
-            run(H_batched, jump_ops_batched, y0_batched)

--- a/tests/system.py
+++ b/tests/system.py
@@ -17,9 +17,9 @@ class System(ABC):
     def __init__(self):
         self.n = None
         self.H = None
-        self.H_batched = None
+        self.Hb = None
         self.y0 = None
-        self.y0_batched = None
+        self.y0b = None
         self.exp_ops = None
 
     @abstractmethod


### PR DESCRIPTION
On top of https://github.com/dynamiqs/dynamiqs/pull/366. Related to DYN-133.

- The tests were coming hard to read IMO, I know it’s usually better to be explicit but we are in a situation where we need to test tons of configuration, so I think it's more readable to factor. Moreover it will help not copy-pasting all these lines for the incoming `smesolve` tests.
- The way we test the batching is a bit outdated, I added a minimal test for the flat batching which is good enough for now IMO.
- I refactord a bit how we handle the `flat_batching` option in `mesolve` to remove repeated code and to have a uniformized code with `sesolve` and `smesolve`.
- The `smesolve` batching is broken but I'm a lil' tired, I'll fix it once I have written proper tests for `smesolve`, because it's super annoying to fix without them.