### PR TITLE
Fix mesolve correctness tests

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -50,7 +50,7 @@ def check_time_array(x: Array, arg_name: str, allow_empty: bool = False):
 def bexpect(O: Array, x: Array) -> Array:
     # batched over O
     if isket(x):
-        return jnp.einsum('ij,...jk,kl->...', dag(x), O, x)  # <x|O|x>
+        return jnp.einsum('ij,bjk,kl->b', dag(x), O, x)  # <x|O|x>
     return jnp.einsum('bij,ji->b', O, x)  # tr(Ox)
 
 

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -7,7 +7,7 @@ import diffrax as dx
 from jax import numpy as jnp
 from jaxtyping import Array
 
-from .gradient import Autograd, Adjoint
+from .gradient import Adjoint, Autograd
 from .utils import dag, isket
 
 

--- a/dynamiqs/mesolve/lindblad_term.py
+++ b/dynamiqs/mesolve/lindblad_term.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree, Scalar
 
-from ..time_array import TimeArray, ConstantTimeArray
+from ..time_array import ConstantTimeArray, TimeArray
 from ..utils.utils import dag
 
 

--- a/dynamiqs/mesolve/lindblad_term.py
+++ b/dynamiqs/mesolve/lindblad_term.py
@@ -1,49 +1,33 @@
-import functools
 from typing import Callable
 
 import diffrax as dx
-import jax
 import jax.numpy as jnp
 from jaxtyping import Array, PyTree, Scalar
 
-from ..time_array import ConstantTimeArray, TimeArray
+from .._utils import merge_complex, split_complex
+from ..time_array import TimeArray
 from ..utils.utils import dag
 
 
 class LindbladTerm(dx.ODETerm):
     H: TimeArray  # (n, n)
-    Ls: TimeArray  # (nL, n, n)
+    Ls: list[TimeArray]  # (nL, n, n)
     vector_field: Callable[[Scalar, PyTree, PyTree], PyTree]
 
     def __init__(self, H: TimeArray, Ls: TimeArray):
-        self.constant_H = isinstance(self.H, ConstantTimeArray)
-        # rewrite but shorter
-        self.H = H(0.0) if self.constant_H else H
+        self.H = H
+        self.Ls = Ls
 
-        self.constant_Ls = isinstance(self.Ls, ConstantTimeArray)
-        self.Ls = Ls(0.0) if self.constant_Ls else Ls
-
-        self.constant_Hnh = self.constant_H and self.constant_Ls
-        if self.constant_Hnh:
-            self.Hnh = LindbladTerm.Hnh(self.H, self.Ls)
-        elif self.constant_H:
-            self.Hnh = lambda t: LindbladTerm.Hnh(self.H, self.Ls(t))
-        elif self.constant_Ls:
-            self.Hnh = lambda t: LindbladTerm.Hnh(self.H(t), self.Ls)
-        else:
-            self.Hnh = lambda t: LindbladTerm.Hnh(self.H(t), self.Ls(t))
-
-    @functools.partial(jax.jit, static_argnums=0)
     def vector_field(self, t: Scalar, rho: PyTree, _args: PyTree):
-        Ls_t = self.Ls if self.constant_Ls else self.Ls(t)
-        Hnh = self.Hnh if self.constant_Hnh else self.Hnh(t)
+        rho = merge_complex(rho)
+        Ls_t = jnp.stack([L(t) for L in self.Ls])
+        Hnh_t = self.H(t) - 0.5j * jnp.sum(dag(Ls_t) @ Ls_t, axis=0)
+        out = -1j * Hnh_t @ rho + 0.5 * jnp.sum(Ls_t @ rho @ dag(Ls_t), axis=0)
+        return split_complex(out + dag(out))
 
-        out = -1j * Hnh @ rho + 0.5 * jnp.sum(Ls_t @ rho @ dag(Ls_t), axis=0)
-        return out + dag(out)
-
-    @staticmethod
-    def Hnh(H, Ls) -> Array:
-        return H - 0.5j * jnp.sum(dag(Ls) @ Ls, axis=0)
+    def Hnh(self, t: float) -> Array:
+        Ls_t = jnp.stack([L(t) for L in self.Ls])
+        return self.H(t) - 0.5j * jnp.sum(dag(Ls_t) @ Ls_t, axis=0)
 
     @property
     def Id(self) -> Array:

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -2,22 +2,20 @@ from __future__ import annotations
 
 from typing import Any
 
-import numpy as np
 import diffrax as dx
 import jax.numpy as jnp
+import numpy as np
 from jaxtyping import ArrayLike
 
