### PR TITLE
Batch sesolve

### DIFF
--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -2,10 +2,11 @@ from importlib.metadata import version
 
 from . import dark, rand
 from ._utils import *  # todo: remove, dev purpose only
+from .mesolve import mesolve
+from .options import Options
 from .plots import *
 from .result import Result
 from .sesolve import sesolve
-from .mesolve import mesolve
 from .time_array import TimeArray, TimeArrayLike, totime
 from .utils import *
 

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
 
 import jax
 from jax import numpy as jnp
@@ -27,12 +26,9 @@ def mesolve(
     exp_ops: list[ArrayLike] | None = None,
     solver: Solver = Dopri5(),
     gradient: Gradient | None = None,
-    options: dict[str, Any] | None = None,
+    options: Options = Options(),
 ) -> Result:
     # === convert arguments
-    options = {} if options is None else options
-    options = Options(**options)
-
     H = _astimearray(H, dtype=options.cdtype)
     Ls = [_astimearray(L, dtype=options.cdtype) for L in jump_ops]
     y0 = jnp.asarray(psi0, dtype=options.cdtype)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -52,7 +52,7 @@ def _sesolve(
     H: ArrayLike | TimeArray,
     psi0: ArrayLike,
     tsave: ArrayLike,
-    exp_ops: ArrayLike | None = None,
+    exp_ops: list[ArrayLike] | None = None,
     solver: Solver = Dopri5(),
     gradient: Gradient | None = None,
     options: Options = Options(),

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
 
 import jax
 from jax import numpy as jnp
@@ -25,12 +24,9 @@ def sesolve(
     exp_ops: list[ArrayLike] | None = None,
     solver: Solver = Dopri5(),
     gradient: Gradient | None = None,
-    options: dict[str, Any] | None = None,
+    options: Options = Options(),
 ) -> Result:
     # === convert arguments
-    options = {} if options is None else options
-    options = Options(**options)
-
     H = _astimearray(H, dtype=options.cdtype)
     y0 = jnp.asarray(psi0, dtype=options.cdtype)
     ts = jnp.asarray(tsave, dtype=options.rdtype)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dev = [
     "black[jupyter]==23.11.0",
     "codespell",
     "flake8",
-    "pytest",
+    "pytest>=7.0,<8.0",
     "pytest-sugar",
     "pytest-xdist",
     "mkdocs-material",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "matplotlib",
     "tqdm",
     "jax",
+    "jaxlib",
     "jaxtyping",
     "diffrax>=0.5.0",  # for complex support
     "equinox",

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections import namedtuple
-from typing import Any
 
 import numpy as np
 from jax import Array
@@ -11,6 +10,7 @@ from jaxtyping import ArrayLike, PyTree
 
 import dynamiqs as dq
 from dynamiqs.gradient import Gradient
+from dynamiqs.options import Options
 from dynamiqs.result import Result
 from dynamiqs.solver import Solver
 from dynamiqs.time_array import TimeArray
@@ -29,7 +29,7 @@ class OpenSystem(System):
         solver: Solver,
         *,
         gradient: Gradient | None = None,
-        options: dict[str, Any] | None = None,
+        options: Options = Options(),
         params: PyTree | None = None,
     ) -> Result:
         params = self.params_default if params is None else params

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import Any
 
 import numpy as np
 from jax import Array
@@ -10,6 +9,7 @@ from jaxtyping import ArrayLike, PyTree
 
 import dynamiqs as dq
 from dynamiqs.gradient import Gradient
+from dynamiqs.options import Options
 from dynamiqs.result import Result
 from dynamiqs.solver import Solver
 from dynamiqs.time_array import TimeArray
@@ -23,7 +23,7 @@ class ClosedSystem(System):
         solver: Solver,
         *,
         gradient: Gradient | None = None,
-        options: dict[str, Any] | None = None,
+        options: Options = Options(),
         params: PyTree | None = None,
     ) -> Result:
         params = self.params_default if params is None else params

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -1,0 +1,47 @@
+import jax
+import pytest
+from jax import numpy as jnp
+
+import dynamiqs as dq
+
+
+@pytest.mark.parametrize('cartesian_batching', [True, False])
+def test_batching(cartesian_batching):
+    n = 8
+    nt = 11
+    nH = 3
+    npsi0 = 4 if cartesian_batching else nH
+    nEs = 5
+
+    options = dq.options.Options(cartesian_batching=cartesian_batching)
+
+    # create random objects
+    key = jax.random.PRNGKey(42)
+    H = dq.rand.herm(key, (nH, n, n))
+    exp_ops = dq.rand.complex(key, (nEs, n, n))
+    psi0 = dq.rand.ket(key, (npsi0, n, 1))
+    tsave = jnp.linspace(0, 0.01, nt)
+
+    # no batching
+    result = dq.sesolve(H[0], psi0[0], tsave, exp_ops=exp_ops, options=options)
+    assert result.ysave.shape == (nt, n, 1)
+    assert result.Esave.shape == (nEs, nt)
+
+    # H batched
+    result = dq.sesolve(H, psi0[0], tsave, exp_ops=exp_ops, options=options)
+    assert result.ysave.shape == (nH, nt, n, 1)
+    assert result.Esave.shape == (nH, nEs, nt)
+
+    # psi0 batched
+    result = dq.sesolve(H[0], psi0, tsave, exp_ops=exp_ops, options=options)
+    assert result.ysave.shape == (npsi0, nt, n, 1)
+    assert result.Esave.shape == (npsi0, nEs, nt)
+
+    # H and psi0 batched
+    result = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops, options=options)
+    if cartesian_batching:
+        assert result.ysave.shape == (nH, npsi0, nt, n, 1)
+        assert result.Esave.shape == (nH, npsi0, nEs, nt)
+    else:
+        assert result.ysave.shape == (nH, nt, n, 1)
+        assert result.Esave.shape == (nH, nEs, nt)

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import logging
 from abc import ABC
 from functools import partial
