### PR TITLE
Add TimeTensor [2/4]: implement `PWCTimeTensor`

### DIFF
--- a/tests/test_time_tensor.py
+++ b/tests/test_time_tensor.py
@@ -6,7 +6,7 @@ from dynamiqs.time_tensor import (
     CallableTimeTensor,
     ConstantTimeTensor,
     PWCTimeTensor,
-    _PWCTensor,
+    _PWCFactor,
 )
 
 
@@ -157,13 +157,13 @@ class TestPWCTimeTensor:
         # PWC factor 1
         t1 = torch.tensor([0, 1, 2, 3])
         v1 = torch.tensor([1, 10, 100])
-        f1 = _PWCTensor(t1, v1)
+        f1 = _PWCFactor(t1, v1)
         tensor1 = torch.tensor([[1, 2], [3, 4]])
 
         # PWC factor 2
         t2 = torch.tensor([1, 3, 5])
         v2 = torch.tensor([1, 1])
-        f2 = _PWCTensor(t2, v2)
+        f2 = _PWCFactor(t2, v2)
         tensor2 = torch.tensor([[1j, 1j], [1j, 1j]])
 
         factors = [f1, f2]

--- a/tests/test_time_tensor.py
+++ b/tests/test_time_tensor.py
@@ -180,6 +180,12 @@ class TestPWCTimeTensor:
         assert_equal(self.x(3.0), [[1j, 1j], [1j, 1j]])
         assert_equal(self.x(5.0), [[0, 0], [0, 0]])
 
+    def test_call_caching(self):
+        assert hash(self.x(-0.1)) == hash(self.x(-0.1)) == hash(self.x(-0.2))
+        assert hash(self.x(0.0)) == hash(self.x(0.0)) == hash(self.x(0.5))
+        assert hash(self.x(1.0)) == hash(self.x(1.0)) == hash(self.x(1.999))
+        assert hash(self.x(5.0)) == hash(self.x(5.0)) == hash(self.x(6.0))
+
     def test_view(self):
         x = self.x.view(1, 2, 2)
         assert_equal(x(-0.1), [[[0, 0], [0, 0]]])

--- a/tests/test_time_tensor.py
+++ b/tests/test_time_tensor.py
@@ -2,7 +2,12 @@ import pytest
 import torch
 from torch import Tensor
 
-from dynamiqs.time_tensor import CallableTimeTensor, ConstantTimeTensor
+from dynamiqs.time_tensor import (
+    CallableTimeTensor,
+    ConstantTimeTensor,
+    PWCTimeTensor,
+    _PWCTimeTensor,
+)
 
 
 def assert_equal(xt: Tensor, y: list):
@@ -144,3 +149,142 @@ class TestCallableTimeTensor:
         assert isinstance(x, CallableTimeTensor)
         assert_equal(x(0.0), [0, 1])
         assert_equal(x(1.0), [1, 3])
