### PR TITLE
Convert `Tensor` to `Array`

### DIFF
--- a/benchmarks/systems/cat_cnot.py
+++ b/benchmarks/systems/cat_cnot.py
@@ -29,9 +29,9 @@ class CatCNOT(OpenSystem):
         self.g = pi / (4 * alpha * T)
 
         # Hamiltonian
-        ac = dq.tensprod(dq.destroy(N), dq.eye(N))
-        at = dq.tensprod(dq.eye(N), dq.destroy(N))
-        i = dq.tensprod(dq.eye(N), dq.eye(N))
+        ac = dq.tensor(dq.destroy(N), dq.eye(N))
+        at = dq.tensor(dq.eye(N), dq.destroy(N))
+        i = dq.tensor(dq.eye(N), dq.eye(N))
         self.H = self.g * (ac + ac.mH) @ (at.mH @ at - alpha**2 * i)
 
         # jump operator
@@ -39,7 +39,7 @@ class CatCNOT(OpenSystem):
 
         # initial state
         plus = dq.unit(dq.coherent(N, alpha) + dq.coherent(N, -alpha))
-        self.y0 = dq.tensprod(plus, plus)
+        self.y0 = dq.tensor(plus, plus)
 
         # tsave
         self.tsave = torch.linspace(0, self.T, self.num_tslots + 1)

--- a/benchmarks/systems/transmon_gate.py
+++ b/benchmarks/systems/transmon_gate.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 from math import cos, exp, pi, sqrt
 
 import torch
+from jax import Array
 from scipy.special import erf
-from torch import Tensor
 
 import dynamiqs as dq
-from dynamiqs.utils.tensor_types import get_cdtype
+from dynamiqs.utils.array_types import get_cdtype
 
 from .system import ClosedSystem, OpenSystem
 
@@ -82,15 +82,15 @@ class TransmonGate(ClosedSystem):
     def eps(self, t: float) -> float:
         return self.eps_0 * (self.gaussian(t) - self.gaussian(0))
 
-    def H(self, t: float) -> Tensor:
+    def H(self, t: float) -> Array:
         return self.H0 + self.eps(t) * cos(self.omega_t * t) * self.charge
 
     @property
-    def y0(self) -> Tensor:
+    def y0(self) -> Array:
         return dq.fock(self.N, 0)
 
     @property
-    def tsave(self) -> Tensor:
+    def tsave(self) -> Array:
         return torch.linspace(0, self.T, self.num_tslots + 1)
 
     def to(self, dtype: torch.dtype, device: torch.device):
@@ -101,5 +101,5 @@ class TransmonGate(ClosedSystem):
 
 class OpenTransmonGate(TransmonGate, OpenSystem):
     @property
-    def jump_ops(self) -> list[Tensor]:
+    def jump_ops(self) -> list[Array]:
         return [sqrt(self.kappa) * torch.triu(self.charge)]

--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -10,7 +10,7 @@ PATHS_TO_PARSE = [
     'dynamiqs/utils/operators.py',
     'dynamiqs/utils/states.py',
     'dynamiqs/utils/utils.py',
-    'dynamiqs/utils/tensor_types.py',
+    'dynamiqs/utils/array_types.py',
     'dynamiqs/utils/wigners.py',
     'dynamiqs/utils/vectorization.py',
     'dynamiqs/utils/optimal_control.py',

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -112,7 +112,7 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
         - mpow
         - trace
         - ptrace
-        - tensprod
+        - tensor
         - expect
         - norm
         - unit

--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -1,15 +1,14 @@
 from importlib.metadata import version
 
-from . import dark
+from . import dark, solver
+from ._utils import *  # todo: remove, dev purpose only
 from .mesolve import mesolve
+from .plots import *
+from .result import Result
 from .sesolve import sesolve
 from .smesolve import smesolve
-from .result import Result
-from .plots import *
-from .time_tensor import TimeTensor, totime
+from .time_array import TimeArray, totime
 from .utils import *
-from ._utils import *  # todo: remove, dev purpose only
-from . import solver
 
 # get version from pyproject.toml
 __version__ = version(__package__)

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from typing import Any
+
 from jax import numpy as jnp
 from jaxtyping import Array
 
-from .utils import isket, dag
+from .utils import dag, isket
 
 
 def type_str(type: Any) -> str:
@@ -26,12 +27,12 @@ def merge_complex(x: Array) -> Array:
     return x[..., 0] + 1j * x[..., 1]
 
 
-def check_time_tensor(x: Array, arg_name: str, allow_empty=False):
-    # check that a time tensor is valid (it must be a 1D tensor sorted in strictly
+def check_time_array(x: Array, arg_name: str, allow_empty=False):
+    # check that a time array is valid (it must be a 1D array sorted in strictly
     # ascending order and containing only positive values)
     if x.ndim != 1:
         raise ValueError(
-            f'Argument `{arg_name}` must be a 1D tensor, but is a {x.ndim}D tensor.'
+            f'Argument `{arg_name}` must be a 1D array, but is a {x.ndim}D array.'
         )
     if not allow_empty and len(x) == 0:
         raise ValueError(f'Argument `{arg_name}` must contain at least one element.')

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -6,7 +6,7 @@ import torch
 
 from .gradient import Adjoint, Gradient
 from .solver import Solver
-from .utils.tensor_types import dtype_complex_to_real, get_cdtype
+from .utils.array_types import dtype_complex_to_real, get_cdtype
 
 
 class Options:
@@ -62,9 +62,9 @@ class SharedOptions:
         #     time value. If `False`, only the final state is stored and returned.
         #     Defaults to `True`.
         # dtype (torch.dtype, optional): Complex data type to which all complex-valued
-        #     tensors are converted. `tsave` is also converted to a real data type of
+        #     arrays are converted. `tsave` is also converted to a real data type of
         #     the corresponding precision.
-        # device (string or torch.device, optional): Device on which the tensors are
+        # device (string or torch.device, optional): Device on which the arrays are
         #     stored.
         self.save_states = save_states
         self.verbose = verbose

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any
 
-from jax import numpy as jnp, Array
+from jax import Array
 
 from .gradient import Gradient
 from .options import Options
@@ -24,8 +24,8 @@ def memory_str(x: Array) -> str:
         return f'{mem / 1024**3:.2f} Gb'
 
 
-def tensor_str(x: Array) -> str:
-    return f'Tensor {tuple(x.shape)} | {memory_str(x)}'
+def array_str(x: Array) -> str:
+    return f'Array {tuple(x.shape)} | {memory_str(x)}'
 
 
 class Result:
@@ -104,10 +104,10 @@ class Result:
             'Start': self.start_datetime.strftime('%Y-%m-%d %H:%M:%S'),
             'End': self.end_datetime.strftime('%Y-%m-%d %H:%M:%S'),
             'Total time': f'{self.total_time.total_seconds():.2f} s',
-            'States': tensor_str(self.states),
-            'Expects': tensor_str(self.expects) if self.expects is not None else None,
+            'States': array_str(self.states),
+            'Expects': array_str(self.expects) if self.expects is not None else None,
             'Measurements': (
-                tensor_str(self.measurements) if self.measurements is not None else None
+                array_str(self.measurements) if self.measurements is not None else None
             ),
         }
         parts = {k: v for k, v in parts.items() if v is not None}

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -3,19 +3,15 @@ from __future__ import annotations
 from typing import Any
 
 import diffrax as dx