-from .lindblad_term import LindbladTerm
-from .rouchon import Rouchon1Solver
-from .._utils import save_fn, _get_solver_class, _get_adjoint_class
+from .._utils import _get_adjoint_class, _get_solver_class, save_fn
 from ..gradient import Autograd, Gradient
 from ..options import Options
 from ..result import Result
 from ..solver import Dopri5, Rouchon1, Solver, _stepsize_controller
-from ..utils.utils import todm
-
-
 from ..time_array import TimeArray, totime
+from ..utils.utils import todm
+from .lindblad_term import LindbladTerm
+from .rouchon import Rouchon1Solver
 
 
 def mesolve(
@@ -46,7 +44,8 @@ def mesolve(
 
     # === solve differential equation with diffrax
     H = totime(H)
-    Ls = format_L(jump_ops)
+    Ls = [totime(L) for L in jump_ops]
+    Ls = format_L(Ls)
     term = LindbladTerm(H=H, Ls=Ls)
 
     solution = dx.diffeqsolve(
@@ -67,7 +66,7 @@ def mesolve(
         ysave = solution.ys['states']
 
     Esave = None
-    if "expects" in solution.ys:
+    if 'expects' in solution.ys:
         Esave = solution.ys['expects']
         Esave = jnp.stack(Esave, axis=0)
 
@@ -79,34 +78,32 @@ def mesolve(
     )
 
 
-def format_L(L: list[ArrayLike | TimeArray]) -> list[TimeArray]:
-    # Format a list of tensors of individual shape (n, n) or (?, n, n) into a single
-    # batched tensor of shape (nL, bL, n, n). An error is raised if all batched
-    # dimensions `?` are not the same.
+def format_L(Ls: list[TimeArray]) -> list[TimeArray]:
+    # Format a list of TimeArrays of individual shape (n, n) or (?, n, n) into a list of
+    # TimeArrays of shape (bL, n, n) where bL is a common batch size. An error is
+    # raised if all batched dimensions `?` do not match.
+    n = Ls[0].shape[-1]
+    Ls = [L.reshape(-1, n, n) for L in Ls]  # [(?, n, n)] with ? = 1 if not batched
 
-    L = [totime(x) for x in L]
-    n = L[0](0.0).shape[-1]
-    L = [x.reshape(-1, n, n) for x in L]  # [(?, n, n)] with ? = 1 if not batched
-
-    bL = common_batch_size([x.shape[0] for x in L])
+    bL = common_batch_size([L.shape[0] for L in Ls])
     if bL is None:
-        L_shapes = [tuple(x.shape) for x in L]
+        L_shapes = [tuple(L.shape) for L in Ls]
         raise ValueError(
             'Argument `jump_ops` should be a list of 2D arrays or 3D arrays with the'
             ' same batch size, but got a list of arrays with incompatible shapes'
             f' {L_shapes}.'
         )
 
-    res = []
-    for x in L:
-        if x.ndim == 3:
-            L.append(x)
-        elif x.ndim == 2:
-            L.append(x.repeat(bL, 0))
+    Ls_formatted = []
+    for L in Ls:
+        if L.ndim == 3:
+            Ls_formatted.append(L)
+        elif L.ndim == 2:
+            Ls_formatted.append(L.repeat(bL, 0))
         else:
-            raise Exception(f'Unexpected dimension {x.ndim}.')
+            raise Exception(f'Unexpected dimension {L.ndim}.')
 
-    return res
+    return Ls_formatted
 
 
 def common_batch_size(dims: list[int]) -> int | None:

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import jax.numpy as jnp
 from typing import Any
+
+import jax.numpy as jnp
 
 from .gradient import Gradient
 from .solver import Solver

--- a/dynamiqs/sesolve/schrodinger_term.py
+++ b/dynamiqs/sesolve/schrodinger_term.py
@@ -4,26 +4,17 @@ import diffrax as dx
 from jaxtyping import PyTree, Scalar
 
 from .._utils import merge_complex, split_complex
-from ..time_array import ConstantTimeArray, TimeArray
+from ..time_array import TimeArray
 
 
 class SchrodingerTerm(dx.ODETerm):
     H: TimeArray  # (n, n)
-    constant_H: bool
     vector_field: Callable[[Scalar, PyTree, PyTree], PyTree]
 
     def __init__(self, H: TimeArray):
-        self.constant_H = isinstance(H, ConstantTimeArray)
-        if self.constant_H:
-            self.H = H(0.0)
-        else:
-            self.H = H
+        self.H = H
 
     def vector_field(self, t: Scalar, psi: PyTree, _args: PyTree):
-        if self.constant_H:
-            H = self.H
-        else:
-            H = self.H(t)
         psi = merge_complex(psi)
-        res = -1j * H @ psi
+        res = -1j * self.H(t) @ psi
         return split_complex(res)

--- a/dynamiqs/sesolve/schrodinger_term.py
+++ b/dynamiqs/sesolve/schrodinger_term.py
@@ -4,7 +4,7 @@ import diffrax as dx
 from jaxtyping import PyTree, Scalar
 
 from .._utils import merge_complex, split_complex
-from ..time_array import TimeArray, ConstantTimeArray
+from ..time_array import ConstantTimeArray, TimeArray
 
 
 class SchrodingerTerm(dx.ODETerm):

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -46,10 +46,9 @@ def sesolve(
     stepsize_controller, dt = _stepsize_controller(solver)
 
     # === solve differential equation with diffrax
-    exp_ops = jnp.array(exp_ops)
     H = totime(H)
-
     term = SchrodingerTerm(H=H)
+    exp_ops = jnp.asarray(exp_ops)
 
     solution = dx.diffeqsolve(
         term,

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -6,20 +6,20 @@ import diffrax as dx
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
-from .schrodinger_term import SchrodingerTerm
 from .._utils import (
-    save_fn,
+    SolverArgs,
     _get_adjoint_class,
     _get_solver_class,
-    SolverArgs,
     merge_complex,
+    save_fn,
     split_complex,
 )
 from ..gradient import Autograd, Gradient
 from ..options import Options
 from ..result import Result
-from ..solver import Dopri5, Solver, _stepsize_controller, Euler, _ODEAdaptiveStep
+from ..solver import Dopri5, Euler, Solver, _ODEAdaptiveStep, _stepsize_controller
 from ..time_array import totime
+from .schrodinger_term import SchrodingerTerm
 
 
 def sesolve(
@@ -71,7 +71,7 @@ def sesolve(
         ysave = merge_complex(solution.ys['states'])
 
     Esave = None
-    if "expects" in solution.ys:
+    if 'expects' in solution.ys:
         Esave = merge_complex(solution.ys['expects']).T
         Esave = jnp.stack(Esave, axis=0)
 

--- a/tests/mesolve/test_propagator.py
+++ b/tests/mesolve/test_propagator.py
@@ -1,9 +1,9 @@
 import pytest
+
 from dynamiqs.gradient import Autograd
 
 from ..solver_tester import SolverTester
 from .open_system import gocavity, ocavity
-
 
 Propagator = None
 

--- a/tests/sesolve/test_backward_euler.py
+++ b/tests/sesolve/test_backward_euler.py
@@ -2,10 +2,11 @@ import pytest
 
 from dynamiqs.gradient import Autograd
 
-# from dynamiqs.solver import BackwardEuler
-
 from ..solver_tester import SolverTester
 from .closed_system import cavity, gcavity, gtdqubit, tdqubit
+
+# from dynamiqs.solver import BackwardEuler
+
 
 BackwardEuler = None
 

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -4,7 +4,7 @@ from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
-from .closed_system import cavity, gcavity, gtdqubit, tdqubit
+from .closed_system import cavity, gcavity, tdqubit
 
 
 class TestSEEuler(SolverTester):

--- a/tests/smesolve/monitored_system.py
+++ b/tests/smesolve/monitored_system.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from math import cos, exp, pi, sin
 from typing import Any
 
-from jax import numpy as jnp, Array
+from jax import Array
+from jax import numpy as jnp
 
 import dynamiqs as dq
 from dynamiqs import TimeArray

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -7,7 +7,6 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 
-from dynamiqs import plot_wigner_mosaic
 from dynamiqs.gradient import Gradient
 from dynamiqs.solver import Solver
 
@@ -197,11 +196,6 @@ class SolverTester(ABC):
         grads_expect = jnp.stack(grads_expect)
         true_grads_expect = system.grads_expect(tsave[-1])
 
-        print()
-        print(f'grads_expect      =')
-        print(grads_expect)
-        print(f'true_grads_expect = ')
-        print(true_grads_expect)
         logging.warning(f'grads_expect      = {grads_expect}')
         logging.warning(f'true_grads_expect = {true_grads_expect}')
 


### PR DESCRIPTION
Small refactorings, and fixes the correctness for mesolve (the sesolve one still passes too).

@abocquet I removed the `self.constant_H` logic: with a `ConstantTimeArray`, the result is already "cached" by default since the same array is returned when calling `TimeArray.__call__` at any time `t`.