+
+
+class TestPrivatePWCTimeTensor:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        times = torch.tensor([0.0, 1.0, 2.0, 3.0])
+        values = torch.tensor([10, 100, 1000])  # (3,)
+        tensor = torch.tensor([[1, 2], [3, 4]])  # (2, 2)
+        self.x = _PWCTimeTensor(times, values, tensor)  # shape (2, 2)
+
+    def test_call(self):
+        assert_equal(self.x(-0.1), [[0, 0], [0, 0]])
+        assert_equal(self.x(0.0), [[10, 20], [30, 40]])
+        assert_equal(self.x(0.5), [[10, 20], [30, 40]])
+        assert_equal(self.x(0.999), [[10, 20], [30, 40]])
+        assert_equal(self.x(1.0), [[100, 200], [300, 400]])
+        assert_equal(self.x(1.999), [[100, 200], [300, 400]])
+        assert_equal(self.x(3.0), [[0, 0], [0, 0]])
+        assert_equal(self.x(5.0), [[0, 0], [0, 0]])
+
+    def test_view(self):
+        x = self.x.view(1, 2, 2)
+        assert_equal(x(0.0), [[[10, 20], [30, 40]]])
+
+    def test_adjoint(self):
+        times = torch.tensor([0.0, 1.0, 2.0])
+        values = torch.tensor([10, 100])
+        tensor = torch.tensor([[1.0 + 1.0j, 2.0 + 2.0j], [3.0 + 3.0j, 4.0 + 4.0j]])
+        x = _PWCTimeTensor(times, values, tensor)
+        x = x.adjoint()
+        res = torch.tensor([[10 - 10j, 30 - 30j], [20 - 20j, 40 - 40j]])
+        assert torch.equal(x(0.0), res)
+
+    def test_neg(self):
+        x = -self.x
+        assert_equal(x(0.0), [[-10, -20], [-30, -40]])
+
+    def test_mul(self):
+        # test type `Number`
+        x = self.x * 2
+        assert_equal(x(0.0), [[20, 40], [60, 80]])
+
+        # test type `Tensor`
+        x = self.x * torch.tensor([2])
+        assert_equal(x(0.0), [[20, 40], [60, 80]])
+
+    def test_rmul(self):
+        # test type `Number`
+        x = 2 * self.x
+        assert_equal(x(0.0), [[20, 40], [60, 80]])
+
+        # test type `Tensor`
+        x = torch.tensor([2]) * self.x
+        assert_equal(x(0.0), [[20, 40], [60, 80]])
+
+
+class TestPWCTimeTensor:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        times = torch.tensor([0.0, 1.0, 2.0, 3.0])
+        values = torch.tensor([10, 100, 1000])
+        tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.complex64)
+        pwc1 = _PWCTimeTensor(times, values, tensor)
+
+        times = torch.tensor([1.0, 2.0, 3.0, 4.0])
+        values = torch.tensor([1, 1, 1])
+        tensor = torch.tensor([[1j, 2j], [3j, 4j]])
+        pwc2 = _PWCTimeTensor(times, values, tensor)
+
+        static = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+        self.x = PWCTimeTensor([pwc1, pwc2], static=static)
+
+    def test_init(self):
+        assert torch.equal(self.x.times, torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0]))
+
+    def test_call(self):
+        assert_equal(self.x(-0.1), [[1, 1], [1, 1]])
+        assert_equal(self.x(0.0), [[11, 21], [31, 41]])
+        assert_equal(self.x(0.5), [[11, 21], [31, 41]])
+        assert_equal(self.x(0.999), [[11, 21], [31, 41]])
+        assert_equal(self.x(1.0), [[101 + 1j, 201 + 2j], [301 + 3j, 401 + 4j]])
+        assert_equal(self.x(1.999), [[101 + 1j, 201 + 2j], [301 + 3j, 401 + 4j]])
+        assert_equal(self.x(3.0), [[1 + 1j, 1 + 2j], [1 + 3j, 1 + 4j]])
+        assert_equal(self.x(5.0), [[1, 1], [1, 1]])
+
+    def test_view(self):
+        x = self.x.view(1, 2, 2)
+        assert_equal(x(0.0), [[[11, 21], [31, 41]]])
+
+    def test_adjoint(self):
+        x = self.x.adjoint()
+        assert_equal(x(1.0), [[101 - 1j, 301 - 3j], [201 - 2j, 401 - 4j]])
+
+    def test_neg(self):
+        x = -self.x
+        assert_equal(x(1.0), [[-101 - 1j, -201 - 2j], [-301 - 3j, -401 - 4j]])
+
+    def test_mul(self):
+        res = [[202 + 2j, 402 + 4j], [602 + 6j, 802 + 8j]]
+
+        # test type `Number`
+        x = self.x * 2
+        assert_equal(x(1.0), res)
+
+        # test type `Tensor`
+        x = self.x * torch.tensor([2])
+        assert_equal(x(1.0), res)
+
+    def test_rmul(self):
+        res = [[202 + 2j, 402 + 4j], [602 + 6j, 802 + 8j]]
+
+        # test type `Number`
+        x = 2 * self.x
+        assert_equal(x(1.0), res)
+
+        # test type `Tensor`
+        x = torch.tensor([2]) * self.x
+        assert_equal(x(1.0), res)
+
+    def test_add(self):
+        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+
+        # test type `Tensor`
+        x = self.x + tensor
+        assert isinstance(x, PWCTimeTensor)
+        assert_equal(x(1.0), [[102 + 1j, 202 + 2j], [302 + 3j, 402 + 4j]])
+
+        # test type `PWCTimeTensor`
+        x = self.x + self.x
+        assert isinstance(x, PWCTimeTensor)
+        assert_equal(x(1.0), [[202 + 2j, 402 + 4j], [602 + 6j, 802 + 8j]])
+
+    def test_radd(self):
+        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+
+        # test type `Tensor`
+        x = tensor + self.x
+        assert isinstance(x, PWCTimeTensor)
+        assert_equal(x(1.0), [[102 + 1j, 202 + 2j], [302 + 3j, 402 + 4j]])

