### PR TITLE
Use PWC Hamiltonian format in propagator solvers

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -146,3 +146,7 @@ def cache(func=None, *, maxsize: int = 1):
         return grad_cached_func(*args, grad_enabled=torch.is_grad_enabled(), **kwargs)
 
     return wrapper
+
+
+def merge_tensors(*x: Tensor) -> Tensor:
+    return torch.cat(x).unique(sorted=True)

--- a/dynamiqs/mesolve/propagator.py
+++ b/dynamiqs/mesolve/propagator.py
@@ -10,17 +10,20 @@ from .me_solver import MESolver
 class MEPropagator(MESolver, Propagator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.lindbladian = slindbladian(self.H, self.L)  # (..., n^2, n^2)
+        self.lindbladian = cache(lambda H: slindbladian(H, self.L))  # (..., n^2, n^2)
         self.y0 = operator_to_vector(self.y0)  # (..., n^2, 1)
 
     @cache
-    def propagator(self, delta_t: float) -> Tensor:
+    def propagator(self, lindbladian: Tensor, delta_t: float) -> Tensor:
         # -> (..., n^2, n^2)
-        return torch.matrix_exp(self.lindbladian * delta_t)
+        return torch.matrix_exp(lindbladian * delta_t)
 
     def forward(self, t: float, delta_t: float, rho_vec: Tensor) -> Tensor:
         # rho_vec: (..., n^2, 1) -> (..., n^2, 1)
-        return self.propagator(delta_t) @ rho_vec
+        H = self.H(t)
+        lindbladian = self.lindbladian(H)
+        propagator = self.propagator(lindbladian, delta_t)
+        return propagator @ rho_vec
 
     def save(self, y: Tensor):
         # override `save` method to convert `y` from vector to operator

--- a/dynamiqs/sesolve/propagator.py
+++ b/dynamiqs/sesolve/propagator.py
@@ -7,10 +7,12 @@ from ..solvers.propagator import Propagator
 
 class SEPropagator(Propagator):
     @cache
-    def propagator(self, delta_t: float) -> Tensor:
+    def propagator(self, H: Tensor, delta_t: float) -> Tensor:
         # -> (..., n, n)
-        return torch.matrix_exp(-1j * self.H * delta_t)
+        return torch.matrix_exp(-1j * H * delta_t)
 
     def forward(self, t: float, delta_t: float, psi: Tensor) -> Tensor:
         # psi: (..., n, 1) -> (..., n, 1)
-        return self.propagator(delta_t) @ psi
+        H = self.H(t)
+        propagator = self.propagator(H, delta_t)
+        return propagator @ psi

--- a/dynamiqs/solvers/solver.py
+++ b/dynamiqs/solvers/solver.py
@@ -36,8 +36,8 @@ class Solver(ABC):
         self.H = H
         self.t0 = 0.0
         self.y0 = y0
-        self.tsave = tsave.numpy()
-        self.tmeas = tmeas.numpy()
+        self.tsave = tsave.numpy(force=True)
+        self.tmeas = tmeas.numpy(force=True)
         self.E = E
         self.options = options
 

--- a/dynamiqs/time_tensor.py
+++ b/dynamiqs/time_tensor.py
@@ -6,7 +6,7 @@ from typing import get_args
 import torch
 from torch import Tensor
 
-from ._utils import cache, check_time_tensor, obj_type_str, type_str
+from ._utils import cache, check_time_tensor, merge_tensors, obj_type_str, type_str
 from .utils.tensor_types import (
     ArrayLike,
     Number,
@@ -419,7 +419,7 @@ class PWCTimeTensor(TimeTensor):
         self.static = torch.zeros_like(self.tensors[0]) if static is None else static
 
         # merge all times
-        self.times = torch.cat([x.times for x in self.factors]).unique(sorted=True)
+        self.times = merge_tensors(*(x.times for x in self.factors))
 
     @property
     def dtype(self) -> torch.dtype:


### PR DESCRIPTION
Closes DYN-47.

Replaces #233. I copy-paste a comment from there to motivate the PR (mostly performance related 🚀):
> Notably it allows to use the propagator solver for optimal control problems with PWC drives, which leads to a huge speedup (e.g. optimisation of Fock 2 preparation with cavity + transmon goes from ~3 minutes to ~20 seconds on my CPU). I think it’s important to have a good enough PWC Hamiltonian sesolve solver, because this is the first step of many optimal control proof-of-concept, it's a quick way to know wether something is doable or not.

The important part is that we need to evolve between each time in `self.tstop`, and also each time in `H.times` (otherwise we will _skip_ a PWC part). Thus we create a new `self.tstop_new` times array in the `Propagator` base class to evolve in-between the correct times.

<details>
  <summary>Handcrafted test to check that the caching and the stopping times are correct</summary>

```python
import dynamiqs as dq
import numpy as np
from matplotlib import pyplot as plt

dq.mplstyle()

n = 16
a = dq.destroy(n)

times = [1, 2]
values = [1]

H = dq.totime((times, values, a.mH @ a))
jump_ops = [dq.zero(n)]
psi0 = dq.coherent(n, 2.0)
tsave = np.linspace(0, 3.0, 11)  # [0.0, 0.3, 0.6, ..., 3.0]
exp_ops = [dq.position(n)]
solver = dq.solver.Propagator()
x = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops, solver=solver).expects.real[0]
plt.plot(tsave, x, '--o')
for t in times:
    plt.axvline(t, color='gray', ls='--')
plt.xlim(tsave[0], tsave[-1]);
```

![050e7a38-d294-4840-9c81-787d4a0c8db8](https://github.com/dynamiqs/dynamiqs/assets/38159029/a4c98c72-b985-449d-8691-15b055fc75e0)

```text
Starting from t=0.00, evolving for delta_t=0.3
  └── compute propagator: id(H)=6298916400, delta_t=0.3
Starting from t=0.30, evolving for delta_t=0.3
Starting from t=0.60, evolving for delta_t=0.3
Starting from t=0.90, evolving for delta_t=0.1
  └── compute propagator: id(H)=6298916400, delta_t=0.1  # delta_t changed
Starting from t=1.00, evolving for delta_t=0.2
  └── compute propagator: id(H)=6298916560, delta_t=0.2  # H changed
Starting from t=1.20, evolving for delta_t=0.3
  └── compute propagator: id(H)=6298916560, delta_t=0.3  # delta_t changed
Starting from t=1.50, evolving for delta_t=0.3
Starting from t=1.80, evolving for delta_t=0.2
  └── compute propagator: id(H)=6298916560, delta_t=0.2  # delta_t changed
Starting from t=2.00, evolving for delta_t=0.1
  └── compute propagator: id(H)=6298916800, delta_t=0.1  # H changed
Starting from t=2.10, evolving for delta_t=0.3
  └── compute propagator: id(H)=6298916800, delta_t=0.3  # delta_t changed
Starting from t=2.40, evolving for delta_t=0.3
Starting from t=2.70, evolving for delta_t=0.3
```

</details>