### PR TITLE
Implement base solver

### DIFF
--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+
+import equinox as eqx
+from jax import Array
+from jaxtyping import PyTree
+
+from ..gradient import Gradient
+from ..options import Options
+from ..solver import Solver
+from ..time_array import TimeArray
+
+
+class AbstractSolver(eqx.Module):
+    @abstractmethod
+    def run(self) -> PyTree:
+        pass
+
+
+class BaseSolver(AbstractSolver):
+    ts: Array
+    y0: Array
+    H: TimeArray
+    E: Array
+    solver: Solver
+    gradient: Gradient | None
+    options: Options
+
+
+SESolver = BaseSolver
+
+
+class MESolver(BaseSolver):
+    Ls: list[TimeArray]

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -31,6 +31,8 @@ class DiffraxSolver(BaseSolver):
     term: dx.ODETerm
 
     def __init__(self, *args):
+        # this dummy init is needed because of the way the class hierarchy is set up,
+        # to have subsequent init working properly
         super().__init__(*args)
 
     def run(self) -> PyTree:

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -4,8 +4,6 @@ import warnings
 from collections import namedtuple
 
 import diffrax as dx
-
-# from equinox import AbstractVar
 from jaxtyping import PyTree
 
 from .._utils import bexpect

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import warnings
+from collections import namedtuple
+
+import diffrax as dx
+
+# from equinox import AbstractVar
+from jaxtyping import PyTree
+
+from .._utils import bexpect
+from ..gradient import Adjoint, Autograd
+from ..result import Result
+from .abstract_solver import BaseSolver
+
+SolverArgs = namedtuple('SolverArgs', ['save_states', 'E'])
+
+
+def save_fn(_t, y, args: SolverArgs):
+    res = {}
+    if args.save_states:
+        res['ysave'] = y
+    if args.E is not None and len(args.E) > 0:
+        res['Esave'] = bexpect(args.E, y)
+    return res
+
+
+class DiffraxSolver(BaseSolver):
+    diffrax_solver: dx.AbstractSolver
+    stepsize_controller: dx.AbstractAdaptiveStepSizeController
+    dt0: float | None
+    max_steps: int
+    term: dx.ODETerm
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def run(self) -> PyTree:
+        # todo: remove once complex support is stabilized in diffrax
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+
+            # === prepare diffrax arguments
+            args = SolverArgs(save_states=self.options.save_states, E=self.E)
+            saveat = dx.SaveAt(ts=self.ts, fn=save_fn)
+
+            if self.gradient is None:
+                adjoint = dx.RecursiveCheckpointAdjoint()
+            elif isinstance(self.gradient, Autograd):
+                adjoint = dx.RecursiveCheckpointAdjoint()
+            elif isinstance(self.gradient, Adjoint):
+                adjoint = dx.BacksolveAdjoint()
+
+            # === solve differential equation with diffrax
+            solution = dx.diffeqsolve(
+                self.term,
+                self.diffrax_solver,
+                t0=self.ts[0],
+                t1=self.ts[-1],
+                dt0=self.dt0,
+                y0=self.y0,
+                args=args,
+                saveat=saveat,
+                stepsize_controller=self.stepsize_controller,
+                adjoint=adjoint,
+                max_steps=self.max_steps,
+            )
+
+        # === collect results
+        ysave = solution.ys.get('ysave', None)
+        Esave = solution.ys.get('Esave', None)
+        if Esave is not None:
+            Esave = Esave.swapaxes(-1, -2)
+
+        return Result(self.ts, self.solver, self.gradient, self.options, ysave, Esave)
+
+
+class EulerSolver(DiffraxSolver):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.diffrax_solver = dx.Euler()
+        self.stepsize_controller = dx.ConstantStepSize()
+        self.dt0 = self.solver.dt
+        self.max_steps = 100_000  # todo: fix hard-coded max_steps
+
+
+class Dopri5Solver(DiffraxSolver):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.diffrax_solver = dx.Dopri5()
+        self.stepsize_controller = dx.PIDController(
+            rtol=self.solver.rtol,
+            atol=self.solver.atol,
+            safety=self.solver.safety_factor,
+            factormin=self.solver.min_factor,
+            factormax=self.solver.max_factor,
+        )
+        self.dt0 = None
+        self.max_steps = self.solver.max_steps

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -29,7 +29,7 @@ def array_str(x: Array) -> str:
 class Result(eqx.Module):
     tsave: Array
     solver: Solver
-    gradient: Gradient
+    gradient: Gradient | None
     options: Options
     ysave: Array
     Esave: Array | None
@@ -47,7 +47,9 @@ class Result(eqx.Module):
     def __str__(self) -> str:
         parts = {
             'Solver  ': type(self.solver).__name__,
-            'Gradient': type(self.gradient).__name__,
+            'Gradient': (
+                type(self.gradient).__name__ if self.gradient is not None else None
+            ),
             'States  ': array_str(self.states),
             'Expects ': array_str(self.expects) if self.expects is not None else None,
         }

