### PR TITLE
Switch `dynamiqs.plots` from PyTorch to JAX [4/?]

### DIFF
--- a/dynamiqs/plots/plots_fock.py
+++ b/dynamiqs/plots/plots_fock.py
@@ -1,17 +1,25 @@
 from __future__ import annotations
 
-import numpy as np
+import jax.numpy as jnp
+from jax import Array
+from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 from matplotlib.colors import ListedColormap, LogNorm, Normalize
 
-from ..utils.tensor_types import ArrayLike, to_numpy
+from ..utils.utils import isdm, isket
 from .utils import add_colorbar, colors, integer_ticks, ket_ticks, optax, sample_cmap
 
 __all__ = ['plot_fock', 'plot_fock_evolution']
 
 
-def populations(s: np.ndarray) -> np.ndarray:
-    return np.abs(s.squeeze()) ** 2 if s.shape[1] == 1 else np.real(np.diag(s))
+def _populations(x: ArrayLike) -> Array:
+    x = jnp.asarray(x)
+    if isket(x):
+        return jnp.abs(x.squeeze(-1)) ** 2
+    elif isdm(x):
+        # batched extract diagonal
+        bdiag = jnp.vectorize(jnp.diag, signature='(a,b)->(c)')
+        return bdiag(x).real
 
 
 @optax
