### PR TITLE
Switch `dynamiqs.utils` from PyTorch to JAX [2/?]

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -135,10 +135,7 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
     options:
         table: true
         members:
-        - to_tensor
-        - to_numpy
         - to_qutip
-        - from_qutip
 
 ### Wigner distribution
 
@@ -170,7 +167,6 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
         members:
         - rand_real
         - rand_complex
-        - pwc_pulse
         - snap_gate
         - cd_gate
 

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -7,7 +7,8 @@ import torch
 from methodtools import lru_cache
 from torch import Tensor
 
-from .utils.utils import isket
+# TODO: remove (keep name to avoid ImportError while transitioning from PyTorch to JAX)
+to_device = None
 
 
 def type_str(type: Any) -> str:
@@ -19,34 +20,6 @@ def type_str(type: Any) -> str:
 
 def obj_type_str(x: Any) -> str:
     return type_str(type(x))
-
-
-def to_device(device: str | torch.device | None) -> torch.device:
-    if device is None:
-        torch_device = torch.ones(1).device  # default device
-    elif isinstance(device, str):
-        torch_device = torch.device(device)
-    elif isinstance(device, torch.device):
-        torch_device = device
-    else:
-        raise TypeError(
-            'Argument `device` must be a string, a `torch.device` or `None` but has'
-            f' type {obj_type_str(device)}.'
-        )
-
-    if torch_device.type == 'cuda' and torch_device.index is None:
-        torch_device = torch.device(
-            torch_device.type, index=torch.cuda.current_device()
-        )
-
-    return torch_device
-
-
-def hdim(x: Tensor) -> int:
-    if isket(x):
-        return x.size(-2)
-    else:
-        return x.size(-1)
 
 
 def check_time_tensor(x: Tensor, arg_name: str, allow_empty=False):

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
-from cmath import exp as cexp
-from math import prod, sqrt
-from typing import get_args
+from math import prod
 
-import torch
-from torch import Tensor
+import jax
+import jax.numpy as jnp
+from jax import Array
+from jax.typing import ArrayLike
 
