### PR TITLE
Fix time array implementation

### DIFF
--- a/dynamiqs/types.py
+++ b/dynamiqs/types.py
@@ -1,0 +1,6 @@
+from typing import Union
+
+from jax import Array
+
+# type for single real number (Array = single-element array here)
+Scalar = Union[int, float, Array]

--- a/dynamiqs/utils/array_types.py
+++ b/dynamiqs/utils/array_types.py
@@ -10,9 +10,6 @@ from .utils import _hdim, isbra, isket, isop
 
 __all__ = ['to_qutip']
 
-# TODO: remove (keep name to avoid ImportError while transitioning from PyTorch to JAX)
-Number = None
-
 
 def _get_default_dtype() -> jnp.float32 | jnp.float64:
     default_dtype = jnp.array(0.0).dtype


### PR DESCRIPTION
On top of #405.

I also made a base class for `PWCTimeArray` and `ModulatedTimeArray` as they had the exact same implementation (suggested by @gautierronan a while ago).

```python
import dynamiqs as dq
import jax.numpy as jnp

n = 16
a = dq.destroy(n)

H = dq.totime(dq.dag(a) @ a)
H = dq.totime(lambda t: dq.dag(a) @ a)
H = dq.totime(([1, 2, 3], [1, 3], dq.dag(a) @ a))
H = dq.totime((lambda t: jnp.array([3.0]), dq.dag(a) @ a))
```