### PR TITLE
JIT `sesolve`

### DIFF
--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -6,7 +6,7 @@ from .mesolve import mesolve
 from .plots import *
 from .result import Result
 from .sesolve import sesolve
-from .time_array import TimeArray, totime
+from .time_array import TimeArray, TimeArrayLike, totime
 from .utils import *
 
 # get version from pyproject.toml

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -46,15 +46,15 @@ def bexpect(O: Array, x: Array) -> Array:
     return jnp.einsum('bij,ji->b', O, x)  # tr(Ox)
 
 
-SolverArgs = namedtuple('SolverArgs', ['save_states', 'exp_ops'])
+SolverArgs = namedtuple('SolverArgs', ['save_states', 'E'])
 
 
 def save_fn(_t, y, args: SolverArgs):
     res = {}
     if args.save_states:
-        res['states'] = y
-    if args.exp_ops is not None and len(args.exp_ops) > 0:
-        res['expects'] = bexpect(args.exp_ops, y)
+        res['ysave'] = y
+    if args.E is not None and len(args.E) > 0:
+        res['Esave'] = bexpect(args.E, y)
     return res
 
 

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -1,4 +1,7 @@
-class Gradient:
+import equinox as eqx
+
+
+class Gradient(eqx.Module):
     pass
 
 

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -1,42 +1,17 @@
 from __future__ import annotations
 
-from typing import Any
-
+import equinox as eqx
 import jax.numpy as jnp
 
-from .gradient import Gradient
-from .solver import Solver
-from .utils.array_types import dtype_complex_to_real, get_cdtype
+from .utils.array_types import get_cdtype
 
 
-class Options:
-    def __init__(
-        self,
-        solver: Solver,
-        gradient: Gradient | None,
-        options: dict[str, Any] | None,
-    ):
-        if options is None:
-            options = {}
+class Options(eqx.Module):
+    save_states: bool
+    verbose: bool
+    _double_precision: bool
+    cartesian_batching: bool
 
