### PR TITLE
Add adjoint tests

### DIFF
--- a/tests/mesolve/test_dopri5.py
+++ b/tests/mesolve/test_dopri5.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Adjoint, Autograd
 from dynamiqs.solver import Dopri5
 
 from ..solver_tester import SolverTester
@@ -13,5 +13,6 @@ class TestMEDopri5(SolverTester):
         self._test_correctness(system, Dopri5())
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Dopri5(), Autograd())
+    @pytest.mark.parametrize('gradient', [Autograd(), Adjoint()])
+    def test_gradient(self, system, gradient):
+        self._test_gradient(system, Dopri5(), gradient)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -10,10 +10,8 @@ from .open_system import ocavity, otdqubit
 class TestMEEuler(SolverTester):
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_correctness(self, system):
-        solver = Euler(dt=1e-4)
-        self._test_correctness(system, solver, esave_atol=1e-3)
+        self._test_correctness(system, Euler(dt=1e-4), esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_autograd(self, system):
-        solver = Euler(dt=1e-4)
-        self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)
+        self._test_gradient(system, Euler(dt=1e-4), Autograd(), rtol=1e-2, atol=1e-2)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Adjoint, Autograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
@@ -13,5 +13,6 @@ class TestMEEuler(SolverTester):
         self._test_correctness(system, Euler(dt=1e-4), esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Euler(dt=1e-4), Autograd(), rtol=1e-2, atol=1e-2)
+    @pytest.mark.parametrize('gradient', [Autograd(), Adjoint()])
+    def test_gradient(self, system, gradient):
+        self._test_gradient(system, Euler(dt=1e-4), gradient, rtol=1e-2, atol=1e-2)

--- a/tests/sesolve/test_dopri5.py
+++ b/tests/sesolve/test_dopri5.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Adjoint, Autograd
 from dynamiqs.solver import Dopri5
 
 from ..solver_tester import SolverTester
@@ -13,5 +13,6 @@ class TestSEDopri5(SolverTester):
         self._test_correctness(system, Dopri5())
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Dopri5(), Autograd())
+    @pytest.mark.parametrize('gradient', [Autograd(), Adjoint()])
+    def test_gradient(self, system, gradient):
+        self._test_gradient(system, Dopri5(), gradient)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -10,10 +10,8 @@ from .closed_system import cavity, tdqubit
 class TestSEEuler(SolverTester):
     @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_correctness(self, system):
-        solver = Euler(dt=1e-4)
-        self._test_correctness(system, solver, esave_atol=1e-3)
+        self._test_correctness(system, Euler(dt=1e-4), esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_autograd(self, system):
-        solver = Euler(dt=1e-4)
-        self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)
+        self._test_gradient(system, Euler(dt=1e-4), Autograd(), rtol=1e-2, atol=1e-2)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Adjoint, Autograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
@@ -13,5 +13,6 @@ class TestSEEuler(SolverTester):
         self._test_correctness(system, Euler(dt=1e-4), esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Euler(dt=1e-4), Autograd(), rtol=1e-2, atol=1e-2)
+    @pytest.mark.parametrize('gradient', [Autograd(), Adjoint()])
+    def test_gradient(self, system, gradient):
+        self._test_gradient(system, Euler(dt=1e-4), gradient, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
The adjoint is broken for now:
```
NotImplementedError: Cannot use `adjoint=BacksolveAdjoint()` with `saveat=SaveAt(fn=...)`.
```