### PR TITLE
Add TimeTensor [3/4]: implement ModulatedTimeTensor

### DIFF
--- a/tests/test_time_tensor.py
+++ b/tests/test_time_tensor.py
@@ -5,7 +5,9 @@ from torch import Tensor
 from dynamiqs.time_tensor import (
     CallableTimeTensor,
     ConstantTimeTensor,
+    ModulatedTimeTensor,
     PWCTimeTensor,
+    _ModulatedFactor,
     _PWCFactor,
 )
 
@@ -239,3 +241,81 @@ class TestPWCTimeTensor:
         assert isinstance(x, PWCTimeTensor)
         assert_equal(x(-0.1), [[1, 1], [1, 1]])
         assert_equal(x(0.0), [[2, 3], [4, 5]])
+
+
+class TestModulatedTimeTensor:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        one = torch.tensor(1.0)
+
+        # modulated factor 1
+        eps1 = lambda t: (0.5 * t + 1.0j) * one
+        eps1_0 = eps1(0.0)
+        f1 = _ModulatedFactor(eps1, eps1_0)
+        tensor1 = torch.tensor([[1, 2], [3, 4]])
+
+        # modulated factor 2
+        eps2 = lambda t: t**2 * one
+        eps2_0 = eps2(0.0)
+        f2 = _ModulatedFactor(eps2, eps2_0)
+        tensor2 = torch.tensor([[1j, 1j], [1j, 1j]])
+
+        factors = [f1, f2]
+        tensors = torch.stack([tensor1, tensor2])
+        self.x = ModulatedTimeTensor(factors, tensors)
+
+    def test_call(self):
+        assert_equal(self.x(0.0), [[1.0j, 2.0j], [3.0j, 4.0j]])
+        assert_equal(self.x(2.0), [[1.0 + 5.0j, 2.0 + 6.0j], [3.0 + 7.0j, 4.0 + 8.0j]])
+
+    def test_view(self):
+        x = self.x.view(1, 2, 2)
+        assert_equal(x(0.0), [[[1.0j, 2.0j], [3.0j, 4.0j]]])
+        assert_equal(x(2.0), [[[1.0 + 5.0j, 2.0 + 6.0j], [3.0 + 7.0j, 4.0 + 8.0j]]])
+
+    def test_adjoint(self):
+        x = self.x.adjoint()
+        assert_equal(x(0.0), [[-1.0j, -3.0j], [-2.0j, -4.0j]])
+
+    def test_neg(self):
+        x = -self.x
+        assert_equal(x(0.0), [[-1.0j, -2.0j], [-3.0j, -4.0j]])
+
+    def test_mul(self):
+        # test type `Number`
+        x = self.x * 2
+        assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
+
+        # test type `Tensor`
+        x = self.x * torch.tensor([2])
+        assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
+
+    def test_rmul(self):
+        # test type `Number`
+        x = 2 * self.x
+        assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
+
+        # test type `Tensor`
+        x = torch.tensor([2]) * self.x
+        assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
+
+    def test_add(self):
+        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+
+        # test type `Tensor`
+        x = self.x + tensor
+        assert isinstance(x, ModulatedTimeTensor)
+        assert_equal(x(0.0), [[1.0 + 1.0j, 1.0 + 2.0j], [1.0 + 3.0j, 1.0 + 4.0j]])
+
+        # test type `ModulatedTimeTensor`
+        x = self.x + self.x
+        assert isinstance(x, ModulatedTimeTensor)
+        assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
+
+    def test_radd(self):
+        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+
+        # test type `Tensor`
+        x = tensor + self.x
+        assert isinstance(x, ModulatedTimeTensor)
+        assert_equal(x(0.0), [[1.0 + 1.0j, 1.0 + 2.0j], [1.0 + 3.0j, 1.0 + 4.0j]])


### PR DESCRIPTION
Related to DYN-137.
Stacked on https://github.com/dynamiqs/dynamiqs/pull/374.

Very similar implementation as `PWCTimeTensor`. Most of it is copy-pasted.

Some things left for later PRs:

- Allow for callable factors of signature `t -> Number` (currently only supports `t -> Tensor`
- Take care of batching during addition between different `ModulatedTimeTensor` (same comment for `PWCTimeTensor`).