-        self.solver = solver
-        self.gradient = gradient
-        self.options = SharedOptions(**options)
-
-    def __getattr__(self, name: str) -> Any:
-        if name in dir(self.solver):
-            return getattr(self.solver, name)
-        elif name in dir(self.gradient):
-            return getattr(self.gradient, name)
-        elif name in dir(self.options):
-            return getattr(self.options, name)
-        else:
-            raise AttributeError(
-                f'Attribute `{name}` not found in `{type(self).__name__}`.'
-            )
-
-
-class SharedOptions:
     def __init__(
         self,
         *,
@@ -53,6 +28,14 @@ class SharedOptions:
         #     data type of the corresponding precision.
         self.save_states = save_states
         self.verbose = verbose
-        self.cdtype = get_cdtype(dtype)
-        self.rdtype = dtype_complex_to_real(self.cdtype)
+        cdtype = get_cdtype(dtype)
+        self._double_precision = cdtype == jnp.complex128
         self.cartesian_batching = cartesian_batching
+
+    @property
+    def rdtype(self) -> jnp.float32 | jnp.float64:
+        return jnp.float64 if self._double_precision else jnp.float32
+
+    @property
+    def cdtype(self) -> jnp.complex64 | jnp.complex128:
+        return jnp.complex128 if self._double_precision else jnp.complex64

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Any
-
+import equinox as eqx
 from jax import Array
 
 from .gradient import Gradient
@@ -25,39 +23,16 @@ def memory_str(x: Array) -> str:
 
 
 def array_str(x: Array) -> str:
-    return f'Array {tuple(x.shape)} | {memory_str(x)}'
+    return f'Array {x.dtype} {tuple(x.shape)} | {memory_str(x)}'
 
 
-class Result:
-    def __init__(
-        self,
-        options: Options,
-        ysave: Array,
-        tsave: Array,
-        Esave: Array | None,
-        Lmsave: Array | None = None,
-        tmeas: Array | None = None,
-    ):
-        self._options = options
-        self.ysave = ysave
-        self.tsave = tsave
-        self.Esave = Esave
-        self.Lmsave = Lmsave
-        self.tmeas = tmeas
-        self.start_time: float | None = None
-        self.end_time: float | None = None
-
-    @property
-    def solver(self) -> Solver:
-        return self._options.solver
-
-    @property
-    def gradient(self) -> Gradient:
-        return self._options.gradient
-
-    @property
-    def options(self) -> dict[str, Any]:
-        return self._options.options
+class Result(eqx.Module):
+    tsave: Array
+    solver: Solver
+    gradient: Gradient
+    options: Options
+    ysave: Array
+    Esave: Array | None
 
     @property
     def states(self) -> Array:
@@ -65,64 +40,23 @@ class Result:
         return self.ysave
 
     @property
-    def times(self) -> Array:
-        # alias for tsave
-        return self.tsave
-
-    @property
     def expects(self) -> Array | None:
         # alias for Esave
         return self.Esave
 
-    @property
-    def measurements(self) -> Array | None:
-        # alias for Lmsave
-        return self.Lmsave
-
-    @property
-    def start_datetime(self) -> datetime | None:
-        if self.start_time is None:
-            return None
-        return datetime.fromtimestamp(self.start_time)
-
-    @property
-    def end_datetime(self) -> datetime | None:
-        if self.end_time is None:
-            return None
-        return datetime.fromtimestamp(self.end_time)
-
-    @property
-    def total_time(self) -> timedelta | None:
-        if self.start_datetime is None or self.end_datetime is None:
-            return None
-        return self.end_datetime - self.start_datetime
-
     def __str__(self) -> str:
         parts = {
-            'Solver': type(self.solver).__name__,
-            'Gradient': type(self.gradient).__name__ if self.gradient else None,
-            'Start': self.start_datetime.strftime('%Y-%m-%d %H:%M:%S'),
-            'End': self.end_datetime.strftime('%Y-%m-%d %H:%M:%S'),
-            'Total time': f'{self.total_time.total_seconds():.2f} s',
-            'States': array_str(self.states),
-            'Expects': array_str(self.expects) if self.expects is not None else None,
-            'Measurements': (
-                array_str(self.measurements) if self.measurements is not None else None
-            ),
+            'Solver  ': type(self.solver).__name__,
+            'Gradient': type(self.gradient).__name__,
+            'States  ': array_str(self.states),
+            'Expects ': array_str(self.expects) if self.expects is not None else None,
         }
         parts = {k: v for k, v in parts.items() if v is not None}
-        padding = max(len(k) for k in parts.keys()) + 1
-        parts_str = '\n'.join(f'{k:<{padding}}: {v}' for k, v in parts.items())
+        parts_str = '\n'.join(f'{k}: {v}' for k, v in parts.items())
         return '==== Result ====\n' + parts_str
 
     def to_qutip(self) -> Result:
         raise NotImplementedError
 
     def to_numpy(self) -> Result:
-        raise NotImplementedError
-
-    def save(self, filename: str):
-        raise NotImplementedError
-
-    def load(self, filename: str) -> Result:
         raise NotImplementedError

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -1,51 +1,24 @@
+from typing import ClassVar
+
 import diffrax as dx
-from jax import Array
+import equinox as eqx
+from jaxtyping import Scalar
 
 from .gradient import Adjoint, Autograd, Gradient
 
 
-class Solver:
-    SUPPORTED_GRADIENT = ()
+class Solver(eqx.Module):
+    SUPPORTED_GRADIENT: ClassVar[tuple[Gradient]] = ()
 
-    def supports_gradient(self, gradient: Gradient) -> bool:
-        if len(self.SUPPORTED_GRADIENT) == 0:
-            return False
-        return isinstance(gradient, self.SUPPORTED_GRADIENT)
+    @classmethod
+    def supports_gradient(cls, gradient: Gradient) -> bool:
+        return isinstance(gradient, cls.SUPPORTED_GRADIENT)
 
 
 class _ODEFixedStep(Solver):
-    SUPPORTED_GRADIENT = (Autograd,)
-
-    def __init__(self, *, dt: float):
-        # convert `dt` in case an array was passed instead of a float
-        if isinstance(dt, Array):
-            dt = dt.item()
-        self.dt = dt
-
-
-class _ODEAdaptiveStep(Solver):
     SUPPORTED_GRADIENT = (Autograd, Adjoint)
 
-    def __init__(
-        self,
-        *,
-        atol: float = 1e-8,
-        rtol: float = 1e-6,
-        safety_factor: float = 0.9,
-        min_factor: float = 0.2,
-        max_factor: float = 5.0,
-        max_steps: int = 100_000,
-    ):
-        self.atol = atol
-        self.rtol = rtol
-        self.safety_factor = safety_factor
-        self.min_factor = min_factor
-        self.max_factor = max_factor
-        self.max_steps = max_steps
-
-
-class Dopri5(_ODEAdaptiveStep):
-    pass
+    dt: Scalar
 
 
 class Euler(_ODEFixedStep):
@@ -53,6 +26,21 @@ class Euler(_ODEFixedStep):
 
 
 class Rouchon1(_ODEFixedStep):
+    pass
+
+
+class _ODEAdaptiveStep(Solver):
+    SUPPORTED_GRADIENT = (Autograd, Adjoint)
+
+    atol: float = 1e-8
+    rtol: float = 1e-6
+    safety_factor: float = 0.9
+    min_factor: float = 0.2
+    max_factor: float = 5.0
+    max_steps: int = 100_000
+
+
+class Dopri5(_ODEAdaptiveStep):
     pass
 
 

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -1,4 +1,4 @@
-from typing import ClassVar
+from typing import ClassVar, Literal, Optional
 
 import diffrax as dx
 import equinox as eqx
@@ -15,6 +15,10 @@ class Solver(eqx.Module):
         return isinstance(gradient, cls.SUPPORTED_GRADIENT)
 
 
+class Propagator(Solver):
+    SUPPORTED_GRADIENT = (Autograd,)
+
+
 class _ODEFixedStep(Solver):
     SUPPORTED_GRADIENT = (Autograd, Adjoint)
 
@@ -26,6 +30,19 @@ class Euler(_ODEFixedStep):
 
 
 class Rouchon1(_ODEFixedStep):
+    # normalize: The default scheme is trace-preserving at first order only. This
+    # parameter sets the normalisation behaviour:
+    # - `None`: The scheme is not normalized.
+    # - `'sqrt'`: The Kraus map is renormalized with a matrix square root. Ideal
+    #   for stiff problems, recommended for time-independent problems.
+    # - `cholesky`: The Kraus map is renormalized at each time step using a Cholesky
+    #   decomposition. Ideal for stiff problems, recommended for time-dependent
+    #   problems.
+
+    normalize: Optional[Literal['sqrt', 'cholesky']] = None
+
+
+class Rouchon2(_ODEFixedStep):
     pass
 
 


### PR DESCRIPTION
Everyone is a PyTree, everyone is happy ☀️ We turn all objects to equinox module to make sesolve JIT-compatible.

Notes:
- I had to remove the dtype argument of options bc jnp.dtype is not a JAX type
- I remove result timing as it's not straightfwd to implement

Here's an example:
```python
import dynamiqs as dq
from jax import numpy as jnp
from time import time

n = 64
a = dq.destroy(n)
H = dq.dag(a) @ a
psi0 = dq.coherent(n, 1.0)
tsave = jnp.linspace(0, 1.0, 101)

# JIT and execute
start = time()
dq.sesolve(H, psi0, tsave).ysave.block_until_ready()
print(f'{(time()-start)*1000:.2f} ms')  # 484.34 ms

# execute again
start = time()
dq.sesolve(H, psi0, tsave).ysave.block_until_ready()
print(f'{(time()-start)*1000:.2f} ms')  # 1.02 ms

# check that a different H with same dtype and shape doesn't re-JIT
H = dq.dag(a) @ a + a + dq.dag(a)
start = time()
dq.sesolve(H, psi0, tsave).ysave.block_until_ready()
print(f'{(time()-start)*1000:.2f} ms')  # 1.29 ms
```