--- a/tests/test_time_tensor.py
+++ b/tests/test_time_tensor.py
@@ -6,7 +6,7 @@ from dynamiqs.time_tensor import (
     CallableTimeTensor,
     ConstantTimeTensor,
     PWCTimeTensor,
-    _PWCTimeTensor,
+    _merge_pwc_times_values,
 )
 
 
@@ -151,122 +151,59 @@ class TestCallableTimeTensor:
         assert_equal(x(1.0), [1, 3])
 
 
-class TestPrivatePWCTimeTensor:
+class TestPWCTimeTensor:
     @pytest.fixture(autouse=True)
     def setup(self):
-        times = torch.tensor([0.0, 1.0, 2.0, 3.0])
-        values = torch.tensor([10, 100, 1000])  # (3,)
-        tensor = torch.tensor([[1, 2], [3, 4]])  # (2, 2)
-        self.x = _PWCTimeTensor(times, values, tensor)  # shape (2, 2)
+        times = torch.tensor([0, 1, 2, 3])
+        v1 = [1, 10, 0]
+        v2 = [0, 1, 1]
+        values = torch.tensor([v1, v2])  # (2, 3)
+        pwc1 = [[1, 2], [3, 4]]
+        pwc2 = [[1j, 1j], [1j, 1j]]
+        tensor = torch.tensor([pwc1, pwc2])  # (2, 2, 2)
+        self.x = PWCTimeTensor(times, values, tensor)  # shape at t: (2, 2)
 
     def test_call(self):
         assert_equal(self.x(-0.1), [[0, 0], [0, 0]])
-        assert_equal(self.x(0.0), [[10, 20], [30, 40]])
-        assert_equal(self.x(0.5), [[10, 20], [30, 40]])
-        assert_equal(self.x(0.999), [[10, 20], [30, 40]])
-        assert_equal(self.x(1.0), [[100, 200], [300, 400]])
-        assert_equal(self.x(1.999), [[100, 200], [300, 400]])
+        assert_equal(self.x(0.0), [[1, 2], [3, 4]])
+        assert_equal(self.x(0.5), [[1, 2], [3, 4]])
+        assert_equal(self.x(0.999), [[1, 2], [3, 4]])
+        assert_equal(self.x(1.0), [[10 + 1j, 20 + 1j], [30 + 1j, 40 + 1j]])
+        assert_equal(self.x(1.999), [[10 + 1j, 20 + 1j], [30 + 1j, 40 + 1j]])
+        assert_equal(self.x(2.0), [[1j, 1j], [1j, 1j]])
         assert_equal(self.x(3.0), [[0, 0], [0, 0]])
         assert_equal(self.x(5.0), [[0, 0], [0, 0]])
 
     def test_view(self):
         x = self.x.view(1, 2, 2)