--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -3,6 +3,8 @@ from typing import Callable
 import diffrax as dx
 from jaxtyping import PyTree, Scalar
 
+from ..core.abstract_solver import SESolver
+from ..core.diffrax_solver import DiffraxSolver, Dopri5Solver, EulerSolver
 from ..time_array import TimeArray
 
 
@@ -15,3 +17,17 @@ class SchrodingerTerm(dx.ODETerm):
 
     def vector_field(self, t: Scalar, psi: PyTree, _args: PyTree):
         return -1j * self.H(t) @ psi
+
+
+class SEDiffraxSolver(DiffraxSolver, SESolver):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.term = SchrodingerTerm(self.H)
+
+
+class SEEuler(SEDiffraxSolver, EulerSolver):
+    pass
+
+
+class SEDopri5(SEDiffraxSolver, Dopri5Solver):
+    pass

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -1,21 +1,18 @@
 from __future__ import annotations
 
-import warnings
 from functools import partial
 from typing import Any, get_args
 
-import diffrax as dx
 import jax
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
-from .._utils import SolverArgs, _get_adjoint_class, _get_solver_class, save_fn
-from ..gradient import Autograd, Gradient
+from ..gradient import Gradient
 from ..options import Options
 from ..result import Result
-from ..solver import Dopri5, Euler, Solver, _ODEAdaptiveStep, _stepsize_controller
+from ..solver import Dopri5, Euler, Solver
 from ..time_array import TimeArray, _factory_constant
-from .schrodinger_term import SchrodingerTerm
+from .sediffrax import SEDopri5, SEEuler
 
 
 @partial(jax.jit, static_argnames=('solver', 'gradient', 'options'))
@@ -26,7 +23,7 @@ def sesolve(
     *,
     exp_ops: ArrayLike | None = None,
     solver: Solver = Dopri5(),
-    gradient: Gradient = Autograd(),
+    gradient: Gradient | None = None,
     options: dict[str, Any] | None = None,
 ) -> Result:
     # === convert arguments
