### PR TITLE
Batch mesolve

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Any
 
-import jax
-import numpy as np
 from jax import numpy as jnp
 from jaxtyping import Array
 
@@ -43,27 +41,3 @@ def bexpect(O: Array, x: Array) -> Array:
     if isket(x):
         return jnp.einsum('ij,bjk,kl->b', dag(x), O, x)  # <x|O|x>
     return jnp.einsum('bij,ji->b', O, x)  # tr(Ox)
-
-
-def compute_vmap(
-    f: callable,
-    cartesian_batching: bool,
-    is_batched: list[bool],
-    out_axes: list[int | None],
-) -> callable:
-    if any(is_batched):
-        if cartesian_batching:
-            # iteratively map over the first axis of each batched argument
-            idx_batched = np.where(is_batched)[0]
-            # we apply the successive vmaps in reverse order, so that the output
-            # batched dimensions are in the correct order
-            for i in reversed(idx_batched):
-                in_axes = [None] * len(is_batched)
-                in_axes[i] = 0
-                f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
-        else:
-            # map over the first axis of all batched arguments
-            in_axes = list(np.where(is_batched, 0, None))
-            f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
-
-    return f

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -55,8 +55,8 @@ def compute_vmap(
         if cartesian_batching:
             # iteratively map over the first axis of each batched argument
             idx_batched = np.where(is_batched)[0]
-             # we apply the succesive vmaps in reverse order, so that the output
-             # batched dimensions are in the correct order
+            # we apply the successive vmaps in reverse order, so that the output
+            # batched dimensions are in the correct order
             for i in reversed(idx_batched):
                 in_axes = [None] * len(is_batched)
                 in_axes[i] = 0

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 import jax
+import numpy as np
 from jax import numpy as jnp
 from jaxtyping import Array
 
@@ -44,25 +45,21 @@ def bexpect(O: Array, x: Array) -> Array:
     return jnp.einsum('bij,ji->b', O, x)  # tr(Ox)
 
 
-def compute_batching(f, cartesian_batching, other_in_axes, out_axes, *should_batch):
-    # Build a list of batch mask (ie binary numbers). Each digit is 1 if we
-    # should batch over the dimension and 0 otherwise.
-    # For example if `should_batch` = (True, False, True), the batch_mask will be
-    # [001, 100]
-    batch_mask = [2**k * v for k, v in enumerate(should_batch)]
-
-    # When doing cartesian batching, we need to batch over all dimensions
-    # one by one, but when cartesian batching is off, we want to batch over
-    # every dimension at once, hence the sum.
-    # For example if `should_batch` = (True, False, True), the batch_mask will be
-    # [001, 100] if we want to do cartesian batching and [101] otherwise.
-    if not cartesian_batching:
-        batch_mask = [sum(batch_mask)]
-
-    for mask in reversed(batch_mask):
-        if mask == 0:  # skip the no batching case
-            continue
-        mask = tuple([0 if mask & (1 << i) else None for i in range(len(should_batch))])
-        f = jax.vmap(f, in_axes=mask + other_in_axes, out_axes=out_axes)
+def compute_vmap(
+    f: callable,
+    cartesian_batching: bool,
+    is_batched: list[bool],
+    out_axes: list[int | None],
+) -> callable:
+    if any(is_batched):
+        if cartesian_batching:
+            idx_batched = np.where(is_batched)[0]
+            for i in reversed(idx_batched):
+                in_axes = [None] * len(is_batched)
+                in_axes[i] = 0
+                f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
+        else:
+            in_axes = list(np.where(is_batched, 0, None))
+            f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
 
     return f

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -6,6 +6,7 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
+from dynamiqs import compute_batching
 from ..core._utils import _astimearray, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
@@ -19,11 +20,43 @@ from .mediffrax import MEDopri5, MEEuler
 @partial(jax.jit, static_argnames=('solver', 'gradient', 'options'))
 def mesolve(
     H: ArrayLike | TimeArray,
-    jump_ops: list[ArrayLike | TimeArray],
+    jump_ops: ArrayLike | list[ArrayLike | TimeArray],
     psi0: ArrayLike,
     tsave: ArrayLike,
     *,
-    exp_ops: list[ArrayLike] | None = None,
+    exp_ops: ArrayLike | None = None,
+    solver: Solver = Dopri5(),
+    gradient: Gradient | None = None,
+    options: Options = Options(),
+):
+    # === vectorize function
+
+    # we vectorize over H, jump_ops and psi0, all other arguments are not vectorized
+    args = (None, None, None, None, None)
+    # the result is vectorized over ysave and Esave
+    out_axes = Result(None, None, None, None, 0, 0)
+
+    f = compute_batching(
+        _mesolve,
+        options.cartesian_batching,
+        args,
+        out_axes,
+        H.ndim > 2,
+        jump_ops.ndim > 3,
+        psi0.ndim > 2,
+    )
+
+    # === apply vectorized function
+    return f(H, jump_ops, psi0, tsave, exp_ops, solver, gradient, options)
+
+
+@partial(jax.jit, static_argnames=('solver', 'gradient', 'options'))
+def _mesolve(
+    H: ArrayLike | TimeArray,
+    jump_ops: ArrayLike | list[ArrayLike | TimeArray],
+    psi0: ArrayLike,
+    tsave: ArrayLike,
+    exp_ops: ArrayLike | None = None,
     solver: Solver = Dopri5(),
     gradient: Gradient | None = None,
     options: Options = Options(),

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -6,7 +6,7 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
-from dynamiqs import compute_vmap
+from .._utils import compute_vmap
 from ..core._utils import _astimearray, get_solver_class
 from ..gradient import Gradient
 from ..options import Options

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -30,9 +30,10 @@ def mesolve(
 ):
     # === vectorize function
     # we vectorize over H, jump_ops and psi0, all other arguments are not vectorized
+    jump_ops_ndim = _astimearray(jump_ops[0], dtype=options.cdtype).ndim + 1
     is_batched = (
         H.ndim > 2,
-        jump_ops.ndim > 3,
+        jump_ops_ndim > 3,  # todo: this is a temporary fix
         psi0.ndim > 2,
         False,
         False,

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -6,8 +6,7 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
-from .._utils import compute_vmap
-from ..core._utils import _astimearray, get_solver_class
+from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
 from ..result import Result

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -6,7 +6,7 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
-from dynamiqs import compute_vmap
+from .._utils import compute_vmap
 from ..core._utils import _astimearray, get_solver_class
 from ..gradient import Gradient
 from ..options import Options

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -6,8 +6,7 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
-from .._utils import compute_vmap
-from ..core._utils import _astimearray, get_solver_class
+from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
 from ..result import Result

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -6,7 +6,7 @@ import jax
 from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
-from dynamiqs import compute_batching
+from dynamiqs import compute_vmap
 from ..core._utils import _astimearray, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
@@ -28,14 +28,11 @@ def sesolve(
     options: Options = Options(),
 ):
     # === vectorize function
-
     # we vectorize over H and psi0, all other arguments are not vectorized
-    args = (None, None, None, None, None)
+    is_batched = (H.ndim > 2, psi0.ndim > 2, False, False, False, False, False)
     # the result is vectorized over ysave and Esave
     out_axes = Result(None, None, None, None, 0, 0)
-    f = compute_batching(
-        _sesolve, options.cartesian_batching, args, out_axes, H.ndim > 2, psi0.ndim > 2
-    )
+    f = compute_vmap(_sesolve, options.cartesian_batching, is_batched, out_axes)
 
     # === apply vectorized function
     return f(H, psi0, tsave, exp_ops, solver, gradient, options)

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -19,7 +19,7 @@ def test_batching(cartesian_batching):
     # create random objects
     k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(42), 4)
     H = dq.rand.herm(k1, (nH, n, n))
-    Ls = dq.rand.herm(k2, (nLs, 1, n, n))
+    Ls = dq.rand.herm(k2, (nLs, 2, n, n))
     exp_ops = dq.rand.complex(k3, (nEs, n, n))
     psi0 = dq.rand.ket(k4, (npsi0, n, 1))
     tsave = jnp.linspace(0, 0.01, nt)
@@ -34,7 +34,7 @@ def test_batching(cartesian_batching):
     assert result.ysave.shape == (nH, nt, n, n)
     assert result.Esave.shape == (nH, nEs, nt)
 
-    # jump ops batched
+    # Ls batched
     result = dq.mesolve(H[0], Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
     assert result.ysave.shape == (nLs, nt, n, n)
     assert result.Esave.shape == (nLs, nEs, nt)

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -1,0 +1,72 @@
+import jax
+import pytest
+from jax import numpy as jnp
+
+import dynamiqs as dq
+
+
+@pytest.mark.parametrize('cartesian_batching', [True, False])
+def test_batching(cartesian_batching):
+    n = 8
+    nt = 11
+    nH = 3
+    nLs = 4 if cartesian_batching else nH
+    npsi0 = 5 if cartesian_batching else nH
+    nEs = 6
+
+    options = dq.options.Options(cartesian_batching=cartesian_batching)
+
+    # create random objects
+    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(42), 4)
+    H = dq.rand.herm(k1, (nH, n, n))
+    Ls = dq.rand.herm(k2, (nLs, 1, n, n))
+    exp_ops = dq.rand.complex(k3, (nEs, n, n))
+    psi0 = dq.rand.ket(k4, (npsi0, n, 1))
+    tsave = jnp.linspace(0, 0.01, nt)
+
+    # no batching
+    result = dq.mesolve(H[0], Ls[0], psi0[0], tsave, exp_ops=exp_ops, options=options)
+    assert result.ysave.shape == (nt, n, n)
+    assert result.Esave.shape == (nEs, nt)
+
+    # H batched
+    result = dq.mesolve(H, Ls[0], psi0[0], tsave, exp_ops=exp_ops, options=options)
+    assert result.ysave.shape == (nH, nt, n, n)
+    assert result.Esave.shape == (nH, nEs, nt)
+
+    # jump ops batched
+    result = dq.mesolve(H[0], Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
+    assert result.ysave.shape == (nLs, nt, n, n)
+    assert result.Esave.shape == (nLs, nEs, nt)
+
+    # psi0 batched
+    result = dq.mesolve(H[0], Ls[0], psi0, tsave, exp_ops=exp_ops, options=options)
+    assert result.ysave.shape == (npsi0, nt, n, n)
+    assert result.Esave.shape == (npsi0, nEs, nt)
+
+    # H and Ls batched
+    result = dq.mesolve(H, Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
+    if cartesian_batching:
+        assert result.ysave.shape == (nH, nLs, nt, n, n)
+        assert result.Esave.shape == (nH, nLs, nEs, nt)
+    else:
+        assert result.ysave.shape == (nH, nt, n, n)
+        assert result.Esave.shape == (nH, nEs, nt)
+
+    # H and psi0 batched
+    result = dq.mesolve(H, Ls[0], psi0, tsave, exp_ops=exp_ops, options=options)
+    if cartesian_batching:
+        assert result.ysave.shape == (nH, npsi0, nt, n, n)
+        assert result.Esave.shape == (nH, npsi0, nEs, nt)
+    else:
+        assert result.ysave.shape == (nH, nt, n, n)
+        assert result.Esave.shape == (nH, nEs, nt)
+
+    # H, Ls and psi0 batched
+    result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=exp_ops, options=options)
+    if cartesian_batching:
+        assert result.ysave.shape == (nH, nLs, npsi0, nt, n, n)
+        assert result.Esave.shape == (nH, nLs, npsi0, nEs, nt)
+    else:
+        assert result.ysave.shape == (nH, nt, n, n)
+        assert result.Esave.shape == (nH, nEs, nt)

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -16,10 +16,10 @@ def test_batching(cartesian_batching):
     options = dq.options.Options(cartesian_batching=cartesian_batching)
 
     # create random objects
-    key = jax.random.PRNGKey(42)
-    H = dq.rand.herm(key, (nH, n, n))
-    exp_ops = dq.rand.complex(key, (nEs, n, n))
-    psi0 = dq.rand.ket(key, (npsi0, n, 1))
+    k1, k2, k3 = jax.random.split(jax.random.PRNGKey(42), 3)
+    H = dq.rand.herm(k1, (nH, n, n))
+    exp_ops = dq.rand.complex(k2, (nEs, n, n))
+    psi0 = dq.rand.ket(k3, (npsi0, n, 1))
     tsave = jnp.linspace(0, 0.01, nt)
 
     # no batching


### PR DESCRIPTION
Re-edition of https://github.com/dynamiqs/dynamiqs/pull/437 that died because of an infortunate force-push 

# Original comment : 
Here I use the convention that the dissipators batching dimension is always outwards because it makes the reasoning much simpler for this code, but if there is a good reason to adopt another one, we can switch.

# @gautierronan comment

Nice! I like the overall idea of the PR, but I'd suggest the changes below (or similar) to remedy two issues that I find in the current form:
- it's lacking readability (mesolve is the first function people will look at when reading source code: it should be very easy to follow IMO),
- compute_batching does not support batching over arguments that are not within the first function arguments (useful for smesolve).


## Answer 

I understand your concern but 
- the code proposal does not work as is since we need a for loop to vmap properly. If we chose to split the code according to your comment the loop would be in the mesolve code. The complexity does not disappear, it is moved outside of compute_batching
-  I am not sure how to make very easy to read of piece of code with 16 possible cases (32 for smesolve) without explicitly code them all or do tedious list/dict based case handling
- one does not need to understand the batching mechanism during the first read. The goal of compute_batching is to abstract this mechanism away. This way of splitting concerns allows for understanding mesolve aside for batching and come back later if this is the part of interest
- regarding smesolve this is a problem we can address later and probably the ntraj dimension (if this is what you are thinking about), could be in the first arguments of _smesolve which solves the problem
