### PR TITLE
Make TimeArrays as PyTrees

### DIFF
--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -8,9 +8,9 @@ import numpy as np
 from jax import Array, lax
 from jax import numpy as jnp
 from jax.tree_util import Partial
+from jaxtyping import Scalar
 
 from ._utils import check_time_array, obj_type_str, type_str
-from .types import Scalar
 from .utils.array_types import ArrayLike, dtype_complex_to_real, get_cdtype
 
 __all__ = ['totime']

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -29,6 +29,9 @@ def totime(
 ) -> TimeArray:
     dtype = dtype or get_cdtype(dtype)  # assume complex by default
 
+    # already a time array
+    if isinstance(x, TimeArray):
+        return x
     # PWC time array
     if isinstance(x, tuple) and len(x) == 3:
         return _factory_pwc(x, dtype=dtype)

--- a/dynamiqs/types.py
+++ b/dynamiqs/types.py
@@ -1,6 +1,0 @@
-from typing import Union
-
-from jax import Array
-
-# type for single real number (Array = single-element array here)
-Scalar = Union[int, float, Array]

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -162,7 +162,9 @@ class OTDQubit(OpenSystem):
         self.loss_op = dq.sigmaz()
 
         # prepare quantum operators
-        self.H = dq.totime(lambda t: self.eps * jnp.cos(self.omega * t) * dq.sigmax())
+        self.H = dq.totime(
+            lambda t, args: self.eps * jnp.cos(self.omega * t) * dq.sigmax()
+        )
         self.L = [jnp.sqrt(self.gamma) * dq.sigmax()]
         self.E = [dq.sigmax(), dq.sigmay(), dq.sigmaz()]
 

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -149,7 +149,7 @@ class TDQubit(ClosedSystem):
 
     def H(self, params: Array = None):
         eps, omega = params if params is not None else self.params
-        return dq.totime(lambda t: eps * jnp.cos(omega * t) * dq.sigmax())
+        return dq.totime(lambda t, args: eps * jnp.cos(omega * t) * dq.sigmax())
 
     def tsave(self, n: int) -> Array:
         return jnp.linspace(0.0, self.t_end.item(), n)


### PR DESCRIPTION
Makes all TimeArrays subclasses of eqx.Module such that they are Pytrees and that the JIT is well-handled.

With this syntax, `dq.totime` should receive a callable of signature `(t: Scalar, args: tuple) -> Array` instead of `(t: Scalar) -> Array` as before. The `args` can then be passed into `dq.totime` as an optional argument, and the jit doesn't run again.

Note we probably don't need `eqx.Module` and could work around it, but it makes everything very neat IMO.

To test this:
```python
import jax.numpy as jnp
import time
from jax import jit
import dynamiqs as dq


def time_once(f, *args, **kwargs):
    start = time.time()
    f(*args, **kwargs).block_until_ready()
    print(f'Elapsed: {(time.time() - start) * 1000:.3f} ms')


@jit
def loss(x):
    return jnp.linalg.norm(2 * x(1.0) - x(0.0))


# ==============================
# test constant array
# ==============================

N = 100
x0 = jnp.arange(N).repeat(N).reshape(N, N).astype(complex)
x1 = (N - jnp.arange(N)).repeat(N).reshape(N, N).astype(complex)
array0 = dq.totime(x0)
array1 = dq.totime(x1)

print("=== constant array")
array = array0
time_once(loss, array)  # jit runs

print("=== constant array (different array)")
array = array0 + array1
time_once(loss, array)  # jit does not rerun

# ==============================
# test callable array
# ==============================

fn = lambda t, args: args * t * x0
array2 = dq.totime(fn, args=2.0)
array3 = dq.totime(fn, args=3.0)

print("\n=== callable array")
array = array0 + array1 + array2
time_once(loss, array)  # jit runs

print("=== callable array (same function with different parameter)")
array = array0 + array1 + array3
time_once(loss, array)  # jit does not rerun

print("=== callable array (different function)")
array = array0 + array1 + array2 + array3
time_once(loss, array)  # jit runs

# ==============================
# test PWC array
# ==============================

times = jnp.linspace(0.0, 1.0, 11)
values0 = jnp.arange(10).astype(complex)
values1 = (10 - jnp.arange(10)).astype(complex)
array4 = dq.totime((times, values0, x0))
array5 = dq.totime((times, values1, x0))
array6 = dq.totime((times, values0, x1))

print("\n=== PWC array")
array = array4
time_once(loss, array)  # jit runs

print("=== PWC array (different values)")
array = array5
time_once(loss, array)  # jit does not rerun

print("=== PWC array (different array)")
array = array6
time_once(loss, array)  # jit does not rerun

print("=== PWC array (sum of two PWC arrays)")
array = array4 + array5
time_once(loss, array)  # jit runs

# ==============================
# test modulated array
# ==============================

fn = lambda t, args: args * jnp.array(t)
array7 = dq.totime((fn, x0), args=1.0)
array8 = dq.totime((fn, x0), args=2.0)

print("\n=== modulated array")
array = array7
time_once(loss, array)  # jit runs

print("=== modulated array (same function with different parameter)")
array = array8
time_once(loss, array)  # jit does not rerun

print("=== modulated array (different function)")
array = array7 + array8
time_once(loss, array)  # jit runs
```
which prints
```markdown
=== constant array
Elapsed: 24.352 ms
=== constant array (different array)
Elapsed: 0.045 ms

=== callable array
Elapsed: 26.352 ms
=== callable array (same function with different parameter)
Elapsed: 0.066 ms
=== callable array (different function)
Elapsed: 28.494 ms

=== PWC array
Elapsed: 72.702 ms
=== PWC array (different values)
Elapsed: 0.074 ms
=== PWC array (different array)
Elapsed: 0.050 ms
=== PWC array (sum of two PWC arrays)
Elapsed: 123.167 ms

=== modulated array
Elapsed: 29.345 ms
=== modulated array (same function with different parameter)
Elapsed: 0.072 ms
=== modulated array (different function)
Elapsed: 51.495 ms
```

In a subsequent PR:

- [ ] Move these tests into our test set.