### PR TITLE
Switch doctest configuration from PyTorch to JAX [1/?]

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,7 +1,7 @@
 from typing import Sequence
 
+import jax.numpy as jnp
 import pytest
-import torch
 from matplotlib import pyplot as plt
 from sybil import Sybil
 from sybil.evaluators.python import PythonEvaluator
@@ -12,8 +12,8 @@ import dynamiqs
 
 # doctest fixture
 @pytest.fixture(scope='session', autouse=True)
-def torch_set_printoptions():
-    torch.set_printoptions(precision=3, sci_mode=False)
+def jax_set_printoptions():
+    jnp.set_printoptions(precision=3, suppress=True)
 
 
 # doctest fixture

--- a/dynamiqs/conftest.py
+++ b/dynamiqs/conftest.py
@@ -1,8 +1,8 @@
 from doctest import ELLIPSIS
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
-import torch
 from matplotlib import pyplot as plt
 from sybil import Sybil
 from sybil.parsers.doctest import DocTestParser
@@ -15,13 +15,13 @@ def sybil_setup(namespace):
     namespace['dq'] = dynamiqs
     namespace['np'] = np
     namespace['plt'] = plt
-    namespace['torch'] = torch
+    namespace['jnp'] = jnp
 
 
 # doctest fixture
 @pytest.fixture(scope='session', autouse=True)
-def torch_set_printoptions():
-    torch.set_printoptions(precision=3, sci_mode=False)
+def jax_set_printoptions():
+    jnp.set_printoptions(precision=3, suppress=True)
 
 
 # doctest fixture


### PR DESCRIPTION
This allows running doctests on functions that are switched from PyTorch to JAX.