-from .._utils import to_device
-from .tensor_types import ArrayLike, Number, get_cdtype, to_tensor
-from .utils import tensprod
+from .tensor_types import get_cdtype
+from .utils import dag, tensprod
 
 __all__ = [
     'eye',
@@ -32,11 +31,7 @@ __all__ = [
 ]
 
 
-def eye(
-    *dims: int,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def eye(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the identity operator.
 
     If only a single dimension is provided, `eye` returns the identity operator
@@ -46,35 +41,32 @@ def eye(
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(n, n)_ Identity operator (with _n_ the product of dimensions in `dims`).
+        _(array of shape (n, n))_ Identity operator (with _n_ the product of
+            dimensions in `dims`).
 
     Examples:
         >>> dq.eye(4)
-        tensor([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j]])
+        Array([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j]], dtype=complex64)
         >>> dq.eye(2, 3)
-        tensor([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j]])
+        Array([[1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j]], dtype=complex64)
     """
+    dtype = get_cdtype(dtype)
     dim = prod(dims)
-    return torch.eye(dim, dtype=get_cdtype(dtype), device=device)
+    return jnp.eye(dim, dtype=dtype)
 
 
-def zero(
-    *dims: int,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def zero(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the null operator.
 
     If only a single dimension is provided, `zero` returns the null operator
@@ -84,35 +76,34 @@ def zero(
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(n, n)_ Null operator (with _n_ the product of dimensions in `dims`).
+        _(array of shape (n, n))_ Null operator (with _n_ the product of dimensions
+            in `dims`).
 
     Examples:
         >>> dq.zero(4)
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
         >>> dq.zero(2, 3)
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
     """
+    dtype = get_cdtype(dtype)
     dim = prod(dims)
-    return torch.zeros(dim, dim, dtype=get_cdtype(dtype), device=device)
+    return jnp.zeros((dim, dim), dtype=dtype)
 
 
 def destroy(
-    *dims: int,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor | tuple[Tensor, ...]:
+    *dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array | tuple[Array, ...]:
     r"""Returns a bosonic annihilation operator, or a tuple of annihilation operators in
     a multi-mode system.
 
@@ -123,63 +114,55 @@ def destroy(
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array(s).
 
     Returns:
-        _(tensor or tuple of tensors)_ Annihilation operator of given dimension, or
+        _(array or tuple of arrays)_ Annihilation operator of given dimension, or
             tuple of annihilation operators in a multi-mode system.
 
     Examples:
         >>> dq.destroy(4)
-        tensor([[0.000+0.j, 1.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 1.414+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 1.732+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j]])
+        Array([[0.   +0.j, 1.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 1.414+0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 1.732+0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j]], dtype=complex64)
         >>> a, b = dq.destroy(2, 3)
         >>> a
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
         >>> b
-        tensor([[0.000+0.j, 1.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 1.414+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 1.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 1.414+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j]])
-    """
-    cdtype = get_cdtype(dtype)
-    device = to_device(device)
-    if len(dims) == 1:
-        return _destroy_single(dims[0], dtype=cdtype, device=device)
+        Array([[0.   +0.j, 1.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 1.414+0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 1.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 1.414+0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j]],      dtype=complex64)
+    """  # noqa: E501
+    dtype = get_cdtype(dtype)
 
-    a = [_destroy_single(dim, dtype=cdtype, device=device) for dim in dims]
-    I = [eye(dim, dtype=cdtype, device=device) for dim in dims]
+    if len(dims) == 1:
+        return _destroy_single(dims[0], dtype=dtype)
+
+    a = [_destroy_single(dim, dtype=dtype) for dim in dims]
+    I = [eye(dim, dtype=dtype) for dim in dims]
     return tuple(
         tensprod(*[a[j] if i == j else I[j] for j in range(len(dims))])
         for i in range(len(dims))
     )
 
 
-def _destroy_single(
-    dim: int,
-    *,
-    dtype: torch.complex64 | torch.complex128,
-    device: torch.device,
-) -> Tensor:
+def _destroy_single(dim: int, *, dtype: jnp.complex64 | jnp.complex128) -> Array:
     """Bosonic annihilation operator."""
-    return torch.arange(1, dim, device=device).sqrt().diag(1).to(dtype)
+    return jnp.diag(jnp.sqrt(jnp.arange(1, stop=dim, dtype=dtype)), k=1)
 
 
 def create(
-    *dims: int,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor | tuple[Tensor, ...]:
+    *dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array | tuple[Array, ...]:
     r"""Returns a bosonic creation operator, or a tuple of creation operators in a
     multi-mode system.
 
@@ -190,64 +173,53 @@ def create(
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array(s).
 
     Returns:
-        _(tensor or tuple of tensors)_ Creation operator of given dimension, or tuple
+        _(array or tuple of arrays)_ Creation operator of given dimension, or tuple
             of creation operators in a multi-mode system.
 
     Examples:
         >>> dq.create(4)
-        tensor([[0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [1.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 1.414+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 1.732+0.j, 0.000+0.j]])
+        Array([[0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [1.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 1.414+0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 1.732+0.j, 0.   +0.j]], dtype=complex64)
         >>> a, b = dq.create(2, 3)
         >>> a
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
         >>> b
-        tensor([[0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [1.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 1.414+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 1.000+0.j, 0.000+0.j, 0.000+0.j],
-                [0.000+0.j, 0.000+0.j, 0.000+0.j, 0.000+0.j, 1.414+0.j, 0.000+0.j]])
-    """
-    cdtype = get_cdtype(dtype)
-    device = to_device(device)
-    if len(dims) == 1:
-        return _create_single(dims[0], dtype=cdtype, device=device)
+        Array([[0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [1.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 1.414+0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 1.   +0.j, 0.   +0.j, 0.   +0.j],
+               [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 1.414+0.j, 0.   +0.j]],      dtype=complex64)
+    """  # noqa: E501
+    dtype = get_cdtype(dtype)
 
-    adag = [_create_single(dim, dtype=cdtype, device=device) for dim in dims]
-    I = [eye(dim, dtype=cdtype, device=device) for dim in dims]
+    if len(dims) == 1:
+        return _create_single(dims[0], dtype=dtype)
+
+    adag = [_create_single(dim, dtype=dtype) for dim in dims]
+    I = [eye(dim, dtype=dtype) for dim in dims]
     return tuple(
         tensprod(*[adag[j] if i == j else I[j] for j in range(len(dims))])
         for i in range(len(dims))
     )
 
 
-def _create_single(
-    dim: int,
-    *,
-    dtype: torch.complex64 | torch.complex128,
-    device: torch.device,
-) -> Tensor:
+def _create_single(dim: int, *, dtype: jnp.complex64 | jnp.complex128) -> Array:
     """Bosonic creation operator."""
-    return torch.arange(1, dim, device=device).sqrt().diag(-1).to(dtype)
+    return jnp.diag(jnp.sqrt(jnp.arange(1, stop=dim, dtype=dtype)), k=-1)
 
 
-def number(
-    dim: int,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def number(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the number operator of a bosonic mode.
 
     It is defined by $n = a^\dag a$, where $a$ and $a^\dag$ are the annihilation and
@@ -255,28 +227,23 @@ def number(
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(dim, dim)_ Number operator.
+        _(array of shape (dim, dim))_ Number operator.
 
     Examples:
         >>> dq.number(4)
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 2.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 3.+0.j]])
+        Array([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 2.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 3.+0.j]], dtype=complex64)
     """
-    return torch.arange(dim, device=device).diag().to(get_cdtype(dtype))
+    dtype = get_cdtype(dtype)
+    return jnp.diag(jnp.arange(0, stop=dim, dtype=dtype))
 
 
-def parity(
-    dim: int,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def parity(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the parity operator of a bosonic mode.
 
     It is defined by $P = e^{i\pi a^\dag a}$, where $a$ and $a^\dag$ are the
@@ -284,31 +251,27 @@ def parity(
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(dim, dim)_ Parity operator.
+        _(array of shape (dim, dim))_ Parity operator.
 
     Examples:
         >>> dq.parity(4)
-        tensor([[ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
-                [ 0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j],
-                [ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j],
-                [ 0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j]])
+        Array([[ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
+               [ 0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j],
+               [ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j],
+               [ 0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j]], dtype=complex64)
     """
-    diag_values = torch.ones(dim, device=device, dtype=get_cdtype(dtype))
-    diag_values[1::2] = -1
-    return diag_values.diag()
+    dtype = get_cdtype(dtype)
+    diag_values = jnp.ones(dim, dtype=dtype)
+    diag_values = diag_values.at[1::2].set(-1)
+    return jnp.diag(diag_values)
 
 
 def displace(
-    dim: int,
-    alpha: Number | ArrayLike,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dim: int, alpha: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array:
     r"""Returns the displacement operator of complex amplitude $\alpha$.
 
     It is defined by
@@ -319,42 +282,33 @@ def displace(
 
     Args:
         dim: Dimension of the Hilbert space.
-        alpha _(...)_: Displacement amplitude.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        alpha _(array_like of shape (...))_: Displacement amplitude.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(..., dim, dim)_ Displacement operator.
+        _(array of shape (..., dim, dim))_ Displacement operator.
 
     Examples:
         >>> dq.displace(4, 0.5)
-        tensor([[ 0.882+0.j, -0.441+0.j,  0.156+0.j, -0.047+0.j],
-                [ 0.441+0.j,  0.662+0.j, -0.542+0.j,  0.270+0.j],
-                [ 0.156+0.j,  0.542+0.j,  0.442+0.j, -0.697+0.j],
-                [ 0.047+0.j,  0.270+0.j,  0.697+0.j,  0.662+0.j]])
+        Array([[ 0.882+0.j, -0.441+0.j,  0.156+0.j, -0.047+0.j],
+               [ 0.441+0.j,  0.662+0.j, -0.542+0.j,  0.27 +0.j],
+               [ 0.156+0.j,  0.542+0.j,  0.442+0.j, -0.697+0.j],
+               [ 0.047+0.j,  0.27 +0.j,  0.697+0.j,  0.662+0.j]], dtype=complex64)
         >>> dq.displace(4, [0.1, 0.2]).shape
-        torch.Size([2, 4, 4])
+        (2, 4, 4)
     """
-    cdtype = get_cdtype(dtype)
-    device = to_device(device)
+    dtype = get_cdtype(dtype)
 
-    if isinstance(alpha, get_args(Number)):
-        alpha = torch.as_tensor(alpha, dtype=cdtype, device=device)
-    else:
-        alpha = to_tensor(alpha, dtype=cdtype, device=device)
+    alpha = jnp.asarray(alpha, dtype=dtype)
     alpha = alpha[..., None, None]  # (..., 1, 1)
 
-    a = destroy(dim, dtype=cdtype, device=device)  # (n, n)
-    return torch.matrix_exp(alpha * a.mH - alpha.conj() * a)
+    a = destroy(dim, dtype=dtype)  # (n, n)
+    return jax.scipy.linalg.expm(alpha * dag(a) - alpha.conj() * a)
 
 
 def squeeze(
-    dim: int,
-    z: Number | ArrayLike,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dim: int, z: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array:
     r"""Returns the squeezing operator of complex squeezing amplitude $z$.
 
     It is defined by
@@ -365,43 +319,34 @@ def squeeze(
 
     Args:
         dim: Dimension of the Hilbert space.
-        z _(...)_: Squeezing amplitude.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        z _(array_like of shape (...))_: Squeezing amplitude.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(..., dim, dim)_ Squeezing operator.
+        _(array of shape (..., dim, dim))_ Squeezing operator.
 
     Examples:
         >>> dq.squeeze(4, 0.5)
-        tensor([[ 0.938+0.j,  0.000+0.j,  0.346+0.j,  0.000+0.j],
-                [ 0.000+0.j,  0.818+0.j,  0.000+0.j,  0.575+0.j],
-                [-0.346+0.j,  0.000+0.j,  0.938+0.j,  0.000+0.j],
-                [ 0.000+0.j, -0.575+0.j,  0.000+0.j,  0.818+0.j]])
+        Array([[ 0.938+0.j,  0.   +0.j,  0.346+0.j,  0.   +0.j],
+               [ 0.   +0.j,  0.818+0.j,  0.   +0.j,  0.575+0.j],
+               [-0.346+0.j,  0.   +0.j,  0.938+0.j,  0.   +0.j],
+               [ 0.   +0.j, -0.575+0.j,  0.   +0.j,  0.818+0.j]], dtype=complex64)
         >>> dq.squeeze(4, [0.1, 0.2]).shape
-        torch.Size([2, 4, 4])
+        (2, 4, 4)
     """
-    cdtype = get_cdtype(dtype)
-    device = to_device(device)
+    dtype = get_cdtype(dtype)
 
-    if isinstance(z, get_args(Number)):
-        z = torch.as_tensor(z, dtype=cdtype, device=device)
-    else:
-        z = to_tensor(z, dtype=cdtype, device=device)
+    z = jnp.asarray(z, dtype=dtype)
     z = z[..., None, None]  # (..., 1, 1)
 
-    a = destroy(dim, dtype=dtype, device=device)  # (n, n)
+    a = destroy(dim, dtype=dtype)  # (n, n)
     a2 = a @ a
-    return torch.matrix_exp(0.5 * (z.conj() * a2 - z * a2.mH))
+    return jax.scipy.linalg.expm(0.5 * (z.conj() * a2 - z * dag(a2)))
 
 
 def quadrature(
-    dim: int,
-    phi: float,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dim: int, phi: float, *, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array:
     r"""Returns the quadrature operator of phase angle $\phi$.
 
     It is defined by $x_\phi = (e^{i\phi} a^\dag + e^{-i\phi} a) / 2$, where $a$ and
@@ -410,215 +355,171 @@ def quadrature(
     Args:
         dim: Dimension of the Hilbert space.
         phi: Phase angle.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(dim, dim)_ Quadrature operator.
+        _(array of shape (dim, dim))_ Quadrature operator.
 
     Examples:
-        >>> from math import pi
         >>> dq.quadrature(3, 0.0)
-        tensor([[0.000+0.j, 0.500+0.j, 0.000+0.j],
-                [0.500+0.j, 0.000+0.j, 0.707+0.j],
-                [0.000+0.j, 0.707+0.j, 0.000+0.j]])
-        >>> dq.quadrature(3, pi / 2)
-        tensor([[    0.000+0.000j,     0.000-0.500j,     0.000+0.000j],
-                [    0.000+0.500j,     0.000+0.000j,     0.000-0.707j],
-                [    0.000+0.000j,     0.000+0.707j,     0.000+0.000j]])
+        Array([[0.   +0.j, 0.5  +0.j, 0.   +0.j],
+               [0.5  +0.j, 0.   +0.j, 0.707+0.j],
+               [0.   +0.j, 0.707+0.j, 0.   +0.j]], dtype=complex64)
+        >>> dq.quadrature(3, jnp.pi / 2)
+        Array([[ 0.+0.j   , -0.-0.5j  ,  0.+0.j   ],
+               [-0.+0.5j  ,  0.+0.j   , -0.-0.707j],
+               [ 0.+0.j   , -0.+0.707j,  0.+0.j   ]], dtype=complex64)
     """
-    a = destroy(dim, dtype=dtype, device=device)
-    return 0.5 * (cexp(1.0j * phi) * a.mH + cexp(-1.0j * phi) * a)
+    dtype = get_cdtype(dtype)
+    a = destroy(dim, dtype=dtype)
+    return 0.5 * (jnp.exp(1.0j * phi) * dag(a) + jnp.exp(-1.0j * phi) * a)
 
 
-def position(
-    dim: int,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def position(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the position operator $x = (a^\dag + a) / 2$.
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(dim, dim)_ Position operator.
+        _(array of shape (dim, dim))_ Position operator.
 
     Examples:
         >>> dq.position(3)
-        tensor([[0.000+0.j, 0.500+0.j, 0.000+0.j],
-                [0.500+0.j, 0.000+0.j, 0.707+0.j],
-                [0.000+0.j, 0.707+0.j, 0.000+0.j]])
+        Array([[0.   +0.j, 0.5  +0.j, 0.   +0.j],
+               [0.5  +0.j, 0.   +0.j, 0.707+0.j],
+               [0.   +0.j, 0.707+0.j, 0.   +0.j]], dtype=complex64)
     """
-    a = destroy(dim, dtype=dtype, device=device)
-    return 0.5 * (a + a.mH)
+    dtype = get_cdtype(dtype)
+    a = destroy(dim, dtype=dtype)
+    return 0.5 * (a + dag(a))
 
 
-def momentum(
-    dim: int,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def momentum(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the momentum operator $p = i (a^\dag - a) / 2$.
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(dim, dim)_ Momentum operator.
+        _(array of shape (dim, dim))_ Momentum operator.
 
     Examples:
         >>> dq.momentum(3)
-        tensor([[0.+0.000j, -0.-0.500j, 0.+0.000j],
-                [0.+0.500j, 0.+0.000j, -0.-0.707j],
-                [0.+0.000j, 0.+0.707j, 0.+0.000j]])
+        Array([[0.+0.j   , 0.-0.5j  , 0.+0.j   ],
+               [0.+0.5j  , 0.+0.j   , 0.-0.707j],
+               [0.+0.j   , 0.+0.707j, 0.+0.j   ]], dtype=complex64)
     """
-    a = destroy(dim, dtype=dtype, device=device)
-    return 0.5j * (a.mH - a)
+    dtype = get_cdtype(dtype)
+    a = destroy(dim, dtype=dtype)
+    return 0.5j * (dag(a) - a)
 
 
-def sigmax(
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def sigmax(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the Pauli $\sigma_x$ operator.
 
     It is defined by $\sigma_x = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(2, 2)_ Pauli $\sigma_x$ operator.
+        _(array of shape (2, 2))_ Pauli $\sigma_x$ operator.
 
     Examples:
         >>> dq.sigmax()
-        tensor([[0.+0.j, 1.+0.j],
-                [1.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 1.+0.j],
+               [1.+0.j, 0.+0.j]], dtype=complex64)
     """
-    return torch.tensor(
-        [[0.0, 1.0], [1.0, 0.0]], dtype=get_cdtype(dtype), device=device
-    )
+    dtype = get_cdtype(dtype)
+    return jnp.array([[0.0, 1.0], [1.0, 0.0]], dtype=dtype)
 
 
-def sigmay(
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def sigmay(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the Pauli $\sigma_y$ operator.
 
     It is defined by $\sigma_y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(2, 2)_ Pauli $\sigma_y$ operator.
+        _(array of shape (2, 2))_ Pauli $\sigma_y$ operator.
 
     Examples:
         >>> dq.sigmay()
-        tensor([[0.+0.j, -0.-1.j],
-                [0.+1.j, 0.+0.j]])
+        Array([[ 0.+0.j, -0.-1.j],
+               [ 0.+1.j,  0.+0.j]], dtype=complex64)
     """
-    return torch.tensor(
-        [[0.0, -1.0j], [1.0j, 0.0]], dtype=get_cdtype(dtype), device=device
-    )
+    dtype = get_cdtype(dtype)
+    return jnp.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=dtype)
 
 
-def sigmaz(
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def sigmaz(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the Pauli $\sigma_z$ operator.
 
     It is defined by $\sigma_z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(2, 2)_ Pauli $\sigma_z$ operator.
+        _(array of shape (2, 2))_ Pauli $\sigma_z$ operator.
 
     Examples:
         >>> dq.sigmaz()
-        tensor([[ 1.+0.j,  0.+0.j],
-                [ 0.+0.j, -1.+0.j]])
+        Array([[ 1.+0.j,  0.+0.j],
+               [ 0.+0.j, -1.+0.j]], dtype=complex64)
     """
-    return torch.tensor(
-        [[1.0, 0.0], [0.0, -1.0]], dtype=get_cdtype(dtype), device=device
-    )
+    dtype = get_cdtype(dtype)
+    return jnp.array([[1.0, 0.0], [0.0, -1.0]], dtype=dtype)
 
 
-def sigmap(
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def sigmap(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the Pauli raising operator $\sigma_+$.
 
     It is defined by $\sigma_+ = \begin{pmatrix} 0 & 1 \\ 0 & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(2, 2)_ Pauli $\sigma_+$ operator.
+        _(array of shape (2, 2))_ Pauli $\sigma_+$ operator.
 
     Examples:
         >>> dq.sigmap()
-        tensor([[0.+0.j, 1.+0.j],
-                [0.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 1.+0.j],
+               [0.+0.j, 0.+0.j]], dtype=complex64)
     """
-    return torch.tensor(
-        [[0.0, 1.0], [0.0, 0.0]], dtype=get_cdtype(dtype), device=device
-    )
+    dtype = get_cdtype(dtype)
+    return jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
 
 
-def sigmam(
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+def sigmam(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
     r"""Returns the Pauli lowering operator $\sigma_-$.
 
     It is defined by $\sigma_- = \begin{pmatrix} 0 & 0 \\ 1 & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(2, 2)_ Pauli $\sigma_-$ operator.
+        _(array of shape (2, 2))_ Pauli $\sigma_-$ operator.
 
     Examples:
         >>> dq.sigmam()
-        tensor([[0.+0.j, 0.+0.j],
-                [1.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 0.+0.j],
+               [1.+0.j, 0.+0.j]], dtype=complex64)
     """
-    return torch.tensor(
-        [[0.0, 0.0], [1.0, 0.0]], dtype=get_cdtype(dtype), device=device
-    )
+    dtype = get_cdtype(dtype)
+    return jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
 
 
 def hadamard(
-    n: int = 1,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    n: int = 1, *, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array:
     r"""Returns the Hadamard transform on $n$ qubits.
 
     For a single qubit, it is defined by
@@ -635,23 +536,22 @@ def hadamard(
 
     Args:
         n: Number of qubits to act on.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(2^n, 2^n)_ Hadamard transform operator.
+        _(array of shape (2^n, 2^n))_ Hadamard transform operator.
 
     Examples:
         >>> dq.hadamard()
-        tensor([[ 0.707+0.j,  0.707+0.j],
-                [ 0.707+0.j, -0.707+0.j]])
+        Array([[ 0.707+0.j,  0.707+0.j],
+               [ 0.707+0.j, -0.707+0.j]], dtype=complex64)
         >>> dq.hadamard(2)
-        tensor([[ 0.500+0.j,  0.500+0.j,  0.500+0.j,  0.500+0.j],
-                [ 0.500+0.j, -0.500+0.j,  0.500+0.j, -0.500+0.j],
-                [ 0.500+0.j,  0.500+0.j, -0.500+0.j, -0.500+0.j],
-                [ 0.500+0.j, -0.500+0.j, -0.500+0.j,  0.500-0.j]])
+        Array([[ 0.5+0.j,  0.5+0.j,  0.5+0.j,  0.5+0.j],
+               [ 0.5+0.j, -0.5+0.j,  0.5+0.j, -0.5+0.j],
+               [ 0.5+0.j,  0.5+0.j, -0.5+0.j, -0.5+0.j],
+               [ 0.5+0.j, -0.5+0.j, -0.5+0.j,  0.5-0.j]], dtype=complex64)
     """
-    cdtype = get_cdtype(dtype)
-    H1 = torch.tensor([[1.0, 1.0], [1.0, -1.0]], dtype=cdtype, device=device) / sqrt(2)
-    Hs = H1.expand(n, -1, -1)  # (n, 2, 2)
+    dtype = get_cdtype(dtype)
+    H1 = jnp.array([[1.0, 1.0], [1.0, -1.0]], dtype=dtype) / jnp.sqrt(2)
+    Hs = jnp.broadcast_to(H1, (n, 2, 2))  # (n, 2, 2)
     return tensprod(*Hs)

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -61,7 +61,7 @@ def rand_complex(
     r"""Returns an array filled with random complex numbers uniformly distributed in
     the complex plane.
 
-    Each element of the returned array is sampled uniformly in the disc of radius
+    Each element of the returned array is sampled uniformly in the disk of radius
     $\text{rmax}$.
 
     Notes-: Uniform sampling in the complex plane

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -1,103 +1,72 @@
 from __future__ import annotations
 
-import torch
-from torch import Tensor
+import jax
+import jax.numpy as jnp
+from jax import Array
+from jaxtyping import ArrayLike
 
-from .._utils import check_time_tensor
 from ..utils.operators import displace
 from ..utils.states import fock
 from ..utils.utils import tensprod, tobra
-from .tensor_types import dtype_complex_to_real, get_cdtype, get_rdtype, to_device
+from .tensor_types import dtype_complex_to_real, get_cdtype, get_rdtype
 
-__all__ = ['rand_real', 'rand_complex', 'pwc_pulse', 'snap_gate', 'cd_gate']
+__all__ = ['rand_real', 'rand_complex', 'snap_gate', 'cd_gate']
 
 
 def rand_real(
-    size: int | tuple[int, ...],
+    shape: int | tuple[int, ...],
     *,
+    min: float = 0.0,
     max: float = 1.0,
-    requires_grad: bool = False,
-    seed: int | None = None,
-    dtype: torch.float32 | torch.float64 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
-    r"""Returns a tensor filled with uniformly distributed random real numbers.
+    seed: int = 0,
+    dtype: jnp.float32 | jnp.float64 | None = None,
+) -> Array:
+    r"""Returns an array filled with uniformly distributed random real numbers.
 
-    Each element of the returned tensor has a random value in the interval
-    $[-\texttt{max}, \texttt{max})$. Formally, each element is defined by
-    $$
-        x = \texttt{max} \cdot (2 \cdot \texttt{rand(0,1)} - 1),
-    $$
-    where $\texttt{rand(0,1)}$ is a random number uniformly distributed between 0 and 1.
+    Each element of the returned array is sampled uniformly in
+    $[\text{min}, \text{max})$.
 
     Args:
-        size _(int or tuple of ints)_: Size of the returned tensor.
-        max: Maximum absolute value of the random real numbers.
-        requires_grad: Whether gradients need to be computed with respect to the
-            returned tensor.
+        shape _(int or tuple of ints)_: Shape of the returned array.
+        min: Minimum (inclusive) value.
+        max: Maximum (exclusive) value.
         seed: Seed for the random number generator.
-        dtype: Real data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(*size)_ Tensor filled with random real numbers.
+        _(array of shape (*shape))_ Array filled with random real numbers.
 
     Examples:
-        >>> x = dq.rand_real((2, 5), max=5.0, seed=42)
-        >>> x
-        tensor([[ 3.823,  4.150, -1.171,  4.593, -1.096],
-                [ 1.009, -2.434,  2.936,  4.408, -3.668]])
+        >>> dq.rand_real((2, 5), max=5.0, seed=42)
+        Array([[3.22 , 1.613, 0.967, 4.432, 4.21 ],
+               [0.96 , 1.726, 1.262, 3.16 , 3.274]], dtype=float32)
     """
-    # Note: We need to manually fetch the default device, because if `device` is `None`
-    # `torch.Generator` picks "cpu" as the default device, and not the device set by
-    # `torch.set_default_device`.
-    device = to_device(device)
+    dtype = get_rdtype(dtype)
+    shape = (shape,) if isinstance(shape, int) else shape
 
-    # define random number generator from seed
-    generator = torch.Generator(device=device)
-    generator.seed() if seed is None else generator.manual_seed(seed)
+    # define PRNG key from seed
+    key = jax.random.PRNGKey(seed)
 
-    rdtype = get_rdtype(dtype)
-
-    # generate random real with values in [-max, max[
-    rand_01 = torch.rand(size, generator=generator, dtype=rdtype, device=device)
-    x = max * (rand_01 * 2 - 1)
-
-    # start tracking operations on the tensor if requires_grad is True
-    x.requires_grad_(requires_grad)
-
-    return x
+    # sample uniformly in [min, max)
+    return jax.random.uniform(key, shape=shape, dtype=dtype, minval=min, maxval=max)
 
 
 def rand_complex(
-    size: int | tuple[int, ...],
+    shape: int | tuple[int, ...],
     *,
     rmax: float = 1.0,
-    requires_grad: bool = False,
-    seed: int | None = None,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
-    r"""Returns a tensor filled with random complex numbers uniformly distributed in
+    seed: int = 0,
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> Array:
+    r"""Returns an array filled with random complex numbers uniformly distributed in
     the complex plane.
 
-    Each element of the returned tensor has a random magnitude in the interval
-    $[0, \texttt{rmax})$ and a random phase in the interval $[0, 2\pi)$. Formally, each
-    element is defined by
-    $$
-        x = re^{i\theta}\ \text{with}\
-        \begin{cases}
-            r = \texttt{rmax} \cdot \sqrt{\texttt{rand(0,1)}} \\\\
-            \theta = 2\pi \cdot \texttt{rand(0,1)}
-        \end{cases}
-    $$
-    where $\texttt{rand(0,1)}$ is a random number uniformly distributed between 0 and 1.
+    Each element of the returned array is sampled uniformly in the disc of radius
+    $\text{rmax}$.
 
-    Notes-: Why using a square root in the definition of the magnitude?
-        The square root in the definition of the magnitude $r$ ensures that the
-        resulting complex numbers are uniformly distributed in the disc of the complex
-        plane with a radius of `rmax`. Here are three common options to generate random
-        complex numbers, `dq.rand_complex()` returns the last one:
+    Notes-: Uniform sampling in the complex plane
+        Here are three common options to generate random complex numbers,
+        `dq.rand_complex()` returns the last one:
 
         ```python
         _, (ax0, ax1, ax2) = dq.gridplot(3, sharex=True, sharey=True)
@@ -106,14 +75,14 @@ def rand_complex(
         n = 10_000
 
         # option 1: uniformly distributed real and imaginary part
-        x = torch.rand(n) * 2 - 1 + 1j * (torch.rand(n) * 2 - 1)
+        x = np.random.rand(n) * 2 - 1 + 1j * (np.random.rand(n) * 2 - 1)
         ax0.scatter(x.real, x.imag, s=1.0)
 
         # option 2: uniformly distributed magnitude and phase
-        x = torch.rand(n) * torch.exp(1j * 2 * torch.pi * torch.rand(n))
+        x = np.random.rand(n) * np.exp(1j * 2 * np.pi * np.random.rand(n))
         ax1.scatter(x.real, x.imag, s=1.0)
 
-        # option 3: uniformly distributed on the unit disk (in dynamiqs)
+        # option 3: uniformly distributed in a disk (in dynamiqs)
         x = dq.rand_complex(n)
         ax2.scatter(x.real, x.imag, s=1.0)
         renderfig('rand_complex')
@@ -122,107 +91,34 @@ def rand_complex(
         ![rand_complex](/figs-code/rand_complex.png){.fig}
 
     Args:
-        size _(int or tuple of ints)_: Size of the returned tensor.
-        rmax: Maximum magnitude of the random complex numbers.
-        requires_grad: Whether gradients need to be computed with respect to the
-            returned tensor.
+        shape _(int or tuple of ints)_: Shape of the returned array.
+        rmax: Maximum magnitude.
         seed: Seed for the random number generator.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(*size)_ Tensor filled with random complex numbers.
+        _(array of shape (*shape))_ Array filled with random complex numbers.
 
     Examples:
-        >>> x = dq.rand_complex((2, 5), rmax=5.0, seed=42)
-        >>> x
-        tensor([[ 4.305-1.876j, -3.980-2.653j,  2.109-2.263j, -4.461-2.021j,
-                 -0.175-3.119j],
-                [-3.501+1.663j,  1.904-1.670j, -3.983-1.995j, -0.504+4.823j,
-                 -1.270-1.310j]])
+        >>> dq.rand_complex((2, 3), rmax=5.0, seed=42)
+        Array([[ 1.341+4.17j ,  3.978-0.979j, -2.592-0.946j],
+               [-4.428+1.744j, -0.53 +1.668j,  2.582+0.65j ]], dtype=complex64)
     """
-    # Note: We need to manually fetch the default device, because if `device` is `None`
-    # `torch.Generator` picks "cpu" as the default device, and not the device set by
-    # `torch.set_default_device`.
-    device = to_device(device)
+    cdtype = get_cdtype(dtype)
+    rdtype = dtype_complex_to_real(cdtype)
+    shape = (shape,) if isinstance(shape, int) else shape
 
-    # define random number generator from seed
-    generator = torch.Generator(device=device)
-    generator.seed() if seed is None else generator.manual_seed(seed)
+    # define PRNG key from seed
+    key = jax.random.PRNGKey(seed)
 
-    rdtype = dtype_complex_to_real(get_cdtype(dtype))
-
-    rand = lambda: torch.rand(size, generator=generator, dtype=rdtype, device=device)
-
-    # generate random magnitude with values in [0, rmax[, the sqrt ensures that the
-    # resulting complex numbers are uniformly distributed in the complex plane
-    r = rmax * rand().sqrt()
-    # generate random phase with values in [0, 2pi[
-    theta = 2 * torch.pi * rand()
-    x = r * torch.exp(1j * theta)
-
-    # start tracking operations on the tensor if requires_grad is True
-    x.requires_grad_(requires_grad)
-
-    return x
-
-
-def pwc_pulse(times: Tensor, values: Tensor) -> callable[[float], Tensor]:
-    r"""Returns a function that takes a time $t$ and returns the corresponding
-    piecewise-constant pulse value.
-
-    The `times` tensor $(t_0,\dots,t_n)$ of shape _(n+1)_ defines the time interval for
-    each element of the `values` tensor of shape _(..., n)_. The pulse value at time
-    $t$ is defined by
-
-    - `torch.zeros(...)` if $t<t_0$ or $t>=t_n$,
-    - `values[..., k]` if $t\in[t_k, t_{k+1})$.
-
-    Notes:
-        You can use [`dq.rand_complex()`][dynamiqs.rand_complex] to generate a tensor
-        filled with random complex numbers for the parameter `values`.
-
-    Args:
-        times _(n+1)_: Time points between which the pulse takes constant values.
-        values _(..., n)_: Pulse complex values.
-
-    Returns:
-        Function with signature `float -> Tensor` that takes a time $t$ and returns the
-            corresponding pulse value, a tensor of shape _(...)_.
-
-    Examples:
-        >>> times = torch.linspace(0.0, 1.0, 11)
-        >>> values = dq.rand_complex((2, 10), rmax=5.0, seed=42)
-        >>> pulse = dq.pwc_pulse(times, values)
-        >>> type(pulse)
-        <class 'function'>
-        >>> pulse(0.5)
-        tensor([-0.474+3.847j,  1.186-3.054j])
-        >>> pulse(1.2)
-        tensor([0.+0.j, 0.+0.j])
-    """
-
-    check_time_tensor(times, 'times')
-
-    def pulse(t):
-        if t < times[0] or t >= times[-1]:
-            # return a null tensor of appropriate shape
-            batch_sizes = values.shape[:-1]
-            return torch.zeros(batch_sizes, dtype=values.dtype, device=values.device)
-        else:
-            # find the index $k$ such that $t \in [t_k, t_{k+1})$
-            idx = torch.searchsorted(times, t, side='right') - 1
-            return values[..., idx]
-
-    return pulse
+    # sample uniformly in the unit L2 ball and scale
+    x = rmax * jax.random.ball(key, 2, shape=shape, dtype=rdtype)
+    return x[..., 0] + 1j * x[..., 1]
 
 
 def snap_gate(
-    phase: Tensor,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    phase: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array:
     r"""Returns a SNAP gate.
 
     The *selective number-dependent arbitrary phase* (SNAP) gate imparts a different
@@ -233,35 +129,32 @@ def snap_gate(
     $$
 
     Args:
-        phase _(..., n)_: Phase for each Fock state. The size of the last tensor
-            dimension _n_ defines the Hilbert space dimension.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        phase _(array_like of shape (..., n))_: Phase for each Fock state. The last
+            dimension of the array _n_ defines the Hilbert space dimension.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(..., n, n)_ SNAP gate operator.
+        _(array of shape (..., n, n))_ SNAP gate operator.
 
     Examples:
-        >>> dq.snap_gate(torch.tensor([0, 1, 2]))
-        tensor([[ 1.000+0.000j,  0.000+0.000j,  0.000+0.000j],
-                [ 0.000+0.000j,  0.540+0.841j,  0.000+0.000j],
-                [ 0.000+0.000j,  0.000+0.000j, -0.416+0.909j]])
-        >>> dq.snap_gate(torch.tensor([[0, 1, 2], [2, 3, 4]])).shape
-        torch.Size([2, 3, 3])
+        >>> dq.snap_gate([0, 1, 2])
+        Array([[ 1.   +0.j   ,  0.   +0.j   ,  0.   +0.j   ],
+               [ 0.   +0.j   ,  0.54 +0.841j,  0.   +0.j   ],
+               [ 0.   +0.j   ,  0.   +0.j   , -0.416+0.909j]], dtype=complex64)
+        >>> dq.snap_gate([[0, 1, 2], [2, 3, 4]]).shape
+        (2, 3, 3)
     """
     cdtype = get_cdtype(dtype)
     rdtype = dtype_complex_to_real(cdtype)
-    phase = phase.to(dtype=rdtype, device=device)
-    return torch.diag_embed(torch.exp(1j * phase))
+    phase = jnp.asarray(phase, dtype=rdtype)
+    # batched construct diagonal array
+    bdiag = jnp.vectorize(jnp.diag, signature='(a)->(a,a)')
+    return bdiag(jnp.exp(1j * phase))
 
 
 def cd_gate(
-    dim: int,
-    alpha: Tensor,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dim: int, alpha: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
+) -> Array:
     r"""Returns a conditional displacement gate.
 
     The *conditional displacement* (CD) gate displaces an oscillator conditioned on
@@ -274,27 +167,26 @@ def cd_gate(
 
     Args:
         dim: Dimension of the oscillator Hilbert space.
-        alpha _(...)_: Displacement amplitude.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        alpha _(array_like of shape (...))_: Displacement amplitude.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(..., n, n)_ CD gate operator (acting on the oscillator + TLS system of
-            dimension _n = 2 x dim_).
+        _(array of shape (..., n, n))_ CD gate operator (acting on the oscillator + TLS
+            system of dimension _n = 2 x dim_).
 
     Examples:
-        >>> dq.cd_gate(3, torch.tensor([0.1]))
-        tensor([[[ 0.999+0.j,  0.000+0.j, -0.050+0.j,  0.000+0.j,  0.002+0.j,  0.000+0.j],
-                 [ 0.000+0.j,  0.999+0.j,  0.000+0.j,  0.050+0.j,  0.000+0.j,  0.002+0.j],
-                 [ 0.050+0.j,  0.000+0.j,  0.996+0.j,  0.000+0.j, -0.071+0.j,  0.000+0.j],
-                 [ 0.000+0.j, -0.050+0.j,  0.000+0.j,  0.996+0.j,  0.000+0.j,  0.071+0.j],
-                 [ 0.002+0.j,  0.000+0.j,  0.071+0.j,  0.000+0.j,  0.998+0.j,  0.000+0.j],
-                 [ 0.000+0.j,  0.002+0.j,  0.000+0.j, -0.071+0.j,  0.000+0.j,  0.998+0.j]]])
-        >>> dq.cd_gate(3, torch.tensor([0.1, 0.2])).shape
-        torch.Size([2, 6, 6])
+        >>> dq.cd_gate(2, 0.1)
+        Array([[ 0.999+0.j,  0.   +0.j, -0.05 +0.j,  0.   +0.j],
+               [ 0.   +0.j,  0.999+0.j,  0.   +0.j,  0.05 +0.j],
+               [ 0.05 +0.j,  0.   +0.j,  0.999+0.j,  0.   +0.j],
+               [ 0.   +0.j, -0.05 +0.j,  0.   +0.j,  0.999+0.j]], dtype=complex64)
+        >>> dq.cd_gate(3, [0.1, 0.2]).shape
+        (2, 6, 6)
     """  # noqa: E501
-    g = fock(2, 0, dtype=dtype, device=device).repeat(len(alpha), 1, 1)  # (n, 2, 1)
-    e = fock(2, 1, dtype=dtype, device=device).repeat(len(alpha), 1, 1)  # (n, 2, 1)
-    disp_plus = displace(dim, alpha / 2, dtype=dtype, device=device)  # (n, dim, dim)
-    disp_minus = displace(dim, -alpha / 2, dtype=dtype, device=device)  # (n, dim, dim)
+    dtype = get_cdtype(dtype)
+    alpha = jnp.asarray(alpha, dtype=dtype)
+    g = fock(2, 0, dtype=dtype)  # (2, 1)
+    e = fock(2, 1, dtype=dtype)  # (2, 1)
+    disp_plus = displace(dim, alpha / 2, dtype=dtype)  # (..., dim, dim)
+    disp_minus = displace(dim, -alpha / 2, dtype=dtype)  # (..., dim, dim)
     return tensprod(disp_plus, g @ tobra(g)) + tensprod(disp_minus, e @ tobra(e))

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from math import prod
-from typing import get_args
 
-import torch
-from torch import Tensor
+import jax.numpy as jnp
+from jax import Array
+from jax.typing import ArrayLike
 
 from .operators import displace
-from .tensor_types import ArrayLike, Number, get_cdtype, to_tensor
+from .tensor_types import get_cdtype
 from .utils import tensprod, todm
 
 __all__ = ['fock', 'fock_dm', 'basis', 'basis_dm', 'coherent', 'coherent_dm']
@@ -17,33 +17,34 @@ def fock(
     dim: int | tuple[int, ...],
     number: int | tuple[int, ...],
     *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> Array:
     r"""Returns the ket of a Fock state or the ket of a tensor product of Fock states.
 
     Args:
         dim _(int or tuple of ints)_: Dimension of the Hilbert space of each mode.
         number _(int or tuple of ints)_: Fock state number of each mode.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(n, 1)_ Ket of the Fock state or tensor product of Fock states.
+        _(array of shape (n, 1))_ Ket of the Fock state or tensor product of Fock
+            states.
 
     Examples:
         >>> dq.fock(3, 1)
-        tensor([[0.+0.j],
-                [1.+0.j],
-                [0.+0.j]])
+        Array([[0.+0.j],
+               [1.+0.j],
+               [0.+0.j]], dtype=complex64)
         >>> dq.fock((3, 2), (1, 0))
-        tensor([[0.+0.j],
-                [0.+0.j],
-                [1.+0.j],
-                [0.+0.j],
-                [0.+0.j],
-                [0.+0.j]])
+        Array([[0.+0.j],
+               [0.+0.j],
+               [1.+0.j],
+               [0.+0.j],
+               [0.+0.j],
+               [0.+0.j]], dtype=complex64)
     """
+    dtype = get_cdtype(dtype)
+
     # convert integer inputs to tuples by default, and check dimensions match
     dim = (dim,) if isinstance(dim, int) else dim
     number = (number,) if isinstance(number, int) else number
@@ -57,8 +58,8 @@ def fock(
     n = 0
     for d, s in zip(dim, number):
         n = d * n + s
-    ket = torch.zeros(prod(dim), 1, dtype=get_cdtype(dtype), device=device)
-    ket[n] = 1.0
+    ket = jnp.zeros((prod(dim), 1), dtype=dtype)
+    ket = ket.at[n].set(1.0)
     return ket
 
 
@@ -66,103 +67,95 @@ def fock_dm(
     dim: int | tuple[int, ...],
     number: int | tuple[int, ...],
     *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> Array:
     r"""Returns the density matrix of a Fock state or the density matrix of a tensor
     product of Fock states.
 
     Args:
         dim _(int or tuple of ints)_: Dimension of the Hilbert space of each mode.
         number _(int or tuple of ints)_: Fock state number of each mode.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(n, n)_ Density matrix of the Fock state or tensor product of Fock states.
+        _(array of shape (n, n))_ Density matrix of the Fock state or tensor product of
+            Fock states.
 
     Examples:
         >>> dq.fock_dm(3, 1)
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 1.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 1.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
         >>> dq.fock_dm((3, 2), (1, 0))
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]])
+        Array([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
     """
-    return todm(fock(dim, number, dtype=dtype, device=device))
+    return todm(fock(dim, number, dtype=dtype))
 
 
 def basis(
     dim: int | tuple[int, ...],
     number: int | tuple[int, ...],
     *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-):
-    """Alias for [`dq.fock()`][dynamiqs.fock]."""
-    return fock(dim, number, dtype=dtype, device=device)
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> Array:
+    """Alias of [`dq.fock()`][dynamiqs.fock]."""
+    return fock(dim, number, dtype=dtype)
 
 
 def basis_dm(
     dim: int | tuple[int, ...],
     number: int | tuple[int, ...],
     *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-):
-    """Alias for [`dq.fock_dm()`][dynamiqs.fock_dm]."""
-    return fock_dm(dim, number, dtype=dtype, device=device)
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> Array:
+    """Alias of [`dq.fock_dm()`][dynamiqs.fock_dm]."""
+    return fock_dm(dim, number, dtype=dtype)
 
 
 def coherent(
     dim: int | tuple[int, ...],
-    alpha: Number | ArrayLike,
+    alpha: ArrayLike,
     *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> Array:
     r"""Returns the ket of a coherent state, or the ket of a tensor product of coherent
     states.
 
     Args:
         dim _(int or tuple of ints)_: Dimension of the Hilbert space of each mode.
-        alpha _(number or array-like object)_: Coherent state amplitude of each mode.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        alpha _(array_like)_: Coherent state amplitude of each mode.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(n, 1)_ Ket of the coherent state.
+        _(array of shape (n, 1))_ Ket of the coherent state.
 
     Examples:
         >>> dq.coherent(4, 0.5)
-        tensor([[0.882+0.j],
-                [0.441+0.j],
-                [0.156+0.j],
-                [0.047+0.j]])
+        Array([[0.882+0.j],
+               [0.441+0.j],
+               [0.156+0.j],
+               [0.047+0.j]], dtype=complex64)
         >>> dq.coherent((2, 3), (0.5, 0.5j))
-        tensor([[ 0.775+0.000j],
-                [ 0.000+0.386j],
-                [-0.146+0.000j],
-                [ 0.423+0.000j],
-                [ 0.000+0.211j],
-                [-0.080+0.000j]])
+        Array([[ 0.775+0.j   ],
+               [ 0.   +0.386j],
+               [-0.146+0.j   ],
+               [ 0.423+0.j   ],
+               [ 0.   +0.211j],
+               [-0.08 +0.j   ]], dtype=complex64)
     """
-    cdtype = get_cdtype(dtype)
+    dtype = get_cdtype(dtype)
 
     # convert inputs to tuples by default, and check dimensions match
     dim = (dim,) if isinstance(dim, int) else dim
-    if isinstance(alpha, get_args(Number)):
-        alpha = torch.as_tensor(alpha, dtype=cdtype, device=device)
-    else:
-        alpha = to_tensor(alpha, dtype=cdtype, device=device)
+    alpha = jnp.asarray(alpha, dtype=dtype)
 
     if alpha.ndim == 0:
-        alpha = alpha.unsqueeze(-1)
+        alpha = alpha[..., None]
     elif alpha.ndim > 1:
         raise ValueError(
             'Argument `alpha` must be a 0-D or 1-D array-like object, but is'
@@ -175,8 +168,7 @@ def coherent(
         )
 
     kets = [
-        displace(d, a, dtype=cdtype, device=device)
-        @ fock(d, 0, dtype=cdtype, device=device)
+        displace(d, a, dtype=dtype) @ fock(d, 0, dtype=dtype)
         for d, a in zip(dim, alpha)
     ]
     return tensprod(*kets)
@@ -184,35 +176,33 @@ def coherent(
 
 def coherent_dm(
     dim: int | tuple[int, ...],
-    alpha: Number | ArrayLike,
+    alpha: ArrayLike,
     *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> Array:
     r"""Returns the density matrix of a coherent state, or the density matrix of a
     tensor product of coherent states.
 
     Args:
         dim _(int or tuple of ints)_: Dimension of the Hilbert space of each mode.
-        alpha _(number or array-like object)_: Coherent state amplitude of each mode.
-        dtype: Complex data type of the returned tensor.
-        device: Device of the returned tensor.
+        alpha _(array_like)_: Coherent state amplitude of each mode.
+        dtype: Complex data type of the returned array.
 
     Returns:
-        _(n, n)_ Density matrix of the coherent state.
+        _(array of shape (n, n))_ Density matrix of the coherent state.
 
     Examples:
         >>> dq.coherent_dm(4, 0.5)
-        tensor([[0.779+0.j, 0.389+0.j, 0.137+0.j, 0.042+0.j],
-                [0.389+0.j, 0.195+0.j, 0.069+0.j, 0.021+0.j],
-                [0.137+0.j, 0.069+0.j, 0.024+0.j, 0.007+0.j],
-                [0.042+0.j, 0.021+0.j, 0.007+0.j, 0.002+0.j]])
+        Array([[0.779+0.j, 0.389+0.j, 0.137+0.j, 0.042+0.j],
+               [0.389+0.j, 0.195+0.j, 0.069+0.j, 0.021+0.j],
+               [0.137+0.j, 0.069+0.j, 0.024+0.j, 0.007+0.j],
+               [0.042+0.j, 0.021+0.j, 0.007+0.j, 0.002+0.j]], dtype=complex64)
         >>> dq.coherent_dm((2, 3), (0.5, 0.5))
-        tensor([[0.600+0.j, 0.299+0.j, 0.113+0.j, 0.328+0.j, 0.163+0.j, 0.062+0.j],
-                [0.299+0.j, 0.149+0.j, 0.056+0.j, 0.163+0.j, 0.081+0.j, 0.031+0.j],
-                [0.113+0.j, 0.056+0.j, 0.021+0.j, 0.062+0.j, 0.031+0.j, 0.012+0.j],
-                [0.328+0.j, 0.163+0.j, 0.062+0.j, 0.179+0.j, 0.089+0.j, 0.034+0.j],
-                [0.163+0.j, 0.081+0.j, 0.031+0.j, 0.089+0.j, 0.044+0.j, 0.017+0.j],
-                [0.062+0.j, 0.031+0.j, 0.012+0.j, 0.034+0.j, 0.017+0.j, 0.006+0.j]])
-    """
-    return todm(coherent(dim, alpha, dtype=dtype, device=device))
+        Array([[0.6  +0.j, 0.299+0.j, 0.113+0.j, 0.328+0.j, 0.163+0.j, 0.062+0.j],
+               [0.299+0.j, 0.149+0.j, 0.056+0.j, 0.163+0.j, 0.081+0.j, 0.031+0.j],
+               [0.113+0.j, 0.056+0.j, 0.021+0.j, 0.062+0.j, 0.031+0.j, 0.012+0.j],
+               [0.328+0.j, 0.163+0.j, 0.062+0.j, 0.179+0.j, 0.089+0.j, 0.034+0.j],
+               [0.163+0.j, 0.081+0.j, 0.031+0.j, 0.089+0.j, 0.044+0.j, 0.017+0.j],
+               [0.062+0.j, 0.031+0.j, 0.012+0.j, 0.034+0.j, 0.017+0.j, 0.006+0.j]],      dtype=complex64)
+    """  # noqa: E501
+    return todm(coherent(dim, alpha, dtype=dtype))

--- a/dynamiqs/utils/tensor_types.py
+++ b/dynamiqs/utils/tensor_types.py
@@ -1,202 +1,81 @@
 from __future__ import annotations
 
-from typing import Union, get_args
-
+import jax.numpy as jnp
 import numpy as np
 import torch
+from jax.typing import ArrayLike
 from qutip import Qobj
-from torch import Tensor
 
-from .._utils import hdim, obj_type_str
-from .utils import isbra, isket, isop
+from .utils import _hdim, isbra, isket, isop
 
-__all__ = ['to_tensor', 'to_numpy', 'to_qutip', 'from_qutip']
+__all__ = ['to_qutip']
 
-Number = Union[int, float, complex]
+# TODO: remove (keep name to avoid ImportError while transitioning from PyTorch to JAX)
+to_device = None
+to_tensor = None
+to_numpy = None
+Number = None
 
-# type for objects convertible to a torch.Tensor using `to_tensor`
-ArrayLike = Union[tuple, list, np.ndarray, Tensor, Qobj]
 
-# data type conversion dictionaries
-DTYPE_TO_REAL = {torch.complex64: torch.float32, torch.complex128: torch.float64}
-DTYPE_TO_COMPLEX = {torch.float32: torch.complex64, torch.float64: torch.complex128}
+def _get_default_dtype() -> jnp.float32 | jnp.float64:
+    default_dtype = jnp.array(0.0).dtype
+    return jnp.float64 if default_dtype == jnp.float64 else jnp.float32
 
 
 def get_cdtype(
-    dtype: torch.complex64 | torch.complex128 | None = None,
-) -> torch.complex64 | torch.complex128:
+    dtype: jnp.complex64 | jnp.complex128 | None = None,
+) -> jnp.complex64 | jnp.complex128:
     if dtype is None:
-        # the default dtype for complex tensors is determined by the default
-        # floating point dtype (torch.complex128 if default is torch.float64,
-        # otherwise torch.complex64)
-        if torch.get_default_dtype() is torch.float64:
-            return torch.complex128
-        else:
-            return torch.complex64
-    elif dtype not in (torch.complex64, torch.complex128):
+        # the default dtype for complex arrays is determined by the default
+        # floating point dtype (jnp.complex128 if default is jnp.float64,
+        # otherwise jnp.complex64)
+        default_dtype = _get_default_dtype()
+        return jnp.complex128 if default_dtype is jnp.float64 else jnp.complex64
+    elif dtype not in (jnp.complex64, jnp.complex128):
         raise TypeError(
-            'Argument `dtype` must be `torch.complex64`, `torch.complex128` or `None`'
-            f' for a complex tensor, but is `{dtype}`.'
+            'Argument `dtype` must be `jnp.complex64`, `jnp.complex128` or `None`'
+            f' for a complex-valued array, but is `{dtype}`.'
         )
     return dtype
 
 
 def get_rdtype(
-    dtype: torch.float32 | torch.float64 | None = None,
-) -> torch.float32 | torch.float64:
+    dtype: jnp.float32 | jnp.float64 | None = None,
+) -> jnp.float32 | jnp.float64:
     if dtype is None:
-        return torch.get_default_dtype()
+        return _get_default_dtype()
     elif dtype not in (torch.float32, torch.float64):
         raise TypeError(
-            'Argument `dtype` must be `torch.float32`, `torch.float64` or `None` for'
-            f' a real-valued tensor, but is `{dtype}`.'
+            'Argument `dtype` must be `jnp.float32`, `jnp.float64` or `None` for'
+            f' a real-valued array, but is `{dtype}`.'
         )
     return dtype
 
 
 def dtype_complex_to_real(
-    dtype: torch.complex64 | torch.complex128,
-) -> torch.float32 | torch.float64:
-    return DTYPE_TO_REAL[dtype]
+    dtype: jnp.complex64 | jnp.complex128,
+) -> jnp.float32 | jnp.float64:
+    if dtype == jnp.complex64:
+        return jnp.float32
+    elif dtype == jnp.complex128:
+        return jnp.float64
 
 
 def dtype_real_to_complex(
-    dtype: torch.float32 | torch.float64,
-) -> torch.complex64 | torch.complex128:
-    return DTYPE_TO_COMPLEX[dtype]
+    dtype: jnp.float32 | jnp.float64,
+) -> jnp.complex64 | jnp.complex128:
+    if dtype == jnp.float32:
+        return jnp.complex64
+    elif dtype == jnp.float64:
+        return jnp.complex128
 
 
-def to_device(device: str | torch.device | None) -> torch.device:
-    if device is None:
-        return torch.ones(1).device  # default device
-    elif isinstance(device, str):
-        return torch.device(device)
-    elif isinstance(device, torch.device):
-        return device
-    else:
-        raise TypeError(
-            f'Argument `device` ({device}) must be a string, a `torch.device` object or'
-            ' `None`.'
-        )
-
-
-def to_tensor(
-    x: ArrayLike | list[ArrayLike] | None,
-    *,
-    dtype: torch.dtype | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
-    """Convert an array-like object or a list of array-like objects to a tensor.
+def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:
+    r"""Convert an array-like object to a QuTiP quantum object (or a list of QuTiP
+    quantum object if it has more than two dimensions).
 
     Args:
-        x: QuTiP quantum object or NumPy array or Python list or Python tuple or PyTorch
-            tensor or list of these types. If `None` returns an empty tensor of shape
-            _(0)_.
-        dtype: Data type of the returned tensor.
-        device: Device on which the returned tensor is stored.
-
-    Returns:
-        Output tensor.
-
-    Examples:
-        >>> import numpy as np
-        >>> import qutip as qt
-        >>> dq.to_tensor(qt.fock(3, 1))
-        tensor([[0.+0.j],
-                [1.+0.j],
-                [0.+0.j]])
-        >>> dq.to_tensor(np.array([[1, 2, 3], [4, 5, 6]]))
-        tensor([[1, 2, 3],
-                [4, 5, 6]])
-        >>> dq.to_tensor([qt.fock(3, 1), qt.fock(3, 2)])
-        tensor([[[0.+0.j],
-                 [1.+0.j],
-                 [0.+0.j]],
-        <BLANKLINE>
-                [[0.+0.j],
-                 [0.+0.j],
-                 [1.+0.j]]])
-    """
-    if x is None:
-        return torch.tensor([], dtype=dtype, device=device)
-    elif isinstance(x, tuple):
-        if len(x) == 0:
-            return torch.tensor([], dtype=dtype, device=device)
-        else:
-            return torch.as_tensor(x, dtype=dtype, device=device)
-    elif isinstance(x, list):
-        if len(x) == 0:
-            return torch.tensor([], dtype=dtype, device=device)
-        if not isinstance(x[0], get_args(ArrayLike)):
-            return torch.as_tensor(x, dtype=dtype, device=device)
-        else:
-            return torch.stack([to_tensor(el, dtype=dtype, device=device) for el in x])
-    elif isinstance(x, Qobj):
-        return from_qutip(x, dtype=get_cdtype(dtype), device=device)
-    elif isinstance(x, (np.ndarray, Tensor)):
-        return torch.as_tensor(x, dtype=dtype, device=device)
-    else:
-        raise TypeError(
-            'Argument `x` must be an array-like object or a list of array-like objects,'
-            f' but has type {obj_type_str(x)}.'
-        )
-
-
-def to_numpy(x: ArrayLike | list[ArrayLike]) -> np.ndarray:
-    """Convert an array-like object or a list of array-like objects to a NumPy array.
-
-    Args:
-        x: QuTiP quantum object or NumPy array or Python list or Python tuple or
-            PyTorch tensor or list of these types.
-
-    Returns:
-        Output NumPy array.
-
-    Examples:
-        >>> import qutip as qt
-        >>> dq.to_numpy(dq.fock(3, 1))
-        array([[0.+0.j],
-               [1.+0.j],
-               [0.+0.j]], dtype=complex64)
-        >>> dq.to_numpy([qt.fock(3, 1), qt.fock(3, 2)])
-        array([[[0.+0.j],
-                [1.+0.j],
-                [0.+0.j]],
-        <BLANKLINE>
-               [[0.+0.j],
-                [0.+0.j],
-                [1.+0.j]]])
-    """
-    if isinstance(x, tuple):
-        if len(x) == 0:
-            return np.array([])
-        else:
-            return np.array(x)
-    elif isinstance(x, list):
-        if len(x) == 0:
-            return np.array([])
-        if not isinstance(x[0], get_args(ArrayLike)):
-            return np.array(x)
-        else:
-            return np.array([to_numpy(el) for el in x])
-    elif isinstance(x, np.ndarray):
-        return x
-    elif isinstance(x, Tensor):
-        return x.numpy(force=True)
-    elif isinstance(x, Qobj):
-        return x.full()
-    else:
-        raise TypeError(
-            f'Argument `x` must be an array-like object but has type {obj_type_str(x)}.'
-        )
-
-
-def to_qutip(x: Tensor, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:
-    r"""Convert a PyTorch tensor to a QuTiP quantum object (or a list of QuTiP quantum
-    object if the tensor is batched).
-
-    Args:
-        x: PyTorch tensor.
+        x: Array-like object.
         dims _(tuple of ints)_: Dimensions of each subsystem in a composite system
             Hilbert space tensor product, defaults to `None` (a single system with the
             same dimension as `x`).
@@ -207,9 +86,9 @@ def to_qutip(x: Tensor, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj
     Examples:
         >>> psi = dq.fock(3, 1)
         >>> psi
-        tensor([[0.+0.j],
-                [1.+0.j],
-                [0.+0.j]])
+        Array([[0.+0.j],
+               [1.+0.j],
+               [0.+0.j]], dtype=complex64)
         >>> dq.to_qutip(psi)
         Quantum object: dims = [[3], [1]], shape = (3, 1), type = ket
         Qobj data =
@@ -218,9 +97,9 @@ def to_qutip(x: Tensor, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj
          [0.]]
 
         For a batched tensor:
-        >>> rhos = torch.stack([dq.coherent_dm(16, i) for i in range(5)])
+        >>> rhos = jnp.stack([dq.coherent_dm(16, i) for i in range(5)])
         >>> rhos.shape
-        torch.Size([5, 16, 16])
+        (5, 16, 16)
         >>> len(dq.to_qutip(rhos))
         5
 
@@ -246,11 +125,13 @@ def to_qutip(x: Tensor, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj
          [0. 0. 0. 0. 1. 0.]
          [0. 0. 0. 0. 0. 1.]]
     """  # noqa: E501
+    x = jnp.asarray(x)
+
     if x.ndim > 2:
         return [to_qutip(sub_x) for sub_x in x]
     else:
         if dims is None:
-            dims = [hdim(x)]
+            dims = [_hdim(x)]
         dims = list(dims)
         if isket(x):  # [[3], [1]] or for composite systems [[3, 4], [1, 1]]
             dims = [dims, [1] * len(dims)]
@@ -258,41 +139,4 @@ def to_qutip(x: Tensor, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj
             dims = [[1] * len(dims), dims]
         elif isop(x):  # [[3], [3]] or for composite systems [[3, 4], [3, 4]]
             dims = [dims, dims]
-        return Qobj(x.numpy(force=True), dims=dims)
-
-
-def from_qutip(
-    x: Qobj,
-    *,
-    dtype: torch.complex64 | torch.complex128 | None = None,
-    device: str | torch.device | None = None,
-) -> Tensor:
-    r"""Convert a QuTiP quantum object to a PyTorch tensor.
-
-    Args:
-        x _(QuTiP quantum object)_: Input quantum object.
-        dtype: Complex data type of the returned tensor.
-        device: Device on which the returned tensor is stored.
-
-    Returns:
-        Output tensor.
-
-    Examples:
-        >>> import qutip as qt
-        >>> omega = 2.0
-        >>> a = qt.destroy(4)
-        >>> H = omega * a.dag() * a
-        >>> H
-        Quantum object: dims = [[4], [4]], shape = (4, 4), type = oper, isherm = True
-        Qobj data =
-        [[0. 0. 0. 0.]
-         [0. 2. 0. 0.]
-         [0. 0. 4. 0.]
-         [0. 0. 0. 6.]]
-        >>> dq.from_qutip(H)
-        tensor([[0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 2.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 4.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j, 6.+0.j]])
-    """
-    return torch.from_numpy(x.full()).to(dtype=get_cdtype(dtype), device=device)
+        return Qobj(np.asarray(x), dims=dims)

--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from functools import reduce
 
-import torch
-from torch import Tensor
+import jax
+import jax.numpy as jnp
+from jax import Array
+from jaxtyping import ArrayLike
 
 __all__ = [
     'dag',
@@ -29,80 +31,88 @@ __all__ = [
 ]
 
 
-def dag(x: Tensor) -> Tensor:
-    r"""Returns the adjoint (conjugate-transpose) of a ket, bra, density matrix or
-    operator.
+def dag(x: ArrayLike) -> Array:
+    r"""Returns the adjoint (complex conjugate transpose) of a ket, bra, density matrix
+    or operator.
 
     Args:
-        x _(..., n, 1) or (..., 1, n) or (..., n, n)_: Ket, bra, density matrix or
-            operator.
+        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,
+            density matrix or operator.
 
     Returns:
-       _(..., n, 1) or (..., 1, n) or (..., n, n)_ Adjoint of `x`.
+       _(array of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Adjoint of `x`.
 
     Notes:
-        This function is equivalent to `x.mH`.
+        This function is equivalent to `x.mT.conj()`.
 
     Examples:
         >>> dq.fock(2, 0)
-        tensor([[1.+0.j],
-                [0.+0.j]])
+        Array([[1.+0.j],
+               [0.+0.j]], dtype=complex64)
         >>> dq.dag(dq.fock(2, 0))
-        tensor([[1.-0.j, 0.-0.j]])
+        Array([[1.-0.j, 0.-0.j]], dtype=complex64)
     """
-    return x.mH
+    x = jnp.asarray(x)
+    return x.mT.conj()
 
 
-def mpow(x: Tensor, n: int) -> Tensor:
-    """Returns the $n$-th matrix power of a tensor.
+def mpow(x: ArrayLike, n: int) -> Array:
+    """Returns the $n$-th matrix power of an array.
 
     Notes:
-        This function is equivalent to `torch.linalg.matrix_power(x, n)`.
+        This function is equivalent to `jnp.linalg.matrix_power(x, n)`.
 
     Args:
-        x _(..., n, n)_: Square matrix.
+        x _(array_like of shape (..., n, n))_: Square matrix.
         n: Integer exponent.
 
     Returns:
-        _(..., n, n)_ Matrix power of `x`.
+        _(array of shape (..., n, n))_ Matrix power of `x`.
 
     Examples:
         >>> dq.mpow(dq.sigmax(), 2)
-        tensor([[1.+0.j, 0.+0.j],
-                [0.+0.j, 1.+0.j]])
+        Array([[1.+0.j, 0.+0.j],
+               [0.+0.j, 1.+0.j]], dtype=complex64)
     """
-    return torch.linalg.matrix_power(x, n)
+    x = jnp.asarray(x)
+    return jnp.linalg.matrix_power(x, n)
 
 
-def trace(x: Tensor) -> Tensor:
-    r"""Returns the trace of a tensor along its last two dimensions.
+def trace(x: ArrayLike) -> Array:
+    r"""Returns the trace of an array along its last two dimensions.
 
     Args:
-        x _(..., n, n)_: Tensor.
+        x _(array_like of shape (..., n, n))_: Array.
 
     Returns:
-        _(...)_ Trace of `x`.
+        _(array of shape (...))_ Trace of `x`.
 
     Examples:
-        >>> x = torch.ones(3, 3)
+        >>> x = jnp.ones((3, 3))
         >>> dq.trace(x)
-        tensor(3.)
+        Array(3., dtype=float32)
     """
-    return x.diagonal(dim1=-1, dim2=-2).sum(-1)
+    x = jnp.asarray(x)
+    return x.trace(axis1=-1, axis2=-2)
 
 
-def ptrace(x: Tensor, keep: int | tuple[int, ...], dims: tuple[int, ...]) -> Tensor:
+def _hdim(x: ArrayLike) -> int:
+    x = jnp.asarray(x)
+    return x.shape[-2] if isket(x) else x.shape[-1]
+
+
+def ptrace(x: ArrayLike, keep: int | tuple[int, ...], dims: tuple[int, ...]) -> Array:
     r"""Returns the partial trace of a ket, bra or density matrix.
 
     Args:
-        x _(..., n, 1) or (..., 1, n) or (..., n, n)_: Ket, bra or density matrix of a
-            composite system.
+        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
+            density matrix of a composite system.
         keep _(int or tuple of ints)_: Dimensions to keep after partial trace.
         dims _(tuple of ints)_: Dimensions of each subsystem in the composite system
             Hilbert space tensor product.
 
     Returns:
-        _(..., m, m)_ Density matrix (with `m <= n`).
+        _(array of shape (..., m, m))_ Density matrix (with `m <= n`).
 
     Raises:
         ValueError: If `x` is not a ket, bra or density matrix.
@@ -116,36 +126,38 @@ def ptrace(x: Tensor, keep: int | tuple[int, ...], dims: tuple[int, ...]) -> Ten
     Examples:
         >>> psi_abc = dq.tensprod(dq.fock(3, 0), dq.fock(4, 2), dq.fock(5, 1))
         >>> psi_abc.shape
-        torch.Size([60, 1])
+        (60, 1)
         >>> rho_a = dq.ptrace(psi_abc, 0, (3, 4, 5))
         >>> rho_a.shape
-        torch.Size([3, 3])
+        (3, 3)
         >>> rho_bc = dq.ptrace(psi_abc, (1, 2), (3, 4, 5))
         >>> rho_bc.shape
-        torch.Size([20, 20])
+        (20, 20)
     """
-    # convert keep and dims to tensors
-    keep = torch.as_tensor([keep] if isinstance(keep, int) else keep)  # e.g. [1, 2]
-    dims = torch.as_tensor(dims)  # e.g. [20, 2, 5]
+    x = jnp.asarray(x)
+
+    # convert keep and dims to arrays
+    keep = jnp.asarray([keep] if isinstance(keep, int) else keep)  # e.g. [1, 2]
+    dims = jnp.asarray(dims)  # e.g. [20, 2, 5]
     ndims = len(dims)  # e.g. 3
 
     # check that input dimensions match
-    hilbert_size = x.size(-2) if isket(x) else x.size(-1)
-    prod_dims = torch.prod(dims)
-    if not prod_dims == hilbert_size:
+    hdim = _hdim(x)
+    prod_dims = jnp.prod(dims)
+    if not prod_dims == hdim:
         dims_prod_str = '*'.join(str(d.item()) for d in dims) + f'={prod_dims}'
         raise ValueError(
             'Argument `dims` must match the Hilbert space dimension of `x` of'
-            f' {hilbert_size}, but the product of its values is {dims_prod_str}.'
+            f' {hdim}, but the product of its values is {dims_prod_str}.'
         )
-    if torch.any(keep < 0) or torch.any(keep > len(dims) - 1):
+    if jnp.any(keep < 0) or jnp.any(keep > len(dims) - 1):
         raise ValueError(
             'Argument `keep` must match the Hilbert space structure specified by'
             ' `dims`.'
         )
 
     # sort keep
-    keep = keep.sort()[0]
+    keep = keep.sort()
 
     # create einsum alphabet
     alphabet = list('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
@@ -156,87 +168,67 @@ def ptrace(x: Tensor, keep: int | tuple[int, ...], dims: tuple[int, ...]) -> Ten
     eq2 = [next(unused) if i in keep else eq1[i] for i in range(ndims)]  # e.g. 'ade'
 
     # trace out x over unkept dimensions
-    batch_dims = x.shape[:-2]
+    bshape = x.shape[:-2]
     if isket(x) or isbra(x):
-        x = x.view(-1, *dims)  # e.g. (..., 20, 2, 5)
+        x = x.reshape(*bshape, *dims)  # e.g. (..., 20, 2, 5)
         eq = ''.join(['...'] + eq1 + [',...'] + eq2)  # e.g. '...abc,...ade'
-        x = torch.einsum(eq, x, x.conj())  # e.g. (..., 2, 5, 2, 5)
+        x = jnp.einsum(eq, x, x.conj())  # e.g. (..., 2, 5, 2, 5)
     elif isdm(x):
-        x = x.view(-1, *dims, *dims)  # e.g. (..., 20, 2, 5, 20, 2, 5)
+        x = x.reshape(*bshape, *dims, *dims)  # e.g. (..., 20, 2, 5, 20, 2, 5)
         eq = ''.join(['...'] + eq1 + eq2)  # e.g. '...abcade'
-        x = torch.einsum(eq, x)  # e.g. (..., 2, 5, 2, 5)
+        x = jnp.einsum(eq, x)  # e.g. (..., 2, 5, 2, 5)
     else:
         raise ValueError(
             'Argument `x` must be a ket, bra or density matrix, but has shape'
-            f' {tuple(x.shape)}.'
+            f' {x.shape}.'
         )
 
     # reshape to final dimension
-    nkeep = torch.prod(dims[keep])  # e.g. 10
-    return x.reshape(*batch_dims, nkeep, nkeep)  # e.g. (..., 10, 10)
+    nkeep = jnp.prod(dims[keep])  # e.g. 10
+    return x.reshape(*bshape, nkeep, nkeep)  # e.g. (..., 10, 10)
 
 
-def tensprod(*args: Tensor) -> Tensor:
+def tensprod(*args: ArrayLike) -> Array:
     r"""Returns the tensor product of multiple kets, bras, density matrices or
     operators.
 
-    The returned tensor shape is:
+    The returned array shape is:
 
-    - $(..., n, 1)$ with $n=\prod_k n_k$ if all input tensors are kets with shape
+    - $(..., n, 1)$ with $n=\prod_k n_k$ if all input arrays are kets with shape
       $(..., n_k, 1)$,
-    - $(..., 1, n)$ with $n=\prod_k n_k$ if all input tensors are bras with shape
+    - $(..., 1, n)$ with $n=\prod_k n_k$ if all input arrays are bras with shape
       $(..., 1, n_k)$,
-    - $(..., n, n)$ with $n=\prod_k n_k$ if all input tensors are density matrices or
-      operators vectors with shape $(..., n_k, n_k)$.
+    - $(..., n, n)$ with $n=\prod_k n_k$ if all input arrays are density matrices or
+      operators with shape $(..., n_k, n_k)$.
 
     Notes:
         This function is the equivalent of `qutip.tensor()`.
 
     Args:
-        *args _(..., n_k, 1) or (..., 1, n_k) or (..., n_k, n_k)_: Variable length
-            argument list of kets, density matrices or operators.
+        *args _(array_like of shape (..., n_k, 1) or (..., 1, n_k) or (..., n_k, n_k))_:
+            Variable length argument list of kets, bras, density matrices or operators.
 
     Returns:
-        _(..., n, 1) or (..., 1, n) or (..., n, n)_ Tensor product of the input tensors.
+        _(array of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Tensor product of
+            the input arrays.
 
     Examples:
         >>> psi = dq.tensprod(dq.fock(3, 0), dq.fock(4, 2), dq.fock(5, 1))
         >>> psi.shape
-        torch.Size([60, 1])
+        (60, 1)
     """
+    args = [jnp.asarray(arg) for arg in args]
+
     return reduce(_bkron, args)
+    # JAXDO: jax.lax.reduce?
+    # JAXDO: ok if not all fully batched as long as batch-compatible
 
 
-def _bkron(x: Tensor, y: Tensor) -> Tensor:
-    """Returns the batched Kronecker product of two matrices."""
-    x_type = _quantum_type(x)
-    y_type = _quantum_type(y)
-    if x_type != y_type:
-        raise ValueError(
-            'Arguments `x` and `y` have incompatible quantum types for tensor product:'
-            f' `x` is a {x_type} with shape {tuple(x.shape)}, but  `y` is a {y_type}'
-            f' with shape {tuple(y.shape)}.'
-        )
-
-    # x: (..., x1, x2)
-    # y: (..., y1, y2)
-
-    batch_dims = x.shape[:-2]
-    x1, x2 = x.shape[-2:]
-    y1, y2 = y.shape[-2:]
-    kron_dims = torch.Size((x1 * y1, x2 * y2))
-
-    # perform element-wise multiplication of appropriately unsqueezed tensors to
-    # simulate the Kronecker product
-    x_tmp = x.unsqueeze(-1).unsqueeze(-3)  # (..., x1, 1, x2, 1)
-    y_tmp = y.unsqueeze(-2).unsqueeze(-4)  # (..., 1, y1, 1, y2)
-    out = x_tmp * y_tmp  # (..., x1, y1, x2, y2)
-
-    # reshape the output
-    return out.reshape(batch_dims + kron_dims)  # (..., x1 * y1, x2 * y2)
+# batched Kronecker product of two arrays
+_bkron = jnp.vectorize(jnp.kron, signature='(a,b),(c,d)->(ac,bd)')
 
 
-def expect(O: Tensor, x: Tensor) -> Tensor:
+def expect(O: ArrayLike, x: ArrayLike) -> Array:
     r"""Returns the expectation value of an operator on a ket, bra or density matrix.
 
     The expectation value $\braket{O}$ of an operator $O$ is computed
@@ -245,17 +237,18 @@ def expect(O: Tensor, x: Tensor) -> Tensor:
     - as $\braket{O}=\tr{O\rho}$ if `x` is a density matrix $\rho$.
 
     Warning:
-        The returned tensor is complex-valued. If the operator $O$ corresponds to a
+        The returned array is complex-valued. If the operator $O$ corresponds to a
         physical observable, it is Hermitian: $O^\dag=O$, and the expectation value
-        is real. One can then keep only the real values of the returned tensor using
+        is real. One can then keep only the real values of the returned array using
         `dq.expect(O, x).real`.
 
     Args:
-        O _(n, n)_: Arbitrary operator.
-        x _(..., n, 1) or (..., 1, n) or (..., n, n)_: Ket, bra or density matrix.
+        O _(array_like of shape (n, n))_: Arbitrary operator.
+        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
+            density matrix.
 
     Returns:
-        _(...)_ Complex-valued expectation value.
+        _(array of shape (...))_ Complex-valued expectation value.
 
     Raises:
         ValueError: If `x` is not a ket, bra or density matrix.
@@ -263,33 +256,37 @@ def expect(O: Tensor, x: Tensor) -> Tensor:
     Examples:
         >>> a = dq.destroy(16)
         >>> psi = dq.coherent(16, 2.0)
-        >>> dq.expect(a.mH @ a, psi)
-        tensor(4.000+0.j)
+        >>> dq.expect(dq.dag(a) @ a, psi)
+        Array(4.+0.j, dtype=complex64)
     """
+    O = jnp.asarray(O)
+    x = jnp.asarray(x)
+
     if isket(x):
-        return torch.einsum('...ij,jk,...kl->...', x.mH, O, x)  # <x|O|x>
+        return (dag(x) @ O @ x).squeeze((-1, -2))  # <x|O|x>
     elif isbra(x):
-        return torch.einsum('...ij,jk,...kl->...', x, O, x.mH)
+        return (x @ O @ dag(x)).squeeze((-1, -2))
     elif isdm(x):
-        return torch.einsum('ij,...ji->...', O, x)  # tr(Ox)
+        return trace(O @ x)  # tr(Ox)
     else:
         raise ValueError(
             'Argument `x` must be a ket, bra or density matrix, but has shape'
-            f' {tuple(x.shape)}.'
+            f' {x.shape}.'
         )
 
 
-def norm(x: Tensor) -> Tensor:
+def norm(x: ArrayLike) -> Array:
     r"""Returns the norm of a ket, bra or density matrix.
 
     For a ket or a bra, the returned norm is $\sqrt{\braket{\psi|\psi}}$. For a density
     matrix, it is $\tr{\rho}$.
 
     Args:
-        x _(..., n, 1) or (..., 1, n) or (..., n, n)_: Ket, bra or density matrix.
+        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
+            density matrix.
 
     Returns:
-        _(...)_ Real-valued norm of `x`.
+        _(array of shape (...))_ Real-valued norm of `x`.
 
     Raises:
         ValueError: If `x` is not a ket, bra or density matrix.
@@ -298,48 +295,53 @@ def norm(x: Tensor) -> Tensor:
         For a ket:
         >>> psi = dq.fock(4, 0) + dq.fock(4, 1)
         >>> dq.norm(psi)
-        tensor(1.414)
+        Array(1.414, dtype=float32)
 
         For a density matrix:
         >>> rho = dq.fock_dm(4, 0) + dq.fock_dm(4, 1) + dq.fock_dm(4, 2)
         >>> dq.norm(rho)
-        tensor(3.)
+        Array(3., dtype=float32)
     """
+    x = jnp.asarray(x)
+
     if isket(x) or isbra(x):
-        return torch.linalg.norm(x, dim=(-2, -1)).real
+        return jnp.linalg.norm(x, axis=(-1, -2)).real
     elif isdm(x):
         return trace(x).real
     else:
         raise ValueError(
             'Argument `x` must be a ket, bra or density matrix, but has shape'
-            f' {tuple(x.shape)}.'
+            f' {x.shape}.'
         )
 
 
-def unit(x: Tensor) -> Tensor:
+def unit(x: ArrayLike) -> Array:
     r"""Normalize a ket, bra or density matrix to unit norm.
 
     The returned object is divided by its norm (see [`dq.norm()`][dynamiqs.norm]).
 
     Args:
-        x _(..., n, 1) or (..., 1, n) or (..., n, n)_: Ket, bra or density matrix.
+        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
+            density matrix.
 
     Returns:
-        _(..., n, 1) or (..., 1, n) or (..., n, n)_ Normalized ket, bra or density
-            matrix.
+        _(array of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Normalized ket,
+            bra or density matrix.
 
     Examples:
         >>> psi = dq.fock(4, 0) + dq.fock(4, 1)
         >>> dq.norm(psi)
-        tensor(1.414)
+        Array(1.414, dtype=float32)
         >>> psi = dq.unit(psi)
         >>> dq.norm(psi)
-        tensor(1.000)
+        Array(1., dtype=float32)
     """
+    x = jnp.asarray(x)
+
     return x / norm(x)[..., None, None]
 
 
-def dissipator(L: Tensor, rho: Tensor) -> Tensor:
+def dissipator(L: ArrayLike, rho: ArrayLike) -> Array:
     r"""Applies the Lindblad dissipation superoperator to a density matrix.
 
     The dissipation superoperator $\mathcal{D}[L]$ is defined by:
@@ -349,26 +351,30 @@ def dissipator(L: Tensor, rho: Tensor) -> Tensor:
     $$
 
     Args:
-        L _(..., n, n)_: Jump operator.
-        rho _(..., n, n)_: Density matrix.
+        L _(array_like of shape (..., n, n))_: Jump operator.
+        rho _(array_like of shape (..., n, n))_: Density matrix.
 
     Returns:
-        _(..., n, n)_ Resulting operator (it is not a density matrix).
+        _(array of shape (..., n, n))_ Resulting operator (it is not a density matrix).
 
     Examples:
         >>> L = dq.destroy(4)
         >>> rho = dq.fock_dm(4, 2)
         >>> dq.dissipator(L, rho)
-        tensor([[ 0.000+0.j,  0.000+0.j,  0.000+0.j,  0.000+0.j],
-                [ 0.000+0.j,  2.000+0.j,  0.000+0.j,  0.000+0.j],
-                [ 0.000+0.j,  0.000+0.j, -2.000+0.j,  0.000+0.j],
-                [ 0.000+0.j,  0.000+0.j,  0.000+0.j,  0.000+0.j]])
+        Array([[ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
+               [ 0.+0.j,  2.+0.j,  0.+0.j,  0.+0.j],
+               [ 0.+0.j,  0.+0.j, -2.+0.j,  0.+0.j],
+               [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j]], dtype=complex64)
     """
-    LdagL = L.mH @ L
-    return L @ rho @ L.mH - 0.5 * LdagL @ rho - 0.5 * rho @ LdagL
+    L = jnp.asarray(L)
+    rho = jnp.asarray(rho)
+
+    Ldag = dag(L)
+    LdagL = Ldag @ L
+    return L @ rho @ Ldag - 0.5 * LdagL @ rho - 0.5 * rho @ LdagL
 
 
-def lindbladian(H: Tensor, jump_ops: list[Tensor] | Tensor, rho: Tensor) -> Tensor:
+def lindbladian(H: ArrayLike, jump_ops: ArrayLike, rho: ArrayLike) -> Array:
     r"""Applies the Lindbladian superoperator to a density matrix.
 
     The Lindbladian superoperator $\mathcal{L}$ is defined by:
@@ -384,239 +390,235 @@ def lindbladian(H: Tensor, jump_ops: list[Tensor] | Tensor, rho: Tensor) -> Tens
         This superoperator is also sometimes called *Liouvillian*.
 
     Args:
-        H _(..., n, n)_: Hamiltonian.
-        jump_ops _(list of tensor (..., n, n), or tensor (N, ..., n, n))_: Sequence of
-            jump operators.
-        rho _(..., n, n)_: Density matrix.
+        H _(array_like of shape (..., n, n))_: Hamiltonian.
+        jump_ops _(array_like of shape (N, ..., n, n))_: Sequence of jump operators.
+        rho _(array_like of shape (..., n, n))_: Density matrix.
 
     Returns:
-        _(..., n, n)_ Resulting operator (it is not a density matrix).
+        _(array of shape (..., n, n))_ Resulting operator (it is not a density matrix).
 
     Examples:
         >>> a = dq.destroy(4)
-        >>> H = a.mH @ a
-        >>> L = torch.stack([a, a.mH @ a])
+        >>> H = dq.dag(a) @ a
+        >>> L = [a, dq.dag(a) @ a]
         >>> rho = dq.fock_dm(4, 1)
         >>> dq.lindbladian(H, L, rho)
-        tensor([[ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
-                [ 0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j],
-                [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
-                [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j]])
-    """
-    Ls = torch.stack(jump_ops) if isinstance(jump_ops, list) else jump_ops
-    return -1j * (H @ rho - rho @ H) + dissipator(Ls, rho).sum(0)
+        Array([[ 1.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
+               [ 0.+0.j, -1.+0.j,  0.+0.j,  0.+0.j],
+               [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
+               [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j]], dtype=complex64)
+    """  # noqa: E501
+    H = jnp.asarray(H)
+    jump_ops = jnp.asarray(jump_ops)
+    rho = jnp.asarray(rho)
+
+    return -1j * (H @ rho - rho @ H) + dissipator(jump_ops, rho).sum(0)
 
 
-def isket(x: Tensor) -> bool:
-    r"""Returns True if a tensor is in the format of a ket.
+def isket(x: ArrayLike) -> bool:
+    r"""Returns True if the array is in the format of a ket.
 
     Args:
-        x _(...)_: Tensor.
+        x _(array_like of shape (...))_: Array.
 
     Returns:
         True if the last dimension of `x` is 1, False otherwise.
 
     Examples:
-        >>> dq.isket(torch.ones(3, 1))
+        >>> dq.isket(jnp.ones((3, 1)))
         True
-        >>> dq.isket(torch.ones(5, 3, 1))
+        >>> dq.isket(jnp.ones((5, 3, 1)))
         True
-        >>> dq.isket(torch.ones(3, 3))
+        >>> dq.isket(jnp.ones((3, 3)))
         False
     """
-    return x.size(-1) == 1
+    x = jnp.asarray(x)
+    return x.shape[-1] == 1
 
 
-def isbra(x: Tensor) -> bool:
-    r"""Returns True if a tensor is in the format of a bra.
+def isbra(x: ArrayLike) -> bool:
+    r"""Returns True if the array is in the format of a bra.
 
     Args:
-        x _(...)_: Tensor.
+        x _(array_like of shape (...))_: Array.
 
     Returns:
         True if the second to last dimension of `x` is 1, False otherwise.
 
     Examples:
-        >>> dq.isbra(torch.ones(1, 3))
+        >>> dq.isbra(jnp.ones((1, 3)))
         True
-        >>> dq.isbra(torch.ones(5, 1, 3))
+        >>> dq.isbra(jnp.ones((5, 1, 3)))
         True
-        >>> dq.isbra(torch.ones(3, 3))
+        >>> dq.isbra(jnp.ones((3, 3)))
         False
     """
-    return x.size(-2) == 1
+    x = jnp.asarray(x)
+    return x.shape[-2] == 1
 
 
-def isdm(x: Tensor) -> bool:
-    r"""Returns True if a tensor is in the format of a density matrix.
+def isdm(x: ArrayLike) -> bool:
+    r"""Returns True if the array is in the format of a density matrix.
 
     Args:
-        x _(...)_: Tensor.
+        x _(array_like of shape (...))_: Array.
 
     Returns:
         True if the last two dimensions of `x` are equal, False otherwise.
 
     Examples:
-        >>> dq.isdm(torch.ones(3, 3))
+        >>> dq.isdm(jnp.ones((3, 3)))
         True
-        >>> dq.isdm(torch.ones(5, 3, 3))
+        >>> dq.isdm(jnp.ones((5, 3, 3)))
         True
-        >>> dq.isdm(torch.ones(3, 1))
+        >>> dq.isdm(jnp.ones((3, 1)))
         False
     """
-    return x.size(-1) == x.size(-2)
+    x = jnp.asarray(x)
+    return x.shape[-1] == x.shape[-2]
 
 
-def isop(x: Tensor) -> bool:
-    r"""Returns True if a tensor is in the format of an operator.
+def isop(x: ArrayLike) -> bool:
+    r"""Returns True if the array is in the format of an operator.
 
     Args:
-        x _(...)_: Tensor.
+        x _(array_like of shape (...))_: Array.
 
     Returns:
         True if the last two dimensions of `x` are equal, False otherwise.
 
     Examples:
-        >>> dq.isop(torch.ones(3, 3))
+        >>> dq.isop(jnp.ones((3, 3)))
         True
-        >>> dq.isop(torch.ones(5, 3, 3))
+        >>> dq.isop(jnp.ones((5, 3, 3)))
         True
-        >>> dq.isop(torch.ones(3, 1))
+        >>> dq.isop(jnp.ones((3, 1)))
         False
     """
-    return x.size(-1) == x.size(-2)
+    x = jnp.asarray(x)
+    return x.shape[-1] == x.shape[-2]
 
 
-def _quantum_type(x: Tensor) -> str:
-    """Returns the quantum type of a tensor."""
-    if isket(x):
-        return 'ket'
-    elif isbra(x):
-        return 'bra'
-    elif isdm(x):
-        return 'density matrix'
-    else:
-        raise ValueError(
-            'Argument `x` must be a ket, bra or density matrix, but has shape'
-            f' {tuple(x.shape)}.'
-        )
-
-
-def toket(x: Tensor) -> Tensor:
+def toket(x: ArrayLike) -> Array:
     r"""Returns the ket representation of a pure quantum state.
 
     Args:
-        x _(..., 1, n) or (..., n, 1)_: Input bra or ket.
+        x _(array_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
-        _(..., n, 1)_ Ket.
+        _(array of shape (..., n, 1))_ Ket.
 
     Examples:
         >>> psi = dq.tobra(dq.fock(3, 0))  # shape: (1, 3)
         >>> psi
-        tensor([[1.-0.j, 0.-0.j, 0.-0.j]])
+        Array([[1.-0.j, 0.-0.j, 0.-0.j]], dtype=complex64)
         >>> dq.toket(psi)  # shape: (3, 1)
-        tensor([[1.+0.j],
-                [0.+0.j],
-                [0.+0.j]])
+        Array([[1.+0.j],
+               [0.+0.j],
+               [0.+0.j]], dtype=complex64)
     """
+    x = jnp.asarray(x)
+
     if isbra(x):
-        return x.mH
+        return dag(x)
     elif isket(x):
         return x
     else:
-        raise ValueError(
-            f'Argument `x` must be a ket or bra, but has shape {tuple(x.shape)}.'
-        )
+        raise ValueError(f'Argument `x` must be a ket or bra, but has shape {x.shape}.')
 
 
-def tobra(x: Tensor) -> Tensor:
+def tobra(x: ArrayLike) -> Array:
     r"""Returns the bra representation of a pure quantum state.
 
     Args:
-        x _(..., 1, n) or (..., n, 1)_: Input bra or ket.
+        x _(array_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
-        _(..., 1, n)_ Bra.
+        _(array of shape (..., 1, n))_ Bra.
 
     Examples:
         >>> psi = dq.fock(3, 0)  # shape: (3, 1)
         >>> psi
-        tensor([[1.+0.j],
-                [0.+0.j],
-                [0.+0.j]])
+        Array([[1.+0.j],
+               [0.+0.j],
+               [0.+0.j]], dtype=complex64)
         >>> dq.tobra(psi)  # shape: (1, 3)
-        tensor([[1.-0.j, 0.-0.j, 0.-0.j]])
+        Array([[1.-0.j, 0.-0.j, 0.-0.j]], dtype=complex64)
     """
+    x = jnp.asarray(x)
+
     if isbra(x):
         return x
     elif isket(x):
-        return x.mH
+        return dag(x)
     else:
-        raise ValueError(
-            f'Argument `x` must be a ket or bra, but has shape {tuple(x.shape)}.'
-        )
+        raise ValueError(f'Argument `x` must be a ket or bra, but has shape {x.shape}.')
 
 
-def todm(x: Tensor) -> Tensor:
+def todm(x: ArrayLike) -> Array:
     r"""Returns the density matrix representation of a quantum state.
 
     Args:
-        x _(..., 1, n), (..., n, 1) or (..., n, n)_: Input bra, ket or density
-            matrix.
+        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
+            density matrix.
 
     Returns:
-        _(..., n, n)_ Density matrix.
+        _(array of shape (..., n, n))_ Density matrix.
 
     Examples:
         >>> psi = dq.fock(3, 0)  # shape: (3, 1)
         >>> psi
-        tensor([[1.+0.j],
-                [0.+0.j],
-                [0.+0.j]])
+        Array([[1.+0.j],
+               [0.+0.j],
+               [0.+0.j]], dtype=complex64)
         >>> dq.todm(psi)  # shape: (3, 3)
-        tensor([[1.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j],
-                [0.+0.j, 0.+0.j, 0.+0.j]])
+        Array([[1.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j],
+               [0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
     """
+    x = jnp.asarray(x)
+
     if isbra(x):
-        return x.mH @ x
+        return dag(x) @ x
     elif isket(x):
-        return x @ x.mH
+        return x @ dag(x)
     elif isdm(x):
         return x
     else:
         raise ValueError(
             'Argument `x` must be a ket, bra or density matrix, but has shape'
-            f' {tuple(x.shape)}.'
+            f' {x.shape}.'
         )
 
 
-def braket(x: Tensor, y: Tensor) -> Tensor:
+def braket(x: ArrayLike, y: ArrayLike) -> Array:
     r"""Returns the inner product $\braket{\psi|\varphi}$ between two kets.
 
     Args:
-        x _(..., n, 1)_: Left-side ket.
-        y _(..., n, 1)_: Right-side ket.
+        x (array_like of shape _(..., n, 1))_: Left-side ket.
+        y (array_like of shape _(..., n, 1))_: Right-side ket.
 
     Returns:
-        _(...)_ Complex-valued inner product.
+        _(array of shape (...))_ Complex-valued inner product.
 
     Examples:
         >>> fock0 = dq.fock(3, 0)
         >>> fock01 = dq.unit(dq.fock(3, 0) + dq.fock(3, 1))
         >>> dq.braket(fock0, fock01)
-        tensor(0.707+0.j)
+        Array(0.707+0.j, dtype=complex64)
     """
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
+
     if not isket(x):
-        raise ValueError(f'Argument `x` must be a ket but has shape {tuple(x.shape)}.')
+        raise ValueError(f'Argument `x` must be a ket but has shape {x.shape}.')
     if not isket(y):
-        raise ValueError(f'Argument `y` must be a ket but has shape {tuple(y.shape)}.')
+        raise ValueError(f'Argument `y` must be a ket but has shape {y.shape}.')
 
-    return (x.mH @ y).squeeze(-2, -1)
+    return (dag(x) @ y).squeeze((-1, -2))
 
 
-def overlap(x: Tensor, y: Tensor) -> Tensor:
+def overlap(x: ArrayLike, y: ArrayLike) -> Array:
     r"""Returns the overlap between two quantum states.
 
     The overlap is computed
@@ -629,42 +631,43 @@ def overlap(x: Tensor, y: Tensor) -> Tensor:
       $\sigma$.
 
     Args:
-        x _(..., n, 1) or (..., n, n)_: Ket or density matrix.
-        y _(..., n, 1) or (..., n, n)_: Ket or density matrix.
+        x _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        y _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
-        _(...)_ Real-valued overlap.
+        _(array of shape (...))_ Real-valued overlap.
 
     Examples:
         >>> fock0 = dq.fock(3, 0)
         >>> dq.overlap(fock0, fock0)
-        tensor(1.)
+        Array(1., dtype=float32)
         >>> fock01_dm = 0.5 * (dq.fock_dm(3, 0) + dq.fock_dm(3, 1))
         >>> dq.overlap(fock0, fock01_dm)
-        tensor(0.500)
+        Array(0.5, dtype=float32)
     """
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
+
     if not isket(x) and not isdm(x):
         raise ValueError(
-            'Argument `x` must be a ket or density matrix, but has shape'
-            f' {tuple(x.shape)}.'
+            f'Argument `x` must be a ket or density matrix, but has shape {x.shape}.'
         )
     if not isket(y) and not isdm(y):
         raise ValueError(
-            'Argument `y` must be a ket or density matrix, but has shape'
-            f' {tuple(y.shape)}.'
+            f'Argument `y` must be a ket or density matrix, but has shape {y.shape}.'
         )
 
     if isket(x) and isket(y):
-        return (x.mH @ y).squeeze(-2, -1).abs().pow(2)
+        return jnp.abs((dag(x) @ y).squeeze((-1, -2))) ** 2
     elif isket(x):
-        return (x.mH @ y @ x).squeeze(-2, -1).abs()
+        return jnp.abs((dag(x) @ y @ x).squeeze((-1, -2)))
     elif isket(y):
-        return (y.mH @ x @ y).squeeze(-2, -1).abs()
+        return jnp.abs((dag(y) @ x @ y).squeeze((-1, -2)))
     else:
-        return trace(x.mH @ y).squeeze(-2, -1).real
+        return trace(dag(x) @ y).squeeze((-1, -2)).real
 
 
-def fidelity(x: Tensor, y: Tensor) -> Tensor:
+def fidelity(x: ArrayLike, y: ArrayLike) -> Array:
     r"""Returns the fidelity of two states, kets or density matrices.
 
     The fidelity is computed
@@ -681,60 +684,49 @@ def fidelity(x: Tensor, y: Tensor) -> Tensor:
         fidelity $F_\text{qutip} = \sqrt{F}$.
 
     Args:
-        x _(..., n, 1) or (..., n, n)_: Ket or density matrix.
-        y _(..., n, 1) or (..., n, n)_: Ket or density matrix.
+        x _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        y _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
-        _(...)_ Real-valued fidelity.
+        _(array of shape (...))_ Real-valued fidelity.
 
     Examples:
         >>> fock0 = dq.fock(3, 0)
         >>> dq.fidelity(fock0, fock0)
-        tensor(1.)
+        Array(1., dtype=float32)
         >>> fock01_dm = 0.5 * (dq.fock_dm(3, 1) + dq.fock_dm(3, 0))
         >>> dq.fidelity(fock01_dm, fock01_dm)
-        tensor(1.000)
+        Array(1., dtype=float32)
         >>> dq.fidelity(fock0, fock01_dm)
-        tensor(0.500)
+        Array(0.5, dtype=float32)
     """
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
+
     if isket(x) or isket(y):
         return overlap(x, y)
     else:
         return _dm_fidelity(x, y)
 
 
-def _dm_fidelity(x: Tensor, y: Tensor) -> Tensor:
+def _dm_fidelity(x: ArrayLike, y: ArrayLike) -> Array:
     # returns the fidelity of two density matrices: Tr[sqrt(sqrt(x) @ y @ sqrt(x))]^2
     # x: (..., n, n), y: (..., n, n) -> (...)
-    sqrtm_x = _sqrtm(x)
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
+
+    sqrtm_x = _bsqrtm(x)
     tmp = sqrtm_x @ y @ sqrtm_x
 
     # we don't need the whole matrix `sqrtm(tmp)`, just its trace, which can be computed
     # by summing the square roots of `tmp` eigenvalues
-    eigvals_tmp = torch.linalg.eigvalsh(tmp)
-
+    eigvals_tmp = jnp.linalg.eigvalsh(tmp)
     # we set small negative eigenvalues errors to zero to avoid `nan` propagation
-    zero = torch.zeros((), dtype=x.dtype, device=x.device)
-    eigvals_tmp = eigvals_tmp.where(eigvals_tmp >= 0, zero)
+    eigvals_tmp = jnp.where(eigvals_tmp < 0, 0, eigvals_tmp)
+    trace_sqrtm_tmp = jnp.sqrt(eigvals_tmp).sum(-1)
 
-    trace_sqrtm_tmp = torch.sqrt(eigvals_tmp).sum(-1)
-
-    return trace_sqrtm_tmp.pow(2).real
+    return (trace_sqrtm_tmp**2).real
 
 
-def _sqrtm(x: Tensor) -> Tensor:
-    """Returns the square root of a symmetric or Hermitian positive definite matrix.
-
-    Args:
-        x _(..., n, n)_: Symmetric or Hermitian positive definite matrix.
-
-    Returns:
-        _(..., n, n)_ Square root of `x`.
-    """
-    # code copied from
-    # https://github.com/pytorch/pytorch/issues/25481#issuecomment-1032789228
-    L, Q = torch.linalg.eigh(x)
-    zero = torch.zeros((), dtype=L.dtype, device=L.device)
-    threshold = L.max(-1).values * L.size(-1) * torch.finfo(L.dtype).eps
-    L = L.where(L > threshold.unsqueeze(-1), zero)  # zero out small components
-    return (Q * L.sqrt().unsqueeze(-2)) @ Q.mH
+# batched matrix square root
+_bsqrtm = jnp.vectorize(jax.scipy.linalg.sqrtm, signature='(m,n)->(m,n)')

--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -219,9 +219,8 @@ def tensprod(*args: ArrayLike) -> Array:
     """
     args = [jnp.asarray(arg) for arg in args]
 
+    # todo: use jax.lax.reduce
     return reduce(_bkron, args)
-    # JAXDO: jax.lax.reduce?
-    # JAXDO: ok if not all fully batched as long as batch-compatible
 
 
 # batched Kronecker product of two arrays

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from math import sqrt
-
-import torch
-from torch import Tensor
+import jax.numpy as jnp
+from jax import Array
+from jaxtyping import ArrayLike
 
 from .operators import eye
-from .utils import _bkron
+from .utils import _bkron, dag
 
 __all__ = [
     'operator_to_vector',
@@ -19,7 +18,7 @@ __all__ = [
 ]
 
 
-def operator_to_vector(x: Tensor) -> Tensor:
+def operator_to_vector(x: ArrayLike) -> Array:
     r"""Returns the vectorized version of an operator.
 
     The vectorized column vector $\kett{A}$ (shape $n^2\times 1$) is obtained by
@@ -31,27 +30,28 @@ def operator_to_vector(x: Tensor) -> Tensor:
     $$
 
     Args:
-        x _(..., n, n)_: Operator.
+        x _(array_like of shape (..., n, n))_: Operator.
 
     Returns:
-        _(..., n^2, 1)_ Vectorized operator.
+        _(array of shape (..., n^2, 1))_ Vectorized operator.
 
     Examples:
-        >>> A = torch.tensor([[1, 2], [3, 4]])
+        >>> A = jnp.array([[1, 2], [3, 4]])
         >>> A
-        tensor([[1, 2],
-                [3, 4]])
+        Array([[1, 2],
+               [3, 4]], dtype=int32)
         >>> dq.operator_to_vector(A)
-        tensor([[1],
-                [3],
-                [2],
-                [4]])
+        Array([[1],
+               [3],
+               [2],
+               [4]], dtype=int32)
     """
-    batch_sizes = x.shape[:-2]
-    return x.mT.reshape(*batch_sizes, -1, 1)
+    x = jnp.asarray(x)
+    bshape = x.shape[:-2]
+    return dag(x).reshape(*bshape, -1, 1)
 
 
-def vector_to_operator(x: Tensor) -> Tensor:
+def vector_to_operator(x: ArrayLike) -> Array:
     r"""Returns the operator version of a vectorized operator.
 
     The matrix $A$ (shape $n\times n$) is obtained by stacking horizontally next to
@@ -64,28 +64,29 @@ def vector_to_operator(x: Tensor) -> Tensor:
     $$
 
     Args:
-        x _(..., n^2, 1)_: Vectorized operator.
+        x _(array_like of shape (..., n^2, 1))_: Vectorized operator.
 
     Returns:
-        _(..., n, n)_ Operator.
+        _(array of shape (..., n, n))_ Operator.
 
     Examples:
-        >>> Avec = torch.tensor([[1], [2], [3], [4]])
+        >>> Avec = jnp.array([[1], [2], [3], [4]])
         >>> Avec
-        tensor([[1],
-                [2],
-                [3],
-                [4]])
+        Array([[1],
+               [2],
+               [3],
+               [4]], dtype=int32)
         >>> dq.vector_to_operator(Avec)
-        tensor([[1, 3],
-                [2, 4]])
+        Array([[1, 3],
+               [2, 4]], dtype=int32)
     """
+    x = jnp.asarray(x)
     batch_sizes = x.shape[:-2]
-    n = int(sqrt(x.shape[-2]))
+    n = int(jnp.sqrt(x.shape[-2]))
     return x.reshape(*batch_sizes, n, n).mT
 
 
-def spre(x: Tensor) -> Tensor:
+def spre(x: ArrayLike) -> Array:
     r"""Returns the superoperator formed from pre-multiplication by an operator.
 
     Pre-multiplication by matrix $A$ is defined by the superoperator
@@ -95,21 +96,22 @@ def spre(x: Tensor) -> Tensor:
     $$
 
     Args:
-        x _(..., n, n)_: Operator.
+        x _(array_like of shape (..., n, n))_: Operator.
 
     Returns:
-        _(..., n^2, n^2)_ Pre-multiplication superoperator.
+        _(array of shape (..., n^2, n^2))_ Pre-multiplication superoperator.
 
     Examples:
         >>> dq.spre(dq.destroy(3)).shape
-        torch.Size([9, 9])
+        (9, 9)
     """
-    n = x.size(-1)
+    x = jnp.asarray(x)
+    n = x.shape[-1]
     I = eye(n)
-    return torch.kron(I, x)
+    return _bkron(I, x)
 
 
-def spost(x: Tensor) -> Tensor:
+def spost(x: ArrayLike) -> Array:
     r"""Returns the superoperator formed from post-multiplication by an operator.
 
     Post-multiplication by matrix $A$ is defined by the superoperator
@@ -119,24 +121,22 @@ def spost(x: Tensor) -> Tensor:
     $$
 
     Args:
-        x _(..., n, n)_: Operator.
+        x _(array_like of shape (..., n, n))_: Operator.
 
     Returns:
-        _(..., n^2, n^2)_ Post-multiplication superoperator.
+        _(array of shape (..., n^2, n^2))_ Post-multiplication superoperator.
 
     Examples:
         >>> dq.spost(dq.destroy(3)).shape
-        torch.Size([9, 9])
+        (9, 9)
     """
-    n = x.size(-1)
+    x = jnp.asarray(x)
+    n = x.shape[-1]
     I = eye(n)
-    # torch.kron has undocumented dependence on memory layout, so we need to use
-    # contiguous() here, see e.g. https://github.com/pytorch/pytorch/issues/74442
-    # and https://github.com/pytorch/pytorch/issues/54135
-    return torch.kron(x.mT.contiguous(), I)
+    return _bkron(dag(x), I)
 
 
-def sprepost(x: Tensor, y: Tensor) -> Tensor:
+def sprepost(x: ArrayLike, y: ArrayLike) -> Array:
     r"""Returns the superoperator formed from pre- and post-multiplication by operators.
 
     Pre-multiplication by matrix $A$ and post-multiplication by matrix $B$ is defined
@@ -146,20 +146,22 @@ def sprepost(x: Tensor, y: Tensor) -> Tensor:
     $$
 
     Args:
-        x _(..., n, n)_: Operator for pre-multiplication.
-        y _(..., n, n)_: Operator for post-multiplication.
+        x _(array_like of shape (..., n, n))_: Operator for pre-multiplication.
+        y _(array_like of shape (..., n, n))_: Operator for post-multiplication.
 
     Returns:
-        _(..., n^2, n^2)_ Pre- and post-multiplication superoperator.
+        _(array of shape (..., n^2, n^2))_ Pre- and post-multiplication superoperator.
 
     Examples:
         >>> dq.sprepost(dq.destroy(3), dq.create(3)).shape
-        torch.Size([9, 9])
+        (9, 9)
     """
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
     return _bkron(y.mT, x)
 
 
-def sdissipator(L: Tensor) -> Tensor:
+def sdissipator(L: ArrayLike) -> Array:
     r"""Returns the Lindblad dissipation superoperator (in matrix form).
 
     The dissipation superoperator $\mathcal{D}[L]$ is defined by:
@@ -176,16 +178,18 @@ def sdissipator(L: Tensor) -> Tensor:
     $$
 
     Args:
-        L _(..., n, n)_: Jump operator.
+        L _(array_like of shape (..., n, n))_: Jump operator.
 
     Returns:
-        _(..., n^2, n^2)_ Dissipation superoperator.
+        _(array of shape (..., n^2, n^2))_ Dissipation superoperator.
     """
-    LdagL = L.mH @ L
-    return sprepost(L, L.mH) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
+    L = jnp.asarray(L)
+    Ldag = dag(L)
+    LdagL = Ldag @ L
+    return sprepost(L, Ldag) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
 
 
-def slindbladian(H: Tensor, jump_ops: list[Tensor] | Tensor) -> Tensor:
+def slindbladian(H: ArrayLike, jump_ops: ArrayLike) -> Array:
     r"""Returns the Lindbladian superoperator (in matrix form).
 
     The Lindbladian superoperator $\mathcal{L}$ is defined by:
@@ -210,12 +214,12 @@ def slindbladian(H: Tensor, jump_ops: list[Tensor] | Tensor) -> Tensor:
         This superoperator is also sometimes called *Liouvillian*.
 
     Args:
-        H _(..., n, n)_: Hamiltonian.
-        jump_ops _(list of tensor (..., n, n), or tensor (N, ..., n, n))_: Sequence of
-            jump operators.
+        H _(array_like of shape (..., n, n))_: Hamiltonian.
+        jump_ops _(array_like of shape (N, ..., n, n))_: Sequence of jump operators.
 
     Returns:
-        _(..., n^2, n^2)_ Lindbladian superoperator.
-    """
-    Ls = torch.stack(jump_ops) if isinstance(jump_ops, list) else jump_ops
-    return -1j * (spre(H) - spost(H)) + sdissipator(Ls).sum(0)
+        _(array of shape (..., n^2, n^2))_ Lindbladian superoperator.
+    """  # noqa: E501
+    H = jnp.asarray(H)
+    jump_ops = jnp.asarray(jump_ops)
+    return -1j * (spre(H) - spost(H)) + sdissipator(jump_ops).sum(0)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -175,10 +175,7 @@ nav:
               - overlap: python_api/utils/utils/overlap.md
               - fidelity: python_api/utils/utils/fidelity.md
           - Tensor conversion:
-              - to_tensor: python_api/utils/tensor_types/to_tensor.md
-              - to_numpy: python_api/utils/tensor_types/to_numpy.md
               - to_qutip: python_api/utils/tensor_types/to_qutip.md
-              - from_qutip: python_api/utils/tensor_types/from_qutip.md
           - Wigner distribution:
               - wigner: python_api/utils/wigners/wigner.md
           - Vectorization:
@@ -192,7 +189,6 @@ nav:
           - Quantum optimal control:
               - rand_real: python_api/utils/optimal_control/rand_real.md
               - rand_complex: python_api/utils/optimal_control/rand_complex.md
-              - pwc_pulse: python_api/utils/optimal_control/pwc_pulse.md
               - snap_gate: python_api/utils/optimal_control/snap_gate.md
               - cd_gate: python_api/utils/optimal_control/cd_gate.md
           - Plotting:

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,5 +1,5 @@
+import jax.numpy as jnp
 import qutip as qt
-import torch
 from pytest import approx
 
 import dynamiqs as dq
@@ -7,14 +7,18 @@ import dynamiqs as dq
 
 def test_ket_fidelity_correctness():
     n = 8
+
+    # qutip
     psi = qt.rand_ket(n, seed=42)
-    psi_tensor = dq.from_qutip(psi)
     phi = qt.rand_ket(n, seed=43)
-    phi_tensor = dq.from_qutip(phi)
-
     qt_fid = qt.fidelity(psi, phi) ** 2
-    dq_fid = dq.fidelity(psi_tensor, phi_tensor).item()
 
+    # dynamiqs
+    psi = jnp.asarray(psi)
+    phi = jnp.asarray(phi)
+    dq_fid = dq.fidelity(psi, phi).item()
+
+    # compare
     assert qt_fid == approx(dq_fid)
 
 
@@ -22,44 +26,52 @@ def test_ket_fidelity_batching():
     b1, b2, n = 3, 5, 8
     psi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
     phi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
-    psi = dq.to_tensor(psi)
-    phi = dq.to_tensor(phi)
+    psi = jnp.asarray(psi)
+    phi = jnp.asarray(phi)
     assert dq.fidelity(psi, phi).shape == (b1, b2)
 
 
 def test_dm_fidelity_correctness():
     n = 8
+
+    # qutip
     rho = qt.rand_dm(n, n, seed=42)
-    rho_tensor = dq.from_qutip(rho)
     sigma = qt.rand_dm(n, n, seed=43)
-    sigma_tensor = dq.from_qutip(sigma)
-
     qt_fid = qt.fidelity(rho, sigma) ** 2
-    dq_fid = dq.fidelity(rho_tensor, sigma_tensor).item()
 
-    assert qt_fid == approx(dq_fid, abs=1e-6)
+    # dynamiqs
+    rho = jnp.asarray(rho)
+    sigma = jnp.asarray(sigma)
+    dq_fid = dq.fidelity(rho, sigma).item()
+
+    # compare
+    assert qt_fid == approx(dq_fid, abs=1e-5)
 
 
 def test_dm_fidelity_batching():
     b1, b2, n = 3, 5, 8
     rho = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
     sigma = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
-    rho = dq.to_tensor(rho)
-    sigma = dq.to_tensor(sigma)
+    rho = jnp.asarray(rho)
+    sigma = jnp.asarray(sigma)
     assert dq.fidelity(rho, sigma).shape == (b1, b2)
 
 
 def test_ket_dm_fidelity_correctness():
     n = 8
+
+    # qutip
     psi = qt.rand_ket(n, seed=42)
-    psi_tensor = dq.from_qutip(psi)
     rho = qt.rand_dm(n, n, seed=43)
-    rho_tensor = dq.from_qutip(rho)
-
     qt_fid = qt.fidelity(psi, rho) ** 2
-    dq_fid_ket_dm = dq.fidelity(psi_tensor, rho_tensor).item()
-    dq_fid_dm_ket = dq.fidelity(rho_tensor, psi_tensor).item()
 
+    # dynmaiqs
+    psi = jnp.asarray(psi)
+    rho = jnp.asarray(rho)
+    dq_fid_ket_dm = dq.fidelity(psi, rho).item()
+    dq_fid_dm_ket = dq.fidelity(rho, psi).item()
+
+    # compare
     assert qt_fid == approx(dq_fid_ket_dm, abs=1e-6)
     assert qt_fid == approx(dq_fid_dm_ket, abs=1e-6)
 
@@ -68,21 +80,21 @@ def test_ket_dm_fidelity_batching():
     b1, b2, n = 3, 5, 8
     psi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n)
     rho = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
-    psi = dq.to_tensor(psi)
-    rho = dq.to_tensor(rho)
+    psi = jnp.asarray(psi)
+    rho = jnp.asarray(rho)
     assert dq.fidelity(rho, psi).shape == (b1, b2)
     assert dq.fidelity(psi, rho).shape == (b1, b2)
 
 
 def test_hadamard():
-    c64 = torch.complex64
+    c64 = jnp.complex64
 
     # one qubit
-    H1 = 2 ** (-1 / 2) * torch.tensor([[1, 1], [1, -1]], dtype=c64)
-    assert torch.allclose(dq.hadamard(1), H1)
+    H1 = 2 ** (-1 / 2) * jnp.array([[1, 1], [1, -1]], dtype=c64)
+    assert jnp.allclose(dq.hadamard(1), H1)
 
     # two qubits
-    H2 = 0.5 * torch.tensor(
+    H2 = 0.5 * jnp.array(
         [
             [1, 1, 1, 1],
             [1, -1, 1, -1],
@@ -91,10 +103,10 @@ def test_hadamard():
         ],
         dtype=c64,
     )
-    assert torch.allclose(dq.hadamard(2), H2)
+    assert jnp.allclose(dq.hadamard(2), H2)
 
     # three qubits
-    H3 = 2 ** (-3 / 2) * torch.tensor(
+    H3 = 2 ** (-3 / 2) * jnp.array(
         [
             [1, 1, 1, 1, 1, 1, 1, 1],
             [1, -1, 1, -1, 1, -1, 1, -1],
@@ -107,4 +119,4 @@ def test_hadamard():
         ],
         dtype=c64,
     )
-    assert torch.allclose(dq.hadamard(3), H3)
+    assert jnp.allclose(dq.hadamard(3), H3)


### PR DESCRIPTION
![Screenshot 2023-12-28 at 18 58 35](https://github.com/dynamiqs/dynamiqs/assets/38159029/919bf5c8-2914-4795-a44e-249adefaea46)

On top of #394.

A lot of things are packed in this PR, sorry for the gigantic change. It transitions the following files from PyTorch to JAX:
```
dynamiqs
└── utils
    ├── operators.py
    ├── optimal_control.py
    ├── states.py
    ├── tensor_types.py
    ├── utils.py
    ├── vectorization.py
    └── wigners.py (partially)
tests
└── utils
    └── test_utils.py
```

The doctest is running on all these files.

Most of the code is similar, some things are more natural to do which is nice! 😊 A few random remarks:
- https://jax.readthedocs.io/en/latest/jax.typing.html advises to type all public APIs argument with `ArrayLike`, so I followed their advice. It's quite amazing, now all our functions work on any QuTiP quantum objects for example (or even lists of QuTiP quantum objects).
- I removed the `device` argument as it is managed differently in JAX.
- I added "array_like" or "array" to all type annotations specifying tensors shape for clarity.
- I removed the functions `to_tensor`, `to_numpy` and `from_qutip` which are replaced by `jnp.asarray`.
- I had to modify `_utils` as a side effet, but it has not been switched to JAX yet.
- JAX array printing is much cleaner, it does not displays extra zeros. 😍
- I did not fully switch `dynamiqs/utils.wigners.py` to JAX, just the `"clenshaw"` method.
- ChatGPT is terrible with JAX, most of the answers are useless. 😭
- JAX does not have a `x.mH`, so I use `dag(x)` everywhere.
- The single main changes are (1) the batched tensor product is now a one-liner using `jnp.vectorize`, (2) `sqrtm()` is natively implemented in JAX.
- JAX mimics NumPy broadcasting which is amazing, for example we can now use the following broadcasting magic:
    ```python
    import dynamiqs as dq
    psi1 = dq.fock(2, 0)  # (2, 1)
    psis = [dq.fock(8, i) for i in range(5)]  # (5, 8, 1)
    dq.tensprod(psi1, psis)  # (5, 16, 1)
    ```