-from jaxtyping import ArrayLike
 from jax import numpy as jnp
+from jaxtyping import ArrayLike
 
-from ..time_tensor import totime
-from .._utils import split_complex, merge_complex, bexpect
-from ..gradient import Gradient, Autograd, Adjoint
+from .._utils import bexpect, merge_complex, split_complex
+from ..gradient import Adjoint, Autograd, Gradient
 from ..options import Options
 from ..result import Result
-from ..solver import (
-    Dopri5,
-    Solver,
-    _stepsize_controller,
-)
+from ..solver import Dopri5, Solver, _stepsize_controller
+from ..time_array import totime
 
 
 def sesolve(
@@ -85,11 +81,11 @@ def sesolve(
     def save(_t, psi, _args):
         res = {}
         if options.save_states:
-            res["states"] = psi
+            res['states'] = psi
 
         psi = merge_complex(psi)
         # TODO : use vmap ?
-        res["expects"] = tuple([split_complex(bexpect(op, psi)) for op in exp_ops])
+        res['expects'] = tuple([split_complex(bexpect(op, psi)) for op in exp_ops])
         return res
 
     solution = dx.diffeqsolve(
@@ -110,12 +106,12 @@ def sesolve(
 
     ysave = None
     if options.save_states:
-        ysave = solution.ys["states"]
+        ysave = solution.ys['states']
         ysave = merge_complex(ysave)
 
     Esave = None
     if len(exp_ops) > 0:
-        Esave = solution.ys["expects"]
+        Esave = solution.ys['expects']
         Esave = jnp.stack(Esave, axis=0)
         Esave = merge_complex(Esave)
 

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -1,7 +1,7 @@
+import diffrax as dx
 from jax import Array
 
-from .gradient import Gradient, Autograd, Adjoint
-import diffrax as dx
+from .gradient import Adjoint, Autograd, Gradient
 
 
 class Solver:
@@ -17,7 +17,7 @@ class _ODEFixedStep(Solver):
     SUPPORTED_GRADIENT = (Autograd,)
 
     def __init__(self, *, dt: float):
-        # convert `dt` in case a tensor was passed instead of a float
+        # convert `dt` in case an array was passed instead of a float
         if isinstance(dt, Array):
             dt = dt.item()
         self.dt = dt

--- a/dynamiqs/utils/__init__.py
+++ b/dynamiqs/utils/__init__.py
@@ -1,6 +1,6 @@
+from .array_types import *
 from .operators import *
 from .states import *
-from .tensor_types import *
 from .utils import *
 from .vectorization import *
 from .wigners import *

--- a/dynamiqs/utils/array_types.py
+++ b/dynamiqs/utils/array_types.py
@@ -93,7 +93,7 @@ def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Q
          [1.]
          [0.]]
 
-        For a batched tensor:
+        For a batched array:
         >>> rhos = jnp.stack([dq.coherent_dm(16, i) for i in range(5)])
         >>> rhos.shape
         (5, 16, 16)

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
 
-from .tensor_types import get_cdtype
+from .array_types import get_cdtype
 from .utils import dag, tensprod
 
 __all__ = [

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -8,7 +8,7 @@ from jax import Array
 from jax.typing import ArrayLike
 
 from .array_types import get_cdtype
-from .utils import dag, tensprod
+from .utils import dag, tensor
 
 __all__ = [
     'eye',
@@ -150,7 +150,7 @@ def destroy(
     a = [_destroy_single(dim, dtype=dtype) for dim in dims]
     I = [eye(dim, dtype=dtype) for dim in dims]
     return tuple(
-        tensprod(*[a[j] if i == j else I[j] for j in range(len(dims))])
+        tensor(*[a[j] if i == j else I[j] for j in range(len(dims))])
         for i in range(len(dims))
     )
 
@@ -209,7 +209,7 @@ def create(
     adag = [_create_single(dim, dtype=dtype) for dim in dims]
     I = [eye(dim, dtype=dtype) for dim in dims]
     return tuple(
-        tensprod(*[adag[j] if i == j else I[j] for j in range(len(dims))])
+        tensor(*[adag[j] if i == j else I[j] for j in range(len(dims))])
         for i in range(len(dims))
     )
 
@@ -554,4 +554,4 @@ def hadamard(
     dtype = get_cdtype(dtype)
     H1 = jnp.array([[1.0, 1.0], [1.0, -1.0]], dtype=dtype) / jnp.sqrt(2)
     Hs = jnp.broadcast_to(H1, (n, 2, 2))  # (n, 2, 2)
-    return tensprod(*Hs)
+    return tensor(*Hs)

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -8,7 +8,7 @@ from jax.typing import ArrayLike
 
 from .array_types import get_cdtype
 from .operators import displace
-from .utils import tensprod, todm
+from .utils import tensor, todm
 
 __all__ = ['fock', 'fock_dm', 'basis', 'basis_dm', 'coherent', 'coherent_dm']
 
@@ -171,7 +171,7 @@ def coherent(
         displace(d, a, dtype=dtype) @ fock(d, 0, dtype=dtype)
         for d, a in zip(dim, alpha)
     ]
-    return tensprod(*kets)
+    return tensor(*kets)
 
 
 def coherent_dm(

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -6,8 +6,8 @@ import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
 
+from .array_types import get_cdtype
 from .operators import displace
-from .tensor_types import get_cdtype
 from .utils import tensprod, todm
 
 __all__ = ['fock', 'fock_dm', 'basis', 'basis_dm', 'coherent', 'coherent_dm']

--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -12,7 +12,7 @@ __all__ = [
     'mpow',
     'trace',
     'ptrace',
-    'tensprod',
+    'tensor',
     'expect',
     'norm',
     'unit',
@@ -124,7 +124,7 @@ def ptrace(x: ArrayLike, keep: int | tuple[int, ...], dims: tuple[int, ...]) -> 
         bra.
 
     Examples:
-        >>> psi_abc = dq.tensprod(dq.fock(3, 0), dq.fock(4, 2), dq.fock(5, 1))
+        >>> psi_abc = dq.tensor(dq.fock(3, 0), dq.fock(4, 2), dq.fock(5, 1))
         >>> psi_abc.shape
         (60, 1)
         >>> rho_a = dq.ptrace(psi_abc, 0, (3, 4, 5))
@@ -188,7 +188,7 @@ def ptrace(x: ArrayLike, keep: int | tuple[int, ...], dims: tuple[int, ...]) -> 
     return x.reshape(*bshape, nkeep, nkeep)  # e.g. (..., 10, 10)
 
 
-def tensprod(*args: ArrayLike) -> Array:
+def tensor(*args: ArrayLike) -> Array:
     r"""Returns the tensor product of multiple kets, bras, density matrices or
     operators.
 
@@ -213,7 +213,7 @@ def tensprod(*args: ArrayLike) -> Array:
             the input arrays.
 
     Examples:
-        >>> psi = dq.tensprod(dq.fock(3, 0), dq.fock(4, 2), dq.fock(5, 1))
+        >>> psi = dq.tensor(dq.fock(3, 0), dq.fock(4, 2), dq.fock(5, 1))
         >>> psi.shape
         (60, 1)
     """

--- a/dynamiqs/utils/wigners.py
+++ b/dynamiqs/utils/wigners.py
@@ -8,8 +8,8 @@ from jax import Array
 from jaxtyping import ArrayLike
 from torch import Tensor
 
+from .array_types import dtype_complex_to_real, dtype_real_to_complex
 from .operators import eye
-from .tensor_types import dtype_complex_to_real, dtype_real_to_complex
 from .utils import isdm, isket, todm
 
 __all__ = ['wigner']

--- a/dynamiqs/utils/wigners.py
+++ b/dynamiqs/utils/wigners.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from typing import Literal
 
+import jax.lax as lax
 import jax.numpy as jnp
-import torch
 from jax import Array
+from jax.scipy.linalg import toeplitz
 from jaxtyping import ArrayLike
-from torch import Tensor
 
 from .array_types import dtype_complex_to_real, dtype_real_to_complex
 from .operators import eye
@@ -118,7 +118,7 @@ def _laguerre_series(i, x, c):
     return y0 - y1 * (i + 1 - x) * (i + 1) ** (-0.5)
 
 
-def _wigner_fft_psi(psi: Tensor, xvec: Tensor, g: float) -> tuple[Tensor, Tensor]:
+def _wigner_fft_psi(psi: Array, xvec: Array, g: float) -> tuple[Array, Array]:
     """Compute the wigner distribution of a ket with the FFT."""
     n = psi.size(0)
 
@@ -132,10 +132,10 @@ def _wigner_fft_psi(psi: Tensor, xvec: Tensor, g: float) -> tuple[Tensor, Tensor
     return 0.5 * g**2 * w.T.real, yvec * jnp.sqrt(2) / g
 
 
-def _wigner_fft_dm(rho: Tensor, xvec: Tensor, g: float) -> tuple[Tensor, Tensor]:
+def _wigner_fft_dm(rho: Array, xvec: Array, g: float) -> tuple[Array, Array]:
     """Compute the wigner distribution of a density matrix with the FFT."""
     # diagonalize rho
-    eig_vals, eig_vecs = torch.linalg.eigh(rho)
+    eig_vals, eig_vecs = lax.linalg.eigh(rho)
 
     # compute the wigner distribution of each eigenstate
     W = 0
@@ -147,14 +147,14 @@ def _wigner_fft_dm(rho: Tensor, xvec: Tensor, g: float) -> tuple[Tensor, Tensor]
     return W, yvec
 
 
-def _fock_to_position(n: int, positions: Tensor) -> Tensor:
+def _fock_to_position(n: int, positions: Array) -> Array:
     """
     Compute the change-of-basis matrix from the Fock basis to the position basis of an
     oscillator of dimension n, as evaluated at the specific position values provided.
     """
     n_positions = positions.shape[0]
-    U = torch.zeros(n, n_positions, dtype=dtype_real_to_complex(positions.dtype))
-    U[0, :] = jnp.pi ** (-0.25) * torch.exp(-0.5 * positions**2)
+    U = jnp.zeros(n, n_positions, dtype=dtype_real_to_complex(positions.dtype))
+    U[0, :] = pi ** (-0.25) * jnp.exp(-0.5 * positions**2)
 
     if n == 1:
         return U
@@ -166,7 +166,7 @@ def _fock_to_position(n: int, positions: Tensor) -> Tensor:
     return U
 
 
-def _wigner_fft(psi: Tensor, xvec: Tensor) -> tuple[Tensor, Tensor]:
+def _wigner_fft(psi: Array, xvec: Array) -> tuple[Array, Array]:
     """Wigner distribution of a given ket using the fast Fourier transform.
 
     Args:
@@ -179,30 +179,17 @@ def _wigner_fft(psi: Tensor, xvec: Tensor) -> tuple[Tensor, Tensor]:
     n = len(psi)
 
     # compute the fourier transform of psi
-    r1 = torch.cat((torch.tensor([0]), psi.conj().flip(-1), torch.zeros(n - 1)))
-    r2 = torch.cat((torch.tensor([0]), psi, torch.zeros(n - 1)))
-    w = _toeplitz(torch.zeros(n), r1) * _toeplitz(torch.zeros(n), r2).flipud()
-    w = torch.cat((w[:, n : 2 * n], w[:, 0:n]), dim=1)
-    w = torch.fft.fft(w)
-    w = torch.cat((w[:, 3 * n // 2 : 2 * n + 1], w[:, 0 : n // 2]), axis=1).real
+    r1 = lax.concatenate((jnp.array([0.0]), psi.conj().flip(-1), jnp.zeros(n - 1)))
+    r2 = lax.concatenate((jnp.array([0.0]), psi, jnp.zeros(n - 1)))
+    w = toeplitz(jnp.zeros(n), r=r1) * jnp.flipud(toeplitz(jnp.zeros(n), r=r2))
+    w = lax.concatenate((w[:, n : 2 * n], w[:, 0:n]), dim=1)
+    w = jnp.fft.fft(w)
+    w = lax.concatenate((w[:, 3 * n // 2 : 2 * n + 1], w[:, 0 : n // 2]), axis=1).real
 
     # compute the fourier transform of xvec
-    p = torch.arange(-n / 2, n / 2) * jnp.pi / (2 * n * (xvec[1] - xvec[0]))
+    p = jnp.arange(-n / 2, n / 2) * pi / (2 * n * (xvec[1] - xvec[0]))
 
     # normalize wigner distribution
     w = w / (p[1] - p[0]) / (2 * n)
 
     return w, p
-
-
-def _toeplitz(c: Tensor, r: Tensor = None) -> Tensor:
-    """Construct a Toeplitz matrix.
-
-    Code copied from https://stackoverflow.com/a/68899386/9099342.
-    """
-    c = torch.ravel(c)
-    r = torch.ravel(r) if r is not None else c.conj()
-    vals = torch.cat((r, c[1:].flip(0)))
-    shape = len(c), len(r)
-    i, j = torch.ones(*shape).nonzero().T
-    return vals[j - i].reshape(*shape)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -174,7 +174,7 @@ nav:
               - braket: python_api/utils/utils/braket.md
               - overlap: python_api/utils/utils/overlap.md
               - fidelity: python_api/utils/utils/fidelity.md
-          - Tensor conversion:
+          - Array conversion:
               - to_qutip: python_api/utils/array_types/to_qutip.md
           - Wigner distribution:
               - wigner: python_api/utils/wigners/wigner.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -158,7 +158,7 @@ nav:
               - mpow: python_api/utils/utils/mpow.md
               - trace: python_api/utils/utils/trace.md
               - ptrace: python_api/utils/utils/ptrace.md
-              - tensprod: python_api/utils/utils/tensprod.md
+              - tensor: python_api/utils/utils/tensor.md
               - expect: python_api/utils/utils/expect.md
               - norm: python_api/utils/utils/norm.md
               - unit: python_api/utils/utils/unit.md
@@ -175,7 +175,7 @@ nav:
               - overlap: python_api/utils/utils/overlap.md
               - fidelity: python_api/utils/utils/fidelity.md
           - Tensor conversion:
-              - to_qutip: python_api/utils/tensor_types/to_qutip.md
+              - to_qutip: python_api/utils/array_types/to_qutip.md
           - Wigner distribution:
               - wigner: python_api/utils/wigners/wigner.md
           - Vectorization:

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -2,14 +2,16 @@ from __future__ import annotations
 
 from math import cos, exp, pi, sin
 from typing import Any
-from jax import numpy as jnp, Array
+
+from jax import Array
+from jax import numpy as jnp
 
 import dynamiqs as dq
-from dynamiqs import TimeTensor, dag
+from dynamiqs import TimeArray, dag
 from dynamiqs.gradient import Gradient
-from dynamiqs.solver import Solver
 from dynamiqs.result import Result
-from dynamiqs.utils.tensor_types import ArrayLike, dtype_real_to_complex
+from dynamiqs.solver import Solver
+from dynamiqs.utils.array_types import ArrayLike, dtype_real_to_complex
 
 from ..system import System
 
@@ -27,7 +29,7 @@ class OpenSystem(System):
         *,
         gradient: Gradient | None = None,
         options: dict[str, Any] | None = None,
-        H: ArrayLike | TimeTensor | None = None,
+        H: ArrayLike | TimeArray | None = None,
         L: list[ArrayLike] | None = None,
         y0: ArrayLike | None = None,
     ) -> Result:

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 from math import cos, pi, sin
 from typing import Any
 
-import dynamiqs as dq
-from dynamiqs import TimeTensor, dag
-from jax import numpy as jnp, Array
 import numpy as np
+from jax import Array
+from jax import numpy as jnp
 
+import dynamiqs as dq
+from dynamiqs import dag
 from dynamiqs.gradient import Gradient
-from dynamiqs.solver import Solver
 from dynamiqs.result import Result
-from dynamiqs.utils.tensor_types import ArrayLike, dtype_real_to_complex
+from dynamiqs.solver import Solver
+from dynamiqs.utils.array_types import ArrayLike, dtype_real_to_complex
 
 from ..system import System
 

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -4,7 +4,7 @@ from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Dopri5
 
 from ..solver_tester import SolverTester
-from .closed_system import cavity, gcavity, gtdqubit, tdqubit
+from .closed_system import cavity, gcavity, tdqubit
 
 
 class TestSEAdaptive(SolverTester):

--- a/tests/smesolve/monitored_system.py
+++ b/tests/smesolve/monitored_system.py
@@ -7,11 +7,11 @@ import torch
 from torch import Tensor
 
 import dynamiqs as dq
-from dynamiqs import TimeTensor
+from dynamiqs import TimeArray
 from dynamiqs.gradient import Gradient
-from dynamiqs.solver import Solver
 from dynamiqs.result import Result
-from dynamiqs.utils.tensor_types import ArrayLike
+from dynamiqs.solver import Solver
+from dynamiqs.utils.array_types import ArrayLike
 
 from ..mesolve.open_system import OpenSystem
 
@@ -28,7 +28,7 @@ class MonitoredSystem(OpenSystem):
         *,
         gradient: Gradient | None = None,
         options: dict[str, Any] | None = None,
-        H: ArrayLike | TimeTensor | None = None,
+        H: ArrayLike | TimeArray | None = None,
         L: list[ArrayLike] | None = None,
         y0: ArrayLike | None = None,
         ntrajs: int = 10,

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -4,8 +4,8 @@ import logging
 from abc import ABC
 from typing import Any
 
-import jax.numpy as jnp
 import jax
+import jax.numpy as jnp
 
 from dynamiqs.gradient import Gradient
 from dynamiqs.solver import Solver

--- a/tests/system.py
+++ b/tests/system.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Any
 
-from jax import numpy as jnp, Array
+from jax import Array
+from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
 import dynamiqs as dq
 from dynamiqs.gradient import Gradient
-from dynamiqs.solver import Solver
 from dynamiqs.result import Result
+from dynamiqs.solver import Solver
 
 
 class System(ABC):
@@ -23,7 +24,7 @@ class System(ABC):
 
     @abstractmethod
     def tsave(self, n: int) -> Array:
-        """Compute the save time tensor."""
+        """Compute the save time array."""
         pass
 
     def state(self, t: float) -> Array:
@@ -48,7 +49,7 @@ class System(ABC):
         """Compute the exact gradients of the example state loss function with respect
         to the system parameters.
 
-        The returned tensor has shape _(num_params)_.
+        The returned array has shape _(num_params)_.
         """
         raise NotImplementedError
 
@@ -60,7 +61,7 @@ class System(ABC):
         """Compute the exact gradients of the example expectation values loss functions
         with respect to the system parameters.
 
-        The returned tensor has shape _(nE, num_params)_.
+        The returned array has shape _(nE, num_params)_.
         """
         raise NotImplementedError
 

--- a/tests/test_time_tensor.py
+++ b/tests/test_time_tensor.py
@@ -2,11 +2,11 @@ import pytest
 import torch
 from torch import Tensor
 
-from dynamiqs.time_tensor import (
-    CallableTimeTensor,
-    ConstantTimeTensor,
-    ModulatedTimeTensor,
-    PWCTimeTensor,
+from dynamiqs.time_array import (
+    CallableTimeArray,
+    ConstantTimeArray,
+    ModulatedTimeArray,
+    PWCTimeArray,
     _ModulatedFactor,
     _PWCFactor,
 )
@@ -16,10 +16,10 @@ def assert_equal(xt: Tensor, y: list):
     assert torch.equal(xt, torch.tensor(y))
 
 
-class TestConstantTimeTensor:
+class TestConstantTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.x = ConstantTimeTensor(torch.tensor([1, 2]))
+        self.x = ConstantTimeArray(torch.tensor([1, 2]))
 
     def test_call(self):
         assert_equal(self.x(0.0), [1, 2])
@@ -34,7 +34,7 @@ class TestConstantTimeTensor:
         assert_equal(x(0.0), [[1, 2]])
 
     def test_adjoint(self):
-        x = ConstantTimeTensor(torch.tensor([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]]))
+        x = ConstantTimeArray(torch.tensor([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]]))
         x = x.adjoint()
         res = torch.tensor([[1 - 1j, 3 - 3j], [2 - 2j, 4 - 4j]])
         assert torch.equal(x(0.0), res)
@@ -64,26 +64,26 @@ class TestConstantTimeTensor:
     def test_add(self):
         # test type `Tensor`
         x = self.x + torch.tensor([0, 1])
-        assert isinstance(x, ConstantTimeTensor)
+        assert isinstance(x, ConstantTimeArray)
         assert_equal(x(0.0), [1, 3])
 
-        # test type `ConstantTimeTensor`
+        # test type `ConstantTimeArray`
         x = self.x + self.x
-        assert isinstance(x, ConstantTimeTensor)
+        assert isinstance(x, ConstantTimeArray)
         assert_equal(x(0.0), [2, 4])
 
     def test_radd(self):
         # test type `Tensor`
         x = torch.tensor([0, 1]) + self.x
-        assert isinstance(x, ConstantTimeTensor)
+        assert isinstance(x, ConstantTimeArray)
         assert_equal(x(0.0), [1, 3])
 
 
-class TestCallableTimeTensor:
+class TestCallableTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
         f = lambda t: t * torch.tensor([1, 2])
-        self.x = CallableTimeTensor(f, f(0.0))
+        self.x = CallableTimeArray(f, f(0.0))
 
     def test_call(self):
         assert_equal(self.x(0.0), [0, 0])
@@ -100,7 +100,7 @@ class TestCallableTimeTensor:
 
     def test_adjoint(self):
         f = lambda t: t * torch.tensor([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
-        x = CallableTimeTensor(f, f(0.0))
+        x = CallableTimeArray(f, f(0.0))
         x = x.adjoint()
         res = torch.tensor([[1 - 1j, 3 - 3j], [2 - 2j, 4 - 4j]])
         assert torch.equal(x(1.0), res)
@@ -135,25 +135,25 @@ class TestCallableTimeTensor:
     def test_add(self):
         # test type `Tensor`
         x = self.x + torch.tensor([0, 1])
-        assert isinstance(x, CallableTimeTensor)
+        assert isinstance(x, CallableTimeArray)
         assert_equal(x(0.0), [0, 1])
         assert_equal(x(1.0), [1, 3])
 
-        # test type `CallableTimeTensor`
+        # test type `CallableTimeArray`
         x = self.x + self.x
-        assert isinstance(x, CallableTimeTensor)
+        assert isinstance(x, CallableTimeArray)
         assert_equal(x(0.0), [0, 0])
         assert_equal(x(1.0), [2, 4])
 
     def test_radd(self):
         # test type `Tensor`
         x = torch.tensor([0, 1]) + self.x
-        assert isinstance(x, CallableTimeTensor)
+        assert isinstance(x, CallableTimeArray)
         assert_equal(x(0.0), [0, 1])
         assert_equal(x(1.0), [1, 3])
 
 
-class TestPWCTimeTensor:
+class TestPWCTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
         # PWC factor 1
@@ -170,7 +170,7 @@ class TestPWCTimeTensor:
 
         factors = [f1, f2]
         tensors = torch.stack([tensor1, tensor2])
-        self.x = PWCTimeTensor(factors, tensors)  # shape at t: (2, 2)
+        self.x = PWCTimeArray(factors, tensors)  # shape at t: (2, 2)
 
     def test_call(self):
         assert_equal(self.x(-0.1), [[0, 0], [0, 0]])
@@ -224,13 +224,13 @@ class TestPWCTimeTensor:
 
         # test type `Tensor`
         x = self.x + tensor
-        assert isinstance(x, PWCTimeTensor)
+        assert isinstance(x, PWCTimeArray)
         assert_equal(x(-0.1), [[1, 1], [1, 1]])
         assert_equal(x(0.0), [[2, 3], [4, 5]])
 
-        # test type `PWCTimeTensor`
+        # test type `PWCTimeArray`
         x = self.x + self.x
-        assert isinstance(x, PWCTimeTensor)
+        assert isinstance(x, PWCTimeArray)
         assert_equal(x(0.0), [[2, 4], [6, 8]])
 
     def test_radd(self):
@@ -238,12 +238,12 @@ class TestPWCTimeTensor:
 
         # test type `Tensor`
         x = tensor + self.x
-        assert isinstance(x, PWCTimeTensor)
+        assert isinstance(x, PWCTimeArray)
         assert_equal(x(-0.1), [[1, 1], [1, 1]])
         assert_equal(x(0.0), [[2, 3], [4, 5]])
 
 
-class TestModulatedTimeTensor:
+class TestModulatedTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
         one = torch.tensor(1.0)
@@ -262,7 +262,7 @@ class TestModulatedTimeTensor:
 
         factors = [f1, f2]
         tensors = torch.stack([tensor1, tensor2])
-        self.x = ModulatedTimeTensor(factors, tensors)
+        self.x = ModulatedTimeArray(factors, tensors)
 
     def test_call(self):
         assert_equal(self.x(0.0), [[1.0j, 2.0j], [3.0j, 4.0j]])
@@ -304,12 +304,12 @@ class TestModulatedTimeTensor:
 
         # test type `Tensor`
         x = self.x + tensor
-        assert isinstance(x, ModulatedTimeTensor)
+        assert isinstance(x, ModulatedTimeArray)
         assert_equal(x(0.0), [[1.0 + 1.0j, 1.0 + 2.0j], [1.0 + 3.0j, 1.0 + 4.0j]])
 
-        # test type `ModulatedTimeTensor`
+        # test type `ModulatedTimeArray`
         x = self.x + self.x
-        assert isinstance(x, ModulatedTimeTensor)
+        assert isinstance(x, ModulatedTimeArray)
         assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
 
     def test_radd(self):
@@ -317,5 +317,5 @@ class TestModulatedTimeTensor:
 
         # test type `Tensor`
         x = tensor + self.x
-        assert isinstance(x, ModulatedTimeTensor)
+        assert isinstance(x, ModulatedTimeArray)
         assert_equal(x(0.0), [[1.0 + 1.0j, 1.0 + 2.0j], [1.0 + 3.0j, 1.0 + 4.0j]])

--- a/tests/test_time_tensor.py
+++ b/tests/test_time_tensor.py
@@ -1,6 +1,7 @@
+import jax.numpy as jnp
 import pytest
 import torch
-from torch import Tensor
+from jax import Array
 
 from dynamiqs.time_array import (
     CallableTimeArray,
@@ -12,14 +13,14 @@ from dynamiqs.time_array import (
 )
 
 
-def assert_equal(xt: Tensor, y: list):
-    assert torch.equal(xt, torch.tensor(y))
+def assert_equal(xt: Array, y: list):
+    assert torch.equal(xt, jnp.array(y))
 
 
 class TestConstantTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.x = ConstantTimeArray(torch.tensor([1, 2]))
+        self.x = ConstantTimeArray(jnp.array([1, 2]))
 
     def test_call(self):
         assert_equal(self.x(0.0), [1, 2])
@@ -34,9 +35,9 @@ class TestConstantTimeArray:
         assert_equal(x(0.0), [[1, 2]])
 
     def test_adjoint(self):
-        x = ConstantTimeArray(torch.tensor([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]]))
+        x = ConstantTimeArray(jnp.array([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]]))
         x = x.adjoint()
-        res = torch.tensor([[1 - 1j, 3 - 3j], [2 - 2j, 4 - 4j]])
+        res = jnp.array([[1 - 1j, 3 - 3j], [2 - 2j, 4 - 4j]])
         assert torch.equal(x(0.0), res)
 
     def test_neg(self):
@@ -48,8 +49,8 @@ class TestConstantTimeArray:
         x = self.x * 2
         assert_equal(x(0.0), [2, 4])
 
-        # test type `Tensor`
-        x = self.x * torch.tensor([0, 1])
+        # test type `Array`
+        x = self.x * jnp.array([0, 1])
         assert_equal(x(0.0), [0, 2])
 
     def test_rmul(self):
@@ -57,13 +58,13 @@ class TestConstantTimeArray:
         x = 2 * self.x
         assert_equal(x(0.0), [2, 4])
 
-        # test type `Tensor`
-        x = torch.tensor([0, 1]) * self.x
+        # test type `Array`
+        x = jnp.array([0, 1]) * self.x
         assert_equal(x(0.0), [0, 2])
 
     def test_add(self):
-        # test type `Tensor`
-        x = self.x + torch.tensor([0, 1])
+        # test type `Array`
+        x = self.x + jnp.array([0, 1])
         assert isinstance(x, ConstantTimeArray)
         assert_equal(x(0.0), [1, 3])
 
@@ -73,8 +74,8 @@ class TestConstantTimeArray:
         assert_equal(x(0.0), [2, 4])
 
     def test_radd(self):
-        # test type `Tensor`
-        x = torch.tensor([0, 1]) + self.x
+        # test type `Array`
+        x = jnp.array([0, 1]) + self.x
         assert isinstance(x, ConstantTimeArray)
         assert_equal(x(0.0), [1, 3])
 
@@ -82,7 +83,7 @@ class TestConstantTimeArray:
 class TestCallableTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
-        f = lambda t: t * torch.tensor([1, 2])
+        f = lambda t: t * jnp.array([1, 2])
         self.x = CallableTimeArray(f, f(0.0))
 
     def test_call(self):
@@ -99,10 +100,10 @@ class TestCallableTimeArray:
         assert_equal(x(1.0), [[1, 2]])
 
     def test_adjoint(self):
-        f = lambda t: t * torch.tensor([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
+        f = lambda t: t * jnp.array([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
         x = CallableTimeArray(f, f(0.0))
         x = x.adjoint()
-        res = torch.tensor([[1 - 1j, 3 - 3j], [2 - 2j, 4 - 4j]])
+        res = jnp.array([[1 - 1j, 3 - 3j], [2 - 2j, 4 - 4j]])
         assert torch.equal(x(1.0), res)
 
     def test_neg(self):
@@ -116,8 +117,8 @@ class TestCallableTimeArray:
         assert_equal(x(0.0), [0, 0])
         assert_equal(x(1.0), [2, 4])
 
-        # test type `Tensor`
-        x = self.x * torch.tensor([0, 1])
+        # test type `Array`
+        x = self.x * jnp.array([0, 1])
         assert_equal(x(0.0), [0, 0])
         assert_equal(x(1.0), [0, 2])
 
@@ -127,14 +128,14 @@ class TestCallableTimeArray:
         assert_equal(x(0.0), [0, 0])
         assert_equal(x(1.0), [2, 4])
 
-        # test type `Tensor`
-        x = torch.tensor([0, 1]) * self.x
+        # test type `Array`
+        x = jnp.array([0, 1]) * self.x
         assert_equal(x(0.0), [0, 0])
         assert_equal(x(1.0), [0, 2])
 
     def test_add(self):
-        # test type `Tensor`
-        x = self.x + torch.tensor([0, 1])
+        # test type `Array`
+        x = self.x + jnp.array([0, 1])
         assert isinstance(x, CallableTimeArray)
         assert_equal(x(0.0), [0, 1])
         assert_equal(x(1.0), [1, 3])
@@ -146,8 +147,8 @@ class TestCallableTimeArray:
         assert_equal(x(1.0), [2, 4])
 
     def test_radd(self):
-        # test type `Tensor`
-        x = torch.tensor([0, 1]) + self.x
+        # test type `Array`
+        x = jnp.array([0, 1]) + self.x
         assert isinstance(x, CallableTimeArray)
         assert_equal(x(0.0), [0, 1])
         assert_equal(x(1.0), [1, 3])
@@ -157,20 +158,20 @@ class TestPWCTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
         # PWC factor 1
-        t1 = torch.tensor([0, 1, 2, 3])
-        v1 = torch.tensor([1, 10, 100])
+        t1 = jnp.array([0, 1, 2, 3])
+        v1 = jnp.array([1, 10, 100])
         f1 = _PWCFactor(t1, v1)
-        tensor1 = torch.tensor([[1, 2], [3, 4]])
+        array1 = jnp.array([[1, 2], [3, 4]])
 
         # PWC factor 2
-        t2 = torch.tensor([1, 3, 5])
-        v2 = torch.tensor([1, 1])
+        t2 = jnp.array([1, 3, 5])
+        v2 = jnp.array([1, 1])
         f2 = _PWCFactor(t2, v2)
-        tensor2 = torch.tensor([[1j, 1j], [1j, 1j]])
+        array2 = jnp.array([[1j, 1j], [1j, 1j]])
 
         factors = [f1, f2]
-        tensors = torch.stack([tensor1, tensor2])
-        self.x = PWCTimeArray(factors, tensors)  # shape at t: (2, 2)
+        arrays = torch.stack([array1, array2])
+        self.x = PWCTimeArray(factors, arrays)  # shape at t: (2, 2)
 
     def test_call(self):
         assert_equal(self.x(-0.1), [[0, 0], [0, 0]])
@@ -206,8 +207,8 @@ class TestPWCTimeArray:
         x = self.x * 2
         assert_equal(x(0.0), [[2, 4], [6, 8]])
 
-        # test type `Tensor`
-        x = self.x * torch.tensor([2])
+        # test type `Array`
+        x = self.x * jnp.array([2])
         assert_equal(x(0.0), [[2, 4], [6, 8]])
 
     def test_rmul(self):
@@ -215,15 +216,15 @@ class TestPWCTimeArray:
         x = 2 * self.x
         assert_equal(x(0.0), [[2, 4], [6, 8]])
 
-        # test type `Tensor`
-        x = torch.tensor([2]) * self.x
+        # test type `Array`
+        x = jnp.array([2]) * self.x
         assert_equal(x(0.0), [[2, 4], [6, 8]])
 
     def test_add(self):
-        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+        array = jnp.array([[1, 1], [1, 1]], dtype=torch.complex64)
 
-        # test type `Tensor`
-        x = self.x + tensor
+        # test type `Array`
+        x = self.x + array
         assert isinstance(x, PWCTimeArray)
         assert_equal(x(-0.1), [[1, 1], [1, 1]])
         assert_equal(x(0.0), [[2, 3], [4, 5]])
@@ -234,10 +235,10 @@ class TestPWCTimeArray:
         assert_equal(x(0.0), [[2, 4], [6, 8]])
 
     def test_radd(self):
-        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+        array = jnp.array([[1, 1], [1, 1]], dtype=torch.complex64)
 
-        # test type `Tensor`
-        x = tensor + self.x
+        # test type `Array`
+        x = array + self.x
         assert isinstance(x, PWCTimeArray)
         assert_equal(x(-0.1), [[1, 1], [1, 1]])
         assert_equal(x(0.0), [[2, 3], [4, 5]])
@@ -246,23 +247,23 @@ class TestPWCTimeArray:
 class TestModulatedTimeArray:
     @pytest.fixture(autouse=True)
     def setup(self):
-        one = torch.tensor(1.0)
+        one = jnp.array(1.0)
 
         # modulated factor 1
         eps1 = lambda t: (0.5 * t + 1.0j) * one
         eps1_0 = eps1(0.0)
         f1 = _ModulatedFactor(eps1, eps1_0)
-        tensor1 = torch.tensor([[1, 2], [3, 4]])
+        array1 = jnp.array([[1, 2], [3, 4]])
 
         # modulated factor 2
         eps2 = lambda t: t**2 * one
         eps2_0 = eps2(0.0)
         f2 = _ModulatedFactor(eps2, eps2_0)
-        tensor2 = torch.tensor([[1j, 1j], [1j, 1j]])
+        array2 = jnp.array([[1j, 1j], [1j, 1j]])
 
         factors = [f1, f2]
-        tensors = torch.stack([tensor1, tensor2])
-        self.x = ModulatedTimeArray(factors, tensors)
+        arrays = torch.stack([array1, array2])
+        self.x = ModulatedTimeArray(factors, arrays)
 
     def test_call(self):
         assert_equal(self.x(0.0), [[1.0j, 2.0j], [3.0j, 4.0j]])
@@ -286,8 +287,8 @@ class TestModulatedTimeArray:
         x = self.x * 2
         assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
 
-        # test type `Tensor`
-        x = self.x * torch.tensor([2])
+        # test type `Array`
+        x = self.x * jnp.array([2])
         assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
 
     def test_rmul(self):
@@ -295,15 +296,15 @@ class TestModulatedTimeArray:
         x = 2 * self.x
         assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
 
-        # test type `Tensor`
-        x = torch.tensor([2]) * self.x
+        # test type `Array`
+        x = jnp.array([2]) * self.x
         assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
 
     def test_add(self):
-        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+        array = jnp.array([[1, 1], [1, 1]], dtype=torch.complex64)
 
-        # test type `Tensor`
-        x = self.x + tensor
+        # test type `Array`
+        x = self.x + array
         assert isinstance(x, ModulatedTimeArray)
         assert_equal(x(0.0), [[1.0 + 1.0j, 1.0 + 2.0j], [1.0 + 3.0j, 1.0 + 4.0j]])
 
@@ -313,9 +314,9 @@ class TestModulatedTimeArray:
         assert_equal(x(0.0), [[2.0j, 4.0j], [6.0j, 8.0j]])
 
     def test_radd(self):
-        tensor = torch.tensor([[1, 1], [1, 1]], dtype=torch.complex64)
+        array = jnp.array([[1, 1], [1, 1]], dtype=torch.complex64)
 
-        # test type `Tensor`
-        x = tensor + self.x
+        # test type `Array`
+        x = array + self.x
         assert isinstance(x, ModulatedTimeArray)
         assert_equal(x(0.0), [[1.0 + 1.0j, 1.0 + 2.0j], [1.0 + 3.0j, 1.0 + 4.0j]])


### PR DESCRIPTION
1. Convert `TimeTensor` to `TimeArray`
2. Rename `time_tensor.py` to `time_array.py`
3. Rename `tensor_types.py` to `array_types.py`
4. Convert `dq.wigner(..., method='fft')` to jax
5. Convert various `tensor` occurences to `array`
6. Rename `dq.tensprod` to `dq.tensor` since now there's no double use of the word (qutip convention).