-from typing import Any
 
 import jax
 import jax.numpy as jnp
 
 from dynamiqs.gradient import Gradient
+from dynamiqs.options import Options
 from dynamiqs.solver import Solver
 
 from .system import System
@@ -20,7 +20,7 @@ class SolverTester(ABC):
         system: System,
         solver: Solver,
         *,
-        options: dict[str, Any] | None = None,
+        options: Options = Options(),
         ysave_atol: float = 1e-3,
         esave_rtol: float = 1e-3,
         esave_atol: float = 1e-5,
@@ -48,7 +48,7 @@ class SolverTester(ABC):
         solver: Solver,
         gradient: Gradient,
         *,
-        options: dict[str, Any] | None = None,
+        options: Options = Options(),
         rtol: float = 1e-3,
         atol: float = 1e-5,
     ):

--- a/tests/system.py
+++ b/tests/system.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any
 
 from jax import Array
 from jax import numpy as jnp
 from jaxtyping import ArrayLike, PyTree
 
 from dynamiqs.gradient import Gradient
+from dynamiqs.options import Options
 from dynamiqs.result import Result
 from dynamiqs.solver import Solver
 from dynamiqs.time_array import TimeArray
@@ -72,7 +72,7 @@ class System(ABC):
         solver: Solver,
         *,
         gradient: Gradient | None = None,
-        options: dict[str, Any] | None = None,
+        options: Options = Options(),
         params: PyTree | None = None,
     ) -> Result:
         pass


### PR DESCRIPTION
On top of #435. JAX made this so easy 😍 Note that I had to fix our API, JIT doesn't work with immutable argument so options can't have the type "dict". Now user would do `dq.sesolve(..., options=dq.Options(...))`. The last 4 commits are minor fixes to be able to implement the batching test easily. I will await for your approval to do the same for `mesolve`.

```python
import dynamiqs as dq
from jax import numpy as jnp

n = 8
delta = 1.0 * 2 * jnp.pi
alpha0 = 1.0
H = jnp.stack([
    1 * delta * dq.number(n),
    2 * delta * dq.number(n),
    3 * delta * dq.number(n)
])  # (3, 8, 8)
y0 = jnp.stack([
    dq.coherent(n, alpha0),
    dq.coherent(n, 1j * alpha0),
    dq.coherent(n, - alpha0),
    dq.coherent(n, -1j * alpha0),
])  # (4, 8, 1)
exp_ops = [dq.position(n), dq.momentum(n)]  # (2,)
tsave = jnp.linspace(0, 0.3, 11)  # (11,)

res = dq.sesolve(H, y0, tsave, exp_ops=exp_ops)
print(res.ysave.shape)  # (3, 4, 11, 8, 1)
print(res.Esave.shape)  # (3, 4, 2, 11)
```

<details>
  <summary>Convincing wigners screenshots</summary>

```python
# different H, same y0
for i in range(3):
    dq.plot_wigner_mosaic(res.states[i, 0], n=6, cross=True, xmax=3, w=1)
```
![Screenshot 2024-02-07 at 21 30 13](https://github.com/dynamiqs/dynamiqs/assets/38159029/41909a27-8d28-4906-9e48-9244f8306af5)

```python
# same H, different y0
for i in range(4):
    dq.plot_wigner_mosaic(res.states[0, i], n=6, cross=True, xmax=3, w=1)
```
![Screenshot 2024-02-07 at 21 30 31](https://github.com/dynamiqs/dynamiqs/assets/38159029/7dbb331f-e0f5-46ac-9fd3-ce4b473648aa)

</details>