-        assert_equal(x(0.0), [[[10, 20], [30, 40]]])
-
-    def test_adjoint(self):
-        times = torch.tensor([0.0, 1.0, 2.0])
-        values = torch.tensor([10, 100])
-        tensor = torch.tensor([[1.0 + 1.0j, 2.0 + 2.0j], [3.0 + 3.0j, 4.0 + 4.0j]])
-        x = _PWCTimeTensor(times, values, tensor)
-        x = x.adjoint()
-        res = torch.tensor([[10 - 10j, 30 - 30j], [20 - 20j, 40 - 40j]])
-        assert torch.equal(x(0.0), res)
-
-    def test_neg(self):
-        x = -self.x
-        assert_equal(x(0.0), [[-10, -20], [-30, -40]])
-
-    def test_mul(self):
-        # test type `Number`
-        x = self.x * 2
-        assert_equal(x(0.0), [[20, 40], [60, 80]])
-
-        # test type `Tensor`
-        x = self.x * torch.tensor([2])
-        assert_equal(x(0.0), [[20, 40], [60, 80]])
-
-    def test_rmul(self):
-        # test type `Number`
-        x = 2 * self.x
-        assert_equal(x(0.0), [[20, 40], [60, 80]])
-
-        # test type `Tensor`
-        x = torch.tensor([2]) * self.x
-        assert_equal(x(0.0), [[20, 40], [60, 80]])
-
-
-class TestPWCTimeTensor:
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        times = torch.tensor([0.0, 1.0, 2.0, 3.0])
-        values = torch.tensor([10, 100, 1000])
-        tensor = torch.tensor([[1, 2], [3, 4]], dtype=torch.complex64)
-        pwc1 = _PWCTimeTensor(times, values, tensor)
-
-        times = torch.tensor([1.0, 2.0, 3.0, 4.0])
-        values = torch.tensor([1, 1, 1])
-        tensor = torch.tensor([[1j, 2j], [3j, 4j]])
-        pwc2 = _PWCTimeTensor(times, values, tensor)
-
-        static = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
-        self.x = PWCTimeTensor([pwc1, pwc2], static=static)
-
-    def test_init(self):
-        assert torch.equal(self.x.times, torch.tensor([0.0, 1.0, 2.0, 3.0, 4.0]))
-
-    def test_call(self):
-        assert_equal(self.x(-0.1), [[1, 1], [1, 1]])
-        assert_equal(self.x(0.0), [[11, 21], [31, 41]])
-        assert_equal(self.x(0.5), [[11, 21], [31, 41]])
-        assert_equal(self.x(0.999), [[11, 21], [31, 41]])
-        assert_equal(self.x(1.0), [[101 + 1j, 201 + 2j], [301 + 3j, 401 + 4j]])
-        assert_equal(self.x(1.999), [[101 + 1j, 201 + 2j], [301 + 3j, 401 + 4j]])
-        assert_equal(self.x(3.0), [[1 + 1j, 1 + 2j], [1 + 3j, 1 + 4j]])
-        assert_equal(self.x(5.0), [[1, 1], [1, 1]])
-
-    def test_view(self):
-        x = self.x.view(1, 2, 2)
-        assert_equal(x(0.0), [[[11, 21], [31, 41]]])
+        assert_equal(x(-0.1), [[[0, 0], [0, 0]]])
+        assert_equal(x(0.0), [[[1, 2], [3, 4]]])
 
     def test_adjoint(self):
         x = self.x.adjoint()
-        assert_equal(x(1.0), [[101 - 1j, 301 - 3j], [201 - 2j, 401 - 4j]])
+        assert_equal(x(1.0), [[10 - 1j, 30 - 1j], [20 - 1j, 40 - 1j]])
 
     def test_neg(self):
         x = -self.x
-        assert_equal(x(1.0), [[-101 - 1j, -201 - 2j], [-301 - 3j, -401 - 4j]])
+        assert_equal(x(0.0), [[-1, -2], [-3, -4]])
 
     def test_mul(self):
-        res = [[202 + 2j, 402 + 4j], [602 + 6j, 802 + 8j]]
-
         # test type `Number`
         x = self.x * 2
-        assert_equal(x(1.0), res)
+        assert_equal(x(0.0), [[2, 4], [6, 8]])
 
         # test type `Tensor`
         x = self.x * torch.tensor([2])
-        assert_equal(x(1.0), res)
+        assert_equal(x(0.0), [[2, 4], [6, 8]])
 
     def test_rmul(self):
-        res = [[202 + 2j, 402 + 4j], [602 + 6j, 802 + 8j]]
-
         # test type `Number`
         x = 2 * self.x
-        assert_equal(x(1.0), res)
+        assert_equal(x(0.0), [[2, 4], [6, 8]])
 
         # test type `Tensor`
         x = torch.tensor([2]) * self.x
