### PR TITLE
Fix time-dependent tests

### DIFF
--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -84,7 +84,7 @@ def _factory_callable(
     # This is necessary:
     # (1) to make f a Pytree, and
     # (2) to avoid jitting again every time the args change.
-    f_partial = Partial(lambda *inv_args: f(inv_args[-1], *inv_args[:-1]), *args)
+    f_partial = Partial(lambda t: f(t, *args))
     return CallableTimeArray(f_partial, f0)
 
 

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -84,7 +84,7 @@ def _factory_callable(
     # This is necessary:
     # (1) to make f a Pytree, and
     # (2) to avoid jitting again every time the args change.
-    f_partial = Partial(f, *args)
+    f_partial = Partial(lambda *inv_args: f(inv_args[-1], *inv_args[:-1]), *args)
     return CallableTimeArray(f_partial, f0)
 
 

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -165,6 +165,9 @@ class OTDQubit(OpenSystem):
         exp_z = eta * jnp.cos(2 * theta)
         return jnp.array([exp_x, exp_y, exp_z]).real
 
+    def loss_state(self, state: Array) -> Array:
+        return dq.expect(dq.sigmaz(), state).real
+
     def grads_state(self, t: float) -> PyTree:
         theta = self._theta(t)
         eta = self._eta(t)

--- a/tests/mesolve/test_dopri5.py
+++ b/tests/mesolve/test_dopri5.py
@@ -4,16 +4,14 @@ from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Dopri5
 
 from ..solver_tester import SolverTester
-from .open_system import ocavity
+from .open_system import ocavity, otdqubit
 
 
 class TestMEDopri5(SolverTester):
-    # @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    @pytest.mark.parametrize('system', [ocavity])
+    @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_correctness(self, system):
         self._test_correctness(system, Dopri5())
 
-    # @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    @pytest.mark.parametrize('system', [ocavity])
+    @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_autograd(self, system):
         self._test_gradient(system, Dopri5(), Autograd())

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -4,18 +4,16 @@ from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
-from .open_system import ocavity
+from .open_system import ocavity, otdqubit
 
 
 class TestMEEuler(SolverTester):
-    # @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    @pytest.mark.parametrize('system', [ocavity])
+    @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_correctness(self, system):
         solver = Euler(dt=1e-4)
         self._test_correctness(system, solver, esave_atol=1e-3)
 
-    # @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    @pytest.mark.parametrize('system', [ocavity])
+    @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_autograd(self, system):
         solver = Euler(dt=1e-4)
         self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -130,6 +130,9 @@ class TDQubit(ClosedSystem):
         exp_z = jnp.cos(2 * theta)
         return jnp.array([exp_x, exp_y, exp_z]).real
 
+    def loss_state(self, state: Array) -> Array:
+        return dq.expect(dq.sigmaz(), state).real
+
     def grads_state(self, t: float) -> PyTree:
         theta = self._theta(t)
         # gradients of theta

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -106,7 +106,7 @@ class TDQubit(ClosedSystem):
         # define default gradient parameters
         self.params_default = self.Params(eps, omega)
 
-    def H(self, params: PyTree) -> ArrayLike | TimeArray:
+    def H(self, params: PyTree) -> TimeArray:
         f = lambda t, eps, omega: eps * jnp.cos(omega * t) * dq.sigmax()
         return dq.totime(f, args=(params.eps, params.omega))
 

--- a/tests/sesolve/test_dopri5.py
+++ b/tests/sesolve/test_dopri5.py
@@ -4,16 +4,14 @@ from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Dopri5
 
 from ..solver_tester import SolverTester
-from .closed_system import cavity
+from .closed_system import cavity, tdqubit
 
 
 class TestSEDopri5(SolverTester):
-    # @pytest.mark.parametrize('system', [cavity, tdqubit])
-    @pytest.mark.parametrize('system', [cavity])
+    @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_correctness(self, system):
         self._test_correctness(system, Dopri5())
 
-    # @pytest.mark.parametrize('system', [cavity, tdqubit])
-    @pytest.mark.parametrize('system', [cavity])
+    @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_autograd(self, system):
         self._test_gradient(system, Dopri5(), Autograd())

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -4,18 +4,16 @@ from dynamiqs.gradient import Autograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
-from .closed_system import cavity
+from .closed_system import cavity, tdqubit
 
 
 class TestSEEuler(SolverTester):
-    # @pytest.mark.parametrize('system', [cavity, tdqubit])
-    @pytest.mark.parametrize('system', [cavity])
+    @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_correctness(self, system):
         solver = Euler(dt=1e-4)
         self._test_correctness(system, solver, esave_atol=1e-3)
 
-    # @pytest.mark.parametrize('system', [cavity, tdqubit])
-    @pytest.mark.parametrize('system', [cavity])
+    @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_autograd(self, system):
         solver = Euler(dt=1e-4)
         self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -30,7 +30,8 @@ class SolverTester(ABC):
         # === test ysave
         true_ysave = system.states(system.tsave)
         errs = jnp.linalg.norm(true_ysave - result.ysave, axis=(-2, -1))
-        logging.warning(f'errs = {errs}')
+        logging.warning(f'true_ysave = {true_ysave}')
+        logging.warning(f'ysave      = {result.ysave}')
         assert jnp.all(errs <= ysave_atol)
 
         # === test Esave


### PR DESCRIPTION
Check that workaround does not re-jit again when args change.
```python
import jax
import jax.numpy as jnp
from jax.tree_util import Partial
import time

def global_fun(y, z):
    def my_fun(x, y, z):
        return x * (y + z) * jnp.ones(3)

    # Partially apply my_fun to bind the first argument
    fun = Partial(lambda x: my_fun(x, *args))

    return fun(3.0)

# == jit the global function
global_fun_jit = jax.jit(global_fun)

# == first set of arguments
args = (2.0, 3.0)

start_time = time.time()
global_fun_jit(*args).block_until_ready()
print(f"{(time.time() - start_time)*1e6:.3f} us") 
# 13761.997 us

start_time = time.time()
global_fun_jit(*args).block_until_ready()
print(f"{(time.time() - start_time)*1e6:.3f} us")
# 227.690 us

# == second set of arguments
args = (4.0, 5.0)

start_time = time.time()
global_fun_jit(*args).block_until_ready()
print(f"{(time.time() - start_time)*1e6:.3f} us")
# 43.154 us

start_time = time.time()
global_fun_jit(*args).block_until_ready()
print(f"{(time.time() - start_time)*1e6:.3f} us")
# 37.909 us
```