### PR TITLE
Fix CI on branch `jax` by bumping Python version to 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         # os: [ubuntu-latest, macOS-latest, windows-latest]
         os: [ubuntu-latest]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-The project was written using Python 3.8+, you must have a compatible version of Python (i.e. >= 3.8) installed on your computer.
+The project was written using Python 3.9+, you must have a compatible version of Python (i.e. >= 3.9) installed on your computer.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [P. Guilmin](https://github.com/pierreguilmin), [R. Gautier](https://github.com/gautierronan), [A. Bocquet](https://github.com/abocquet), [E. Genois](https://github.com/eliegenois)
 
-[![ci](https://github.com/dynamiqs/dynamiqs/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamiqs/dynamiqs/actions/workflows/ci.yml?query=branch%3Amain)  ![python version](https://img.shields.io/badge/python-3.8%2B-blue) [![chat](https://badgen.net/badge/icon/on%20slack?icon=slack&label=chat&color=orange)](https://join.slack.com/t/dynamiqs-org/shared_invite/zt-1z4mw08mo-qDLoNx19JBRtKzXlmlFYLA) [![license: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-yellow)](https://github.com/dynamiqs/dynamiqs/blob/main/LICENSE) [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![ci](https://github.com/dynamiqs/dynamiqs/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamiqs/dynamiqs/actions/workflows/ci.yml?query=branch%3Amain)  ![python version](https://img.shields.io/badge/python-3.9%2B-blue) [![chat](https://badgen.net/badge/icon/on%20slack?icon=slack&label=chat&color=orange)](https://join.slack.com/t/dynamiqs-org/shared_invite/zt-1z4mw08mo-qDLoNx19JBRtKzXlmlFYLA) [![license: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-yellow)](https://github.com/dynamiqs/dynamiqs/blob/main/LICENSE) [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 High-performance quantum systems simulation with PyTorch.
 

--- a/docs/getting_started/contributing.md
+++ b/docs/getting_started/contributing.md
@@ -4,7 +4,7 @@ We warmly welcome all contributions to the library from anyone who, like us, bel
 
 ## Requirements
 
-The project was written using Python 3.8+, you must have a compatible version of Python (i.e. >= 3.8) installed on your computer.
+The project was written using Python 3.9+, you must have a compatible version of Python (i.e. >= 3.9) installed on your computer.
 
 ## Setup
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "dynamiqs"
 version = "0.1.0"
+requires-python = ">=3.9"
 description = "Quantum systems simulation with PyTorch."
 dependencies = [
     "qutip",


### PR DESCRIPTION
This is required by new diffrax versions.