@@ -36,46 +33,28 @@ def sesolve(
     if isinstance(H, get_args(ArrayLike)):
         H = _factory_constant(H, dtype=options.cdtype)
     y0 = jnp.asarray(psi0, dtype=options.cdtype)
-    tsave = jnp.asarray(tsave, dtype=options.rdtype)
+    ts = jnp.asarray(tsave, dtype=options.rdtype)
     E = jnp.asarray(exp_ops, dtype=options.cdtype) if exp_ops is not None else None
 
-    # === solver class
-    solvers = {Dopri5: dx.Dopri5, Euler: dx.Euler}
-    solver_class = _get_solver_class(solver, solvers)
+    # === select solver class
+    solvers = {Euler: SEEuler, Dopri5: SEDopri5}
 
-    # === adjoint class
-    adjoint_class = _get_adjoint_class(gradient, solver)
-
-    # === stepsize controller
-    stepsize_controller, dt = _stepsize_controller(solver)
-
-    # === solve differential equation with diffrax
-    term = SchrodingerTerm(H=H)
-    # todo: fix hard-coded max_steps
-    max_steps = options.max_steps if isinstance(options, _ODEAdaptiveStep) else 100_000
-
-    # todo: remove once complex support is stabilized in diffrax
-    with warnings.catch_warnings():
-        warnings.simplefilter('ignore', UserWarning)
-
-        solution = dx.diffeqsolve(
-            term,
-            solver_class(),
-            t0=tsave[0],
-            t1=tsave[-1],
-            dt0=dt,
-            y0=y0,
-            args=SolverArgs(save_states=options.save_states, E=E),
-            saveat=dx.SaveAt(ts=tsave, fn=save_fn),
-            stepsize_controller=stepsize_controller,
-            adjoint=adjoint_class(),
-            max_steps=max_steps,
+    if not isinstance(solver, tuple(solvers.keys())):
+        supported_str = ', '.join(f'`{x.__name__}`' for x in solvers.keys())
+        raise ValueError(
+            f'Solver of type `{type(solver).__name__}` is not supported (supported'
+            f' solver types: {supported_str}).'
         )
+    solver_class = solvers[type(solver)]
 
-    # === get results
-    ysave = solution.ys.get('ysave', None)
-    Esave = solution.ys.get('Esave', None)
-    if Esave is not None:
-        Esave = Esave.swapaxes(-1, -2)
+    # === check gradient is supported
+    solver.assert_supports_gradient(gradient)
 
-    return Result(tsave, solver, gradient, options, ysave, Esave)
+    # === init solver
+    solver = solver_class(ts, y0, H, E, solver, gradient, options)
+
+    # === run solver
+    result = solver.run()
+
+    # === return result
+    return result

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -7,11 +7,9 @@ from jaxtyping import Scalar
 
 from .gradient import Adjoint, Autograd, Gradient
 
-NoneType = type(None)
-
 
 class Solver(eqx.Module):
-    SUPPORTED_GRADIENT: ClassVar[tuple[Gradient | NoneType]] = (NoneType,)
+    SUPPORTED_GRADIENT: ClassVar[tuple[Gradient]] = ()
 
     @classmethod
     def supports_gradient(cls, gradient: Gradient | None) -> bool:
@@ -19,7 +17,7 @@ class Solver(eqx.Module):
 
     @classmethod
     def assert_supports_gradient(cls, gradient: Gradient | None) -> None:
-        if not cls.supports_gradient(gradient):
+        if gradient is not None and not cls.supports_gradient(gradient):
             support_str = ', '.join(f'`{x.__name__}`' for x in cls.SUPPORTED_GRADIENT)
             raise ValueError(
                 f'Solver `{cls.__name__}` does not support gradient'
@@ -29,11 +27,11 @@ class Solver(eqx.Module):
 
 
 class Propagator(Solver):
-    SUPPORTED_GRADIENT = (NoneType, Autograd)
+    SUPPORTED_GRADIENT = (Autograd,)
 
 
 class _ODESolver(Solver):
-    SUPPORTED_GRADIENT = (NoneType, Autograd, Adjoint)
+    SUPPORTED_GRADIENT = (Autograd, Adjoint)
 
 
 class _ODEFixedStep(_ODESolver):

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -1,27 +1,42 @@
-from typing import ClassVar, Literal, Optional
+from __future__ import annotations
 
-import diffrax as dx
+from typing import ClassVar, Literal
+
 import equinox as eqx
 from jaxtyping import Scalar
 
 from .gradient import Adjoint, Autograd, Gradient
 
+NoneType = type(None)
+
 
 class Solver(eqx.Module):
-    SUPPORTED_GRADIENT: ClassVar[tuple[Gradient]] = ()
+    SUPPORTED_GRADIENT: ClassVar[tuple[Gradient | NoneType]] = (NoneType,)
 
     @classmethod
-    def supports_gradient(cls, gradient: Gradient) -> bool:
+    def supports_gradient(cls, gradient: Gradient | None) -> bool:
         return isinstance(gradient, cls.SUPPORTED_GRADIENT)
+
+    @classmethod
+    def assert_supports_gradient(cls, gradient: Gradient | None) -> None:
+        if not cls.supports_gradient(gradient):
+            support_str = ', '.join(f'`{x.__name__}`' for x in cls.SUPPORTED_GRADIENT)
+            raise ValueError(
+                f'Solver `{cls.__name__}` does not support gradient'
+                f' `{type(gradient).__name__}` (supported gradient types:'
+                f' {support_str}).'
+            )
 
 
 class Propagator(Solver):
-    SUPPORTED_GRADIENT = (Autograd,)
+    SUPPORTED_GRADIENT = (NoneType, Autograd)
 
 
-class _ODEFixedStep(Solver):
-    SUPPORTED_GRADIENT = (Autograd, Adjoint)
+class _ODESolver(Solver):
+    SUPPORTED_GRADIENT = (NoneType, Autograd, Adjoint)
 
+
+class _ODEFixedStep(_ODESolver):
     dt: Scalar
 
 
@@ -39,16 +54,14 @@ class Rouchon1(_ODEFixedStep):
     #   decomposition. Ideal for stiff problems, recommended for time-dependent
     #   problems.
 
-    normalize: Optional[Literal['sqrt', 'cholesky']] = None
+    normalize: Literal['sqrt', 'cholesky'] | None = None
 
 
 class Rouchon2(_ODEFixedStep):
     pass
 
 
-class _ODEAdaptiveStep(Solver):
-    SUPPORTED_GRADIENT = (Autograd, Adjoint)
-
+class _ODEAdaptiveStep(_ODESolver):
     atol: float = 1e-8
     rtol: float = 1e-6
     safety_factor: float = 0.9
@@ -59,23 +72,3 @@ class _ODEAdaptiveStep(Solver):
 
 class Dopri5(_ODEAdaptiveStep):
     pass
-
-
-def _stepsize_controller(solver):
-    if isinstance(solver, _ODEFixedStep):
-        stepsize_controller = dx.ConstantStepSize()
-        dt = solver.dt
-    elif isinstance(solver, _ODEAdaptiveStep):
-        stepsize_controller = dx.PIDController(
-            rtol=solver.rtol,
-            atol=solver.atol,
-            safety=solver.safety_factor,
-            factormin=solver.min_factor,
-            factormax=solver.max_factor,
-        )
-        dt = None
-    else:
-        raise RuntimeError(
-            'Should never occur, all solvers should be either fixed or adaptive.'
-        )
-    return stepsize_controller, dt


### PR DESCRIPTION
This separates the API layer from the diffrax solvers implementation. It also allows implementing custom solvers very easily (not necessarily based on diffrax). I will use this to implement the propagator solver in a subsequent PR.