-        assert_equal(x(1.0), res)
+        assert_equal(x(0.0), [[2, 4], [6, 8]])
 
     def test_add(self):
         tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
@@ -274,12 +211,13 @@ class TestPWCTimeTensor:
         # test type `Tensor`
         x = self.x + tensor
         assert isinstance(x, PWCTimeTensor)
-        assert_equal(x(1.0), [[102 + 1j, 202 + 2j], [302 + 3j, 402 + 4j]])
+        assert_equal(x(-0.1), [[1, 1], [1, 1]])
+        assert_equal(x(0.0), [[2, 3], [4, 5]])
 
         # test type `PWCTimeTensor`
         x = self.x + self.x
         assert isinstance(x, PWCTimeTensor)
-        assert_equal(x(1.0), [[202 + 2j, 402 + 4j], [602 + 6j, 802 + 8j]])
+        assert_equal(x(0.0), [[2, 4], [6, 8]])
 
     def test_radd(self):
         tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
@@ -287,4 +225,28 @@ class TestPWCTimeTensor:
         # test type `Tensor`
         x = tensor + self.x
         assert isinstance(x, PWCTimeTensor)
-        assert_equal(x(1.0), [[102 + 1j, 202 + 2j], [302 + 3j, 402 + 4j]])
+        assert_equal(x(-0.1), [[1, 1], [1, 1]])
+        assert_equal(x(0.0), [[2, 3], [4, 5]])
+
+
+def test_merge_pwc_times_values():
+    # test merge
+    t1 = torch.tensor([0, 10, 20])
+    t2 = torch.tensor([0, 5, 10, 30])
+    v1 = torch.tensor([[1, 2], [3, 4]])  # (2, 2)
+    v2 = torch.tensor([[1, 2, 3]])  # (1, 3)
+    t, v = _merge_pwc_times_values(t1, t2, v1, v2)
+    assert torch.equal(t, torch.tensor([0, 5, 10, 20, 30]))
+    assert v.shape == (3, 4)
+    assert torch.equal(v, torch.tensor([[1, 1, 2, 0], [3, 3, 4, 0], [1, 2, 3, 3]]))
+
+    # test batching (...) = (7, 8)
+    v1 = v1.view(2, 2, 1, 1).expand(2, 2, 7, 8)  # (2, 2, 7, 8)
+    print(v1.shape)
+    v2 = v2.view(1, 3, 1, 1).expand(1, 3, 7, 8)  # (1, 3, 7, 8)
+    print(v2.shape)
+    t, v = _merge_pwc_times_values(t1, t2, v1, v2)
+    assert torch.equal(t, torch.tensor([0, 5, 10, 20, 30]))
+    assert v.shape == (3, 4, 7, 8)
+    v11 = v[:, :, 1, 1]
+    assert torch.equal(v11, torch.tensor([[1, 1, 2, 0], [3, 3, 4, 0], [1, 2, 3, 3]]))


### PR DESCRIPTION
Related to DYN-137.
Stacked on #372.
Replaces #233 except adapting the `Propagator` solver (will do later, see DYN-47).

The batching is held by the values tensor:
```python
import dynamiqs as dq
import torch
n = 8
a = dq.destroy(n)
# define pwc H  = drive x a
times = torch.linspace(0, 1.0, 11)
nseeds = 30
drive = dq.rand_complex((nseeds, 10))  # (30, 10)
Hpwc = dq.totime((times, drive, a))
Hpwc.shape  # (30, 8, 8) --> shape at a given time
```

We can sum tensors with non-aligned times:
```python
n = 8
a = dq.destroy(n)

# static
Hstatic = a.mH @ a
print(Hstatic.shape)  # (8, 8)

# total: H = adag @ a + drive * a + drive.conj() * adag
H = Hstatic + Hpwc + Hpwc.mH
print(H.shape)  # (30, 8, 8)

# test at time 0.0
Hse = Hstatic.expand(nseeds, n, n)
drive0 = drive[0][..., None, None]
assert torch.equal(H(0.0), Hse + drive0 * a + drive0.conj() * a.mH)

# test at time 0.12
drive1 = drive[1][..., None, None]
assert torch.equal(H(0.12), Hse + drive1 * a + drive1.conj() * a.mH)
```