@@ -42,10 +50,11 @@ def plot_fock(
 
         ![plot_fock_even_cat](/figs-code/plot_fock_even_cat.png){.fig}
     """
-    state = to_numpy(state)
+    state = jnp.asarray(state)
+
     n = state.shape[0]
     x = range(n)
-    y = populations(state)
+    y = _populations(state)
 
     # plot
     ax.bar(x, y, color=color)
@@ -60,10 +69,10 @@ def plot_fock(
 
 @optax
 def plot_fock_evolution(
-    states: list[ArrayLike],
+    states: ArrayLike,
     *,
     ax: Axes | None = None,
-    times: np.ndarray | None = None,
+    times: ArrayLike | None = None,
     cmap: str = 'Blues',
     logscale: bool = False,
     logvmin: float = 1e-4,
@@ -79,7 +88,7 @@ def plot_fock_evolution(
         >>> n = 16
         >>> a = dq.destroy(n)
         >>> psi0 = dq.coherent(16, 0.0)
-        >>> H = 2.0 * (a + a.mH)
+        >>> H = 2.0 * (a + dq.dag(a))
         >>> tsave = np.linspace(0, 1.0, 11)
         >>> result = dq.sesolve(H, psi0, tsave)
         >>> dq.plot_fock_evolution(result.states)
@@ -93,18 +102,19 @@ def plot_fock_evolution(
 
         ![plot_fock_evolution_log](/figs-code/plot_fock_evolution_log.png){.fig}
     """
-    states = to_numpy(states)
+    states = jnp.asarray(states)
+    times = jnp.asarray(times) if times is not None else None
 
-    x = np.arange(len(states)) if times is None else times
+    x = jnp.arange(len(states)) if times is None else times
     n = states[0].shape[0]
     y = range(n)
-    z = np.array([populations(s) for s in states]).T
+    z = _populations(states).T
 
     # set norm and colormap
     if logscale:
         norm = LogNorm(vmin=logvmin, vmax=1.0, clip=True)
         # stepped cmap
-        ncolors = int(np.log10(1 / logvmin))
+        ncolors = int(jnp.log10(1 / logvmin))
         clist = sample_cmap(cmap, ncolors + 2)[1:-1]  # remove extremal colors
         cmap = ListedColormap(clist)
     else:

--- a/dynamiqs/plots/plots_hinton.py
+++ b/dynamiqs/plots/plots_hinton.py
@@ -1,29 +1,48 @@
 from __future__ import annotations
 
+from itertools import product
+
+import jax.numpy as jnp
 import matplotlib as mpl
 import matplotlib.patches as patches
 import numpy as np
+from jax import Array
+from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import Normalize
 
-from ..utils.tensor_types import ArrayLike, to_numpy
 from .utils import add_colorbar, bra_ticks, integer_ticks, ket_ticks, optax
 
 __all__ = ['plot_hinton']
 
 
+def _normalize(x: ArrayLike, vmin: float, vmax: float) -> Array:
+    # linearly normalizes data into the [0.0, 1.0] interval
+    # values outside the range [vmin, vmax] are also transformed linearly, resulting in
+    # values outside [0, 1]
+    x = jnp.asarray(x)
+    return (x - vmin) / (vmax - vmin)
+
+
 def _plot_squares(
     ax: Axes,
-    areas: np.ndarray,
-    colors: np.ndarray,
-    offsets: np.ndarray,
+    areas: ArrayLike,
+    colors: ArrayLike,
+    offsets: ArrayLike,
     ecolor: str = 'white',
     ewidth: float = 0.5,
 ):
     # areas: 1D array (n) with real values in [0, 1]
     # colors: 2D array (n, 4) with RGBA values
     # offsets: 2D array (n, 2) with real values in R
+
+    # we convert all inputs to numpy arrays instead of JAX arrays for two reasons:
+    # - to use masking
+    # - to fix `ValueError: Invalid RGBA argument` when using JAX array for colors
+    areas = np.asarray(areas)
+    colors = np.asarray(colors)
+    offsets = np.asarray(offsets)
 
     # compute squares side length
     sides = np.sqrt(areas)
@@ -50,8 +69,8 @@ def _plot_squares(
 
 @optax
 def _plot_hinton(
-    areas: np.ndarray,
-    colors: np.ndarray,
+    areas: ArrayLike,
+    colors: ArrayLike,
     colors_vmin: float,
     colors_vmax: float,
     cmap: str,
@@ -64,6 +83,8 @@ def _plot_hinton(
 ):
     # areas: 2D array (n, n) with real values in [0, 1]
     # colors: 2D array (n, n) with real values in [0, 1]
+    areas = jnp.asarray(areas)
+    colors = jnp.asarray(colors)
 
     areas = areas.clip(0.0, 1.0)
     colors = colors.clip(0.0, 1.0)
@@ -79,8 +100,8 @@ def _plot_hinton(
     integer_ticks(ax.yaxis, n, all=allticks)
 
     # === plot squares
-    # squares coordinates
-    offsets = np.array(list(np.ndindex(areas.shape)))
+    # squares coordinates (cartesian product of all indices)
+    offsets = jnp.asarray(list(product(*(range(s) for s in areas.shape))))
     # squares areas
     areas = areas.T.flatten()
     # squares colors
@@ -92,8 +113,8 @@ def _plot_hinton(
     if colorbar:
         norm = Normalize(colors_vmin, colors_vmax)
         cax = add_colorbar(ax, cmap, norm, size='4%', pad='4%')
-        if colors_vmin == -np.pi and colors_vmax == np.pi:
-            cax.set_yticks([-np.pi, 0.0, np.pi], labels=[r'$-\pi$', r'$0$', r'$\pi$'])
+        if colors_vmin == -jnp.pi and colors_vmax == jnp.pi:
+            cax.set_yticks([-jnp.pi, 0.0, jnp.pi], labels=[r'$-\pi$', r'$0$', r'$\pi$'])
 
 
 @optax
@@ -118,19 +139,19 @@ def plot_hinton(
 
     Examples:
         >>> rho = dq.coherent_dm(16, 2.0)
-        >>> dq.plot_hinton(rho.abs())
+        >>> dq.plot_hinton(jnp.abs(rho))
         >>> renderfig('plot_hinton_coherent')
 
         ![plot_hinton_coherent](/figs-code/plot_hinton_coherent.png){.fig-half}
 
         >>> a = dq.destroy(16)
-        >>> H = a.mH @ a + 2.0 * (a + a.mH)
-        >>> dq.plot_hinton(H.abs())
+        >>> H = dq.dag(a) @ a + 2.0 * (a + dq.dag(a))
+        >>> dq.plot_hinton(jnp.abs(H))
         >>> renderfig('plot_hinton_hamiltonian')
 
         ![plot_hinton_hamiltonian](/figs-code/plot_hinton_hamiltonian.png){.fig-half}
 
-        >>> cnot = torch.tensor(
+        >>> cnot = jnp.array(
         ...     [[1, 0, 0, 0],
         ...      [0, 1, 0, 0],
         ...      [0, 0, 0, 1],
@@ -170,8 +191,8 @@ def plot_hinton(
 
         ![plot_hinton_large](/figs-code/plot_hinton_large.png){.fig}
     """  # noqa: E501
+    x = jnp.asarray(x)
 
-    x = to_numpy(x)
     if x.ndim != 2 or x.shape[0] != x.shape[1]:
         raise ValueError(
             f'Argument `x` must be a 2D square array, but has shape {x.shape}.'
@@ -179,40 +200,40 @@ def plot_hinton(
 
     # set different defaults, areas and colors for real matrix, positive real matrix
     # and complex matrix
-    if np.isrealobj(x):
+    if jnp.isrealobj(x):
         # x: 2D array with real data in [vmin, vmax]
 
-        all_positive = np.all(x >= 0)
+        all_positive = jnp.all(x >= 0)
         if cmap is None:
             # sequential colormap for positive data, diverging colormap otherwise
             cmap = 'Blues' if all_positive else 'dq'
         if vmin is None:
-            vmin = 0.0 if all_positive else np.min(x)
+            vmin = 0.0 if all_positive else jnp.min(x)
 
-        vmax = np.max(x) if vmax is None else vmax
+        vmax = jnp.max(x) if vmax is None else vmax
 
         # areas: absolute value of x
         area_max = max(abs(vmin), abs(vmax))
-        areas = Normalize(0.0, area_max)(np.abs(x))
+        areas = _normalize(jnp.abs(x), 0.0, area_max)
 
         # colors: value of x
-        colors = Normalize(vmin, vmax)(x)
+        colors = _normalize(x, vmin, vmax)
         colors_vmin, colors_vmax = vmin, vmax
-    elif np.iscomplexobj(x):
+    elif jnp.iscomplexobj(x):
         # x: 2D array with complex data
 
         # cyclic colormap for the phase
         cmap = 'cmr_copper' if cmap is None else cmap
 
         # areas: magnitude of x
-        magnitude = np.abs(x)
-        areas_max = np.max(magnitude) if vmax is None else vmax
-        areas = Normalize(0.0, areas_max)(magnitude)
+        magnitude = jnp.abs(x)
+        areas_max = jnp.max(magnitude) if vmax is None else vmax
+        areas = _normalize(magnitude, 0.0, areas_max)
 
         # colors: phase of x
-        phase = np.angle(x)
-        colors = Normalize(-np.pi, np.pi)(phase)
-        colors_vmin, colors_vmax = -np.pi, np.pi
+        phase = jnp.angle(x)
+        colors = _normalize(phase, -jnp.pi, jnp.pi)
+        colors_vmin, colors_vmax = -jnp.pi, jnp.pi
 
     if clear:
         colorbar = False

--- a/dynamiqs/plots/plots_misc.py
+++ b/dynamiqs/plots/plots_misc.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import jax.numpy as jnp
+from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 
-from ..utils.tensor_types import ArrayLike, to_numpy
 from .utils import colors, optax
 
 __all__ = ['plot_pwc_pulse']
@@ -32,8 +33,8 @@ def plot_pwc_pulse(
 
         ![plot_pwc_pulse](/figs-code/plot_pwc_pulse.png){.fig}
     """
-    times = to_numpy(times)  # (n + 1)
-    values = to_numpy(values)  # (n)
+    times = jnp.asarray(times)  # (n + 1)
+    values = jnp.asarray(values)  # (n)
 
     # format times and values, for example:
     # times  = [0, 1, 2, 3] -> [0, 1, 1, 2, 2, 3]

--- a/dynamiqs/plots/plots_wigner.py
+++ b/dynamiqs/plots/plots_wigner.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-import numpy as np
+import jax.numpy as jnp
+from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 from matplotlib.colors import Normalize
 
-from ..utils.tensor_types import ArrayLike, to_numpy, to_tensor
 from ..utils.wigners import wigner
 from .utils import add_colorbar, colors, gridplot, linmap, optax
 
@@ -18,21 +18,21 @@ def plot_wigner_data(
     ymax: float,
     *,
     ax: Axes | None = None,
-    vmax: float = 2 / np.pi,
+    vmax: float = 2 / jnp.pi,
     cmap: str = 'dq',
     interpolation: str = 'bilinear',
     colorbar: bool = True,
     cross: bool = False,
     clear: bool = False,
 ):
-    w = to_numpy(wigner)
+    w = jnp.asarray(wigner)
 
     # set plot norm
     vmin = -vmax
     norm = Normalize(vmin=vmin, vmax=vmax, clip=True)
 
     # clip to avoid rounding errors
-    w = np.clip(w, vmin, vmax)
+    w = w.clip(vmin, vmax)
 
     # plot
     ax.imshow(
@@ -50,7 +50,7 @@ def plot_wigner_data(
 
     if colorbar and not clear:
         cax = add_colorbar(ax, cmap, norm)
-        if vmax == 2 / np.pi:
+        if vmax == 2 / jnp.pi:
             cax.set_yticks([vmin, 0.0, vmax], labels=[r'$-2/\pi$', r'$0$', r'$2/\pi$'])
 
     if cross:
@@ -69,7 +69,7 @@ def plot_wigner(
     ax: Axes | None = None,
     xmax: float = 5.0,
     ymax: float | None = None,
-    vmax: float = 2 / np.pi,
+    vmax: float = 2 / jnp.pi,
     npixels: int = 101,
     cmap: str = 'dq',
     interpolation: str = 'bilinear',
@@ -115,7 +115,8 @@ def plot_wigner(
 
         ![plot_wigner_4legged](/figs-code/plot_wigner_4legged.png){.fig-half}
     """
-    state = to_tensor(state)
+    state = jnp.asarray(state)
+
     ymax = xmax if ymax is None else ymax
     _, _, w = wigner(state, xmax=xmax, ymax=ymax, npixels=npixels)
 
@@ -142,7 +143,7 @@ def plot_wigner_mosaic(
     h: float | None = None,
     xmax: float = 5.0,
     ymax: float | None = None,
-    vmax: float = 2 / np.pi,
+    vmax: float = 2 / jnp.pi,
     npixels: int = 101,
     cmap: str = 'dq',
     interpolation: str = 'bilinear',
@@ -176,7 +177,7 @@ def plot_wigner_mosaic(
 
         >>> n = 16
         >>> a = dq.destroy(n)
-        >>> H = a.mH @ a.mH @ a @ a  # Kerr Hamiltonian
+        >>> H = dq.dag(a) @ dq.dag(a) @ a @ a  # Kerr Hamiltonian
         >>> psi0 = dq.coherent(n, 2)
         >>> tsave = np.linspace(0, np.pi, 101)
         >>> result = dq.sesolve(H, psi0, tsave)
@@ -185,7 +186,7 @@ def plot_wigner_mosaic(
 
         ![plot_wigner_mosaic_kerr](/figs-code/plot_wigner_mosaic_kerr.png){.fig}
     """
-    states = to_tensor(states)
+    states = jnp.asarray(states)
 
     nstates = len(states)
     if nstates < n:


### PR DESCRIPTION
On top of #396.

Transition the following files from PyTorch to JAX:

```
dynamiqs
└── plots
    └── plots_fock.py
    └── plots_hinton.py
    └── plots_misc.py
    └── plots_wigner.py
```

The doctest is running except on examples using `sesolve`/`mesolve`.