### PR TITLE
Change API of slindbladian

### DIFF
--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from math import sqrt
 
 import torch
@@ -174,16 +176,16 @@ def sdissipator(L: Tensor) -> Tensor:
     $$
 
     Args:
-        L _(..., n, n)_: Jump operator (an arbitrary operator).
+        L _(..., n, n)_: Jump operator.
 
     Returns:
-        _(..., n^2, n^2)_ Dissipator superoperator.
+        _(..., n^2, n^2)_ Dissipation superoperator.
     """
     LdagL = L.mH @ L
     return sprepost(L, L.mH) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
 
 
-def slindbladian(H: Tensor, L: Tensor) -> Tensor:
+def slindbladian(H: Tensor, jump_ops: list[Tensor]) -> Tensor:
     r"""Returns the Lindbladian superoperator (in matrix form).
 
     The Lindbladian superoperator $\mathcal{L}$ is defined by:
@@ -209,9 +211,10 @@ def slindbladian(H: Tensor, L: Tensor) -> Tensor:
 
     Args:
         H _(..., n, n)_: Hamiltonian.
-        L _(..., N, n, n)_: Sequence of jump operators (arbitrary operators).
+        jump_ops _(list of tensors of shape (..., n, n))_: List of jump operators.
 
     Returns:
         _(..., n^2, n^2)_ Lindbladian superoperator.
     """
-    return -1j * (spre(H) - spost(H)) + sdissipator(L).sum(0)
+    Ls = torch.stack(jump_ops)
+    return -1j * (spre(H) - spost(H)) + sdissipator(Ls).sum(0)

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -211,7 +211,8 @@ def slindbladian(H: Tensor, jump_ops: list[Tensor] | Tensor) -> Tensor:
 
     Args:
         H _(..., n, n)_: Hamiltonian.
-        jump_ops _(list of tensors of shape (..., n, n))_: List of jump operators.
+        jump_ops _(list of tensors of shape (..., n, n), or tensor of shape (N, ..., n,
+            n))_: List of jump operators.
 
     Returns:
         _(..., n^2, n^2)_ Lindbladian superoperator.

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -211,8 +211,8 @@ def slindbladian(H: Tensor, jump_ops: list[Tensor] | Tensor) -> Tensor:
 
     Args:
         H _(..., n, n)_: Hamiltonian.
-        jump_ops _(list of tensors of shape (..., n, n), or tensor of shape (N, ..., n,
-            n))_: List of jump operators.
+        jump_ops _(list of tensor (..., n, n), or tensor (N, ..., n, n))_: Sequence of
+            jump operators.
 
     Returns:
         _(..., n^2, n^2)_ Lindbladian superoperator.

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -185,7 +185,7 @@ def sdissipator(L: Tensor) -> Tensor:
     return sprepost(L, L.mH) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
 
 
-def slindbladian(H: Tensor, jump_ops: list[Tensor]) -> Tensor:
+def slindbladian(H: Tensor, jump_ops: list[Tensor] | Tensor) -> Tensor:
     r"""Returns the Lindbladian superoperator (in matrix form).
 
     The Lindbladian superoperator $\mathcal{L}$ is defined by:
@@ -216,5 +216,5 @@ def slindbladian(H: Tensor, jump_ops: list[Tensor]) -> Tensor:
     Returns:
         _(..., n^2, n^2)_ Lindbladian superoperator.
     """
-    Ls = torch.stack(jump_ops)
+    Ls = torch.stack(jump_ops) if isinstance(jump_ops, list) else jump_ops
     return -1j * (spre(H) - spost(H)) + sdissipator(Ls).sum(0)


### PR DESCRIPTION
Closes DYN-117.

Make the API of `dq.slindbladian` consistent with `dq.mesolve`, by accepting a list of jump operators.

Ideally, I think we should also accept ArrayLike and make the proper conversions, but it's not super important for now.