### PR TITLE
Remove `dtype` argument

### DIFF
--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -4,7 +4,6 @@ from typing import get_args
 
 import jax
 import numpy as np
-from jax import numpy as jnp
 from jaxtyping import ArrayLike
 
 from ..solver import Solver
@@ -12,11 +11,9 @@ from ..time_array import TimeArray, _factory_constant
 from .abstract_solver import AbstractSolver
 
 
-def _astimearray(
-    x: ArrayLike | TimeArray, dtype: jnp.complex64 | jnp.complex128
-) -> TimeArray:
+def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
     if isinstance(x, get_args(ArrayLike)):
-        return _factory_constant(x, dtype=dtype)
+        return _factory_constant(x)
     elif isinstance(x, TimeArray):
         return x
     else:

--- a/dynamiqs/dark/dark.py
+++ b/dynamiqs/dark/dark.py
@@ -9,9 +9,7 @@ from ..utils.utils import dag
 __all__ = ['quadrature_sign']
 
 
-def quadrature_sign(
-    dim: int, phi: float, *, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array:
+def quadrature_sign(dim: int, phi: float) -> Array:
     r"""Returns the quadrature sign operator of phase angle $\phi$.
 
     It is defined by $s_\phi = \mathrm{sign}(e^{i\phi} a^\dag + e^{-i\phi} a)$, where
@@ -20,12 +18,11 @@ def quadrature_sign(
     Args:
         dim: Dimension of the Hilbert space.
         phi: Phase angle.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (dim, dim))_ Quadrature sign operator.
     """
-    quad = quadrature(dim, phi, dtype=dtype)
+    quad = quadrature(dim, phi)
     L, Q = jnp.linalg.eigh(quad)
     sign_L = jnp.diag(jnp.sign(L))
     return Q @ sign_L @ dag(Q)

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -12,6 +12,7 @@ from ..options import Options
 from ..result import Result
 from ..solver import Dopri5, Euler, Solver
 from ..time_array import TimeArray
+from ..utils.array_types import cdtype
 from ..utils.utils import todm
 from .mediffrax import MEDopri5, MEEuler
 
@@ -30,7 +31,7 @@ def mesolve(
 ):
     # === vectorize function
     # we vectorize over H, jump_ops and psi0, all other arguments are not vectorized
-    jump_ops_ndim = _astimearray(jump_ops[0], dtype=options.cdtype).ndim + 1
+    jump_ops_ndim = _astimearray(jump_ops[0]).ndim + 1
     is_batched = (
         H.ndim > 2,
         jump_ops_ndim > 3,  # todo: this is a temporary fix
@@ -61,12 +62,12 @@ def _mesolve(
     options: Options = Options(),
 ) -> Result:
     # === convert arguments
-    H = _astimearray(H, dtype=options.cdtype)
-    Ls = [_astimearray(L, dtype=options.cdtype) for L in jump_ops]
-    y0 = jnp.asarray(psi0, dtype=options.cdtype)
+    H = _astimearray(H)
+    Ls = [_astimearray(L) for L in jump_ops]
+    y0 = jnp.asarray(psi0, dtype=cdtype())
     y0 = todm(y0)
-    ts = jnp.asarray(tsave, dtype=options.rdtype)
-    Es = jnp.asarray(exp_ops, dtype=options.cdtype) if exp_ops is not None else None
+    ts = jnp.asarray(tsave)
+    Es = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
 
     # === select solver class
     solvers = {Euler: MEEuler, Dopri5: MEDopri5}

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -1,15 +1,11 @@
 from __future__ import annotations
 
 import equinox as eqx
-import jax.numpy as jnp
-
-from .utils.array_types import get_cdtype
 
 
 class Options(eqx.Module):
     save_states: bool
     verbose: bool
-    _double_precision: bool
     cartesian_batching: bool
 
     def __init__(
@@ -17,25 +13,11 @@ class Options(eqx.Module):
         *,
         save_states: bool = True,
         verbose: bool = True,
-        dtype: jnp.complex64 | jnp.complex128 | None = None,
         cartesian_batching: bool = True,
     ):
         # save_states (bool, optional): If `True`, the state is saved at every
         #     time value. If `False`, only the final state is stored and returned.
         #     Defaults to `True`.
-        # dtype (jax.numpy.dtype, optional): Complex data type to which all
-        #     complex-valued arrays are converted. `tsave` is also converted to a real
-        #     data type of the corresponding precision.
         self.save_states = save_states
         self.verbose = verbose
-        cdtype = get_cdtype(dtype)
-        self._double_precision = cdtype == jnp.complex128
         self.cartesian_batching = cartesian_batching
-
-    @property
-    def rdtype(self) -> jnp.float32 | jnp.float64:
-        return jnp.float64 if self._double_precision else jnp.float32
-
-    @property
-    def cdtype(self) -> jnp.complex64 | jnp.complex128:
-        return jnp.complex128 if self._double_precision else jnp.complex64

--- a/dynamiqs/rand.py
+++ b/dynamiqs/rand.py
@@ -2,69 +2,39 @@ from __future__ import annotations
 
 import jax
 from jax import Array
-from jax import numpy as jnp
 from jaxtyping import PRNGKeyArray
 
-from .utils.array_types import dtype_complex_to_real, get_cdtype
 from .utils.utils import dag, unit
 
 
-def complex(
-    key: PRNGKeyArray,
-    shape: tuple[int, ...],
-    *,
-    dtype: jnp.complex64 | jnp.complex128 | None = None,
-) -> Array:
-    rdtype = dtype_complex_to_real(get_cdtype(dtype))
-
+def complex(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
     key1, key2 = jax.random.split(key, 2)
-    x = jax.random.normal(key1, shape, dtype=rdtype)
-    y = jax.random.normal(key2, shape, dtype=rdtype)
-
+    x = jax.random.normal(key1, shape)
+    y = jax.random.normal(key2, shape)
     return x + 1j * y
 
 
-def herm(
-    key: PRNGKeyArray,
-    shape: tuple[int, ...],
-    *,
-    dtype: jnp.complex64 | jnp.complex128 | None = None,
-) -> Array:
+def herm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
     # hermitian
     assert len(shape) >= 2 and shape[-1] == shape[-2]
-    x = complex(key, shape, dtype=dtype)
+    x = complex(key, shape)
     return 0.5 * (x + dag(x))
 
 
-def psd(
-    key: PRNGKeyArray,
-    shape: tuple[int, ...],
-    *,
-    dtype: jnp.complex64 | jnp.complex128 | None = None,
-) -> Array:
+def psd(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
     # positive semi-definite
     assert len(shape) >= 2 and shape[-1] == shape[-2]
-    x = complex(key, shape, dtype=dtype)
+    x = complex(key, shape)
     return x @ dag(x)
 
 
-def dm(
-    key: PRNGKeyArray,
-    shape: tuple[int, ...],
-    *,
-    dtype: jnp.complex64 | jnp.complex128 | None = None,
-) -> Array:
+def dm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
     assert len(shape) >= 2 and shape[-1] == shape[-2]
-    x = psd(key, shape, dtype=dtype)
+    x = psd(key, shape)
     return unit(x)
 
 
-def ket(
-    key: PRNGKeyArray,
-    shape: tuple[int, ...],
-    *,
-    dtype: jnp.complex64 | jnp.complex128 | None = None,
-) -> Array:
+def ket(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
     assert len(shape) >= 2 and shape[-1] == 1
-    x = complex(key, shape, dtype=dtype)
+    x = complex(key, shape)
     return unit(x)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -12,6 +12,7 @@ from ..options import Options
 from ..result import Result
 from ..solver import Dopri5, Euler, Solver
 from ..time_array import TimeArray
+from ..utils.array_types import cdtype
 from .sediffrax import SEDopri5, SEEuler
 
 
@@ -47,10 +48,10 @@ def _sesolve(
     options: Options = Options(),
 ) -> Result:
     # === convert arguments
-    H = _astimearray(H, dtype=options.cdtype)
-    y0 = jnp.asarray(psi0, dtype=options.cdtype)
-    ts = jnp.asarray(tsave, dtype=options.rdtype)
-    Es = jnp.asarray(exp_ops, dtype=options.cdtype) if exp_ops is not None else None
+    H = _astimearray(H)
+    y0 = jnp.asarray(psi0, dtype=cdtype())
+    ts = jnp.asarray(tsave)
+    Es = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
 
     # === select solver class
     solvers = {Euler: SEEuler, Dopri5: SEDopri5}

--- a/dynamiqs/utils/array_types.py
+++ b/dynamiqs/utils/array_types.py
@@ -15,52 +15,11 @@ def _get_default_dtype() -> jnp.float32 | jnp.float64:
     return jnp.float64 if default_dtype == jnp.float64 else jnp.float32
 
 
-def get_cdtype(
-    dtype: jnp.complex64 | jnp.complex128 | None = None,
-) -> jnp.complex64 | jnp.complex128:
-    if dtype is None:
-        # the default dtype for complex arrays is determined by the default
-        # floating point dtype (jnp.complex128 if default is jnp.float64,
-        # otherwise jnp.complex64)
-        default_dtype = _get_default_dtype()
-        return jnp.complex128 if default_dtype is jnp.float64 else jnp.complex64
-    elif dtype not in (jnp.complex64, jnp.complex128):
-        raise TypeError(
-            'Argument `dtype` must be `jnp.complex64`, `jnp.complex128` or `None`'
-            f' for a complex-valued array, but is `{dtype}`.'
-        )
-    return dtype
-
-
-def get_rdtype(
-    dtype: jnp.float32 | jnp.float64 | None = None,
-) -> jnp.float32 | jnp.float64:
-    if dtype is None:
-        return _get_default_dtype()
-    elif dtype not in (jnp.float32, jnp.float64):
-        raise TypeError(
-            'Argument `dtype` must be `jnp.float32`, `jnp.float64` or `None` for'
-            f' a real-valued array, but is `{dtype}`.'
-        )
-    return dtype
-
-
-def dtype_complex_to_real(
-    dtype: jnp.complex64 | jnp.complex128,
-) -> jnp.float32 | jnp.float64:
-    if dtype == jnp.complex64:
-        return jnp.float32
-    elif dtype == jnp.complex128:
-        return jnp.float64
-
-
-def dtype_real_to_complex(
-    dtype: jnp.float32 | jnp.float64,
-) -> jnp.complex64 | jnp.complex128:
-    if dtype == jnp.float32:
-        return jnp.complex64
-    elif dtype == jnp.float64:
-        return jnp.complex128
+def cdtype() -> jnp.complex64 | jnp.complex128:
+    # the default dtype for complex arrays is determined by the default floating point
+    # dtype (jnp.complex128 if default is jnp.float64, otherwise jnp.complex64)
+    default_dtype = _get_default_dtype()
+    return jnp.complex128 if default_dtype is jnp.float64 else jnp.complex64
 
 
 def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:

--- a/dynamiqs/utils/array_types.py
+++ b/dynamiqs/utils/array_types.py
@@ -17,9 +17,14 @@ def _get_default_dtype() -> jnp.float32 | jnp.float64:
 
 def cdtype() -> jnp.complex64 | jnp.complex128:
     # the default dtype for complex arrays is determined by the default floating point
-    # dtype (jnp.complex128 if default is jnp.float64, otherwise jnp.complex64)
-    default_dtype = _get_default_dtype()
-    return jnp.complex128 if default_dtype is jnp.float64 else jnp.complex64
+    # dtype
+    dtype = _get_default_dtype()
+    if dtype is jnp.float32:
+        return jnp.complex64
+    elif dtype is jnp.float64:
+        return jnp.complex128
+    else:
+        raise ValueError(f'Data type `{dtype.dtype}` is not yet supported.')
 
 
 def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
 
-from .array_types import get_cdtype
+from .array_types import cdtype
 from .utils import dag, tensor
 
 __all__ = [
@@ -31,7 +31,7 @@ __all__ = [
 ]
 
 
-def eye(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def eye(*dims: int) -> Array:
     r"""Returns the identity operator.
 
     If only a single dimension is provided, `eye` returns the identity operator
@@ -41,7 +41,6 @@ def eye(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Arra
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (n, n))_ Identity operator (with _n_ the product of
@@ -61,12 +60,11 @@ def eye(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Arra
                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j, 0.+0.j],
                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 1.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
     dim = prod(dims)
-    return jnp.eye(dim, dtype=dtype)
+    return jnp.eye(dim, dtype=cdtype())
 
 
-def zero(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def zero(*dims: int) -> Array:
     r"""Returns the null operator.
 
     If only a single dimension is provided, `zero` returns the null operator
@@ -76,7 +74,6 @@ def zero(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Arr
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (n, n))_ Null operator (with _n_ the product of dimensions
@@ -96,14 +93,11 @@ def zero(*dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Arr
                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j],
                [0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
     dim = prod(dims)
-    return jnp.zeros((dim, dim), dtype=dtype)
+    return jnp.zeros((dim, dim), dtype=cdtype())
 
 
-def destroy(
-    *dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array | tuple[Array, ...]:
+def destroy(*dims: int) -> Array | tuple[Array, ...]:
     r"""Returns a bosonic annihilation operator, or a tuple of annihilation operators in
     a multi-mode system.
 
@@ -114,7 +108,6 @@ def destroy(
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned array(s).
 
     Returns:
         _(array or tuple of arrays)_ Annihilation operator of given dimension, or
@@ -142,27 +135,24 @@ def destroy(
                [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 1.414+0.j],
                [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j]],      dtype=complex64)
     """  # noqa: E501
-    dtype = get_cdtype(dtype)
 
     if len(dims) == 1:
-        return _destroy_single(dims[0], dtype=dtype)
+        return _destroy_single(dims[0])
 
-    a = [_destroy_single(dim, dtype=dtype) for dim in dims]
-    I = [eye(dim, dtype=dtype) for dim in dims]
+    a = [_destroy_single(dim) for dim in dims]
+    I = [eye(dim) for dim in dims]
     return tuple(
         tensor(*[a[j] if i == j else I[j] for j in range(len(dims))])
         for i in range(len(dims))
     )
 
 
-def _destroy_single(dim: int, *, dtype: jnp.complex64 | jnp.complex128) -> Array:
+def _destroy_single(dim: int) -> Array:
     """Bosonic annihilation operator."""
-    return jnp.diag(jnp.sqrt(jnp.arange(1, stop=dim, dtype=dtype)), k=1)
+    return jnp.diag(jnp.sqrt(jnp.arange(1, stop=dim, dtype=cdtype())), k=1)
 
 
-def create(
-    *dims: int, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array | tuple[Array, ...]:
+def create(*dims: int) -> Array | tuple[Array, ...]:
     r"""Returns a bosonic creation operator, or a tuple of creation operators in a
     multi-mode system.
 
@@ -173,7 +163,6 @@ def create(
 
     Args:
         *dims: Variable length argument list of the Hilbert space dimensions.
-        dtype: Complex data type of the returned array(s).
 
     Returns:
         _(array or tuple of arrays)_ Creation operator of given dimension, or tuple
@@ -201,25 +190,23 @@ def create(
                [0.   +0.j, 0.   +0.j, 0.   +0.j, 1.   +0.j, 0.   +0.j, 0.   +0.j],
                [0.   +0.j, 0.   +0.j, 0.   +0.j, 0.   +0.j, 1.414+0.j, 0.   +0.j]],      dtype=complex64)
     """  # noqa: E501
-    dtype = get_cdtype(dtype)
-
     if len(dims) == 1:
-        return _create_single(dims[0], dtype=dtype)
+        return _create_single(dims[0])
 
-    adag = [_create_single(dim, dtype=dtype) for dim in dims]
-    I = [eye(dim, dtype=dtype) for dim in dims]
+    adag = [_create_single(dim) for dim in dims]
+    I = [eye(dim) for dim in dims]
     return tuple(
         tensor(*[adag[j] if i == j else I[j] for j in range(len(dims))])
         for i in range(len(dims))
     )
 
 
-def _create_single(dim: int, *, dtype: jnp.complex64 | jnp.complex128) -> Array:
+def _create_single(dim: int) -> Array:
     """Bosonic creation operator."""
-    return jnp.diag(jnp.sqrt(jnp.arange(1, stop=dim, dtype=dtype)), k=-1)
+    return jnp.diag(jnp.sqrt(jnp.arange(1, stop=dim, dtype=cdtype())), k=-1)
 
 
-def number(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def number(dim: int | None = None) -> Array:
     r"""Returns the number operator of a bosonic mode.
 
     It is defined by $n = a^\dag a$, where $a$ and $a^\dag$ are the annihilation and
@@ -227,7 +214,6 @@ def number(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> 
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (dim, dim))_ Number operator.
@@ -239,11 +225,10 @@ def number(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> 
                [0.+0.j, 0.+0.j, 2.+0.j, 0.+0.j],
                [0.+0.j, 0.+0.j, 0.+0.j, 3.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    return jnp.diag(jnp.arange(0, stop=dim, dtype=dtype))
+    return jnp.diag(jnp.arange(0, stop=dim, dtype=cdtype()))
 
 
-def parity(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def parity(dim: int) -> Array:
     r"""Returns the parity operator of a bosonic mode.
 
     It is defined by $P = e^{i\pi a^\dag a}$, where $a$ and $a^\dag$ are the
@@ -251,7 +236,6 @@ def parity(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> 
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (dim, dim))_ Parity operator.
@@ -263,15 +247,12 @@ def parity(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> 
                [ 0.+0.j,  0.+0.j,  1.+0.j,  0.+0.j],
                [ 0.+0.j,  0.+0.j,  0.+0.j, -1.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    diag_values = jnp.ones(dim, dtype=dtype)
+    diag_values = jnp.ones(dim, dtype=cdtype())
     diag_values = diag_values.at[1::2].set(-1)
     return jnp.diag(diag_values)
 
 
-def displace(
-    dim: int, alpha: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array:
+def displace(dim: int, alpha: ArrayLike) -> Array:
     r"""Returns the displacement operator of complex amplitude $\alpha$.
 
     It is defined by
@@ -283,7 +264,6 @@ def displace(
     Args:
         dim: Dimension of the Hilbert space.
         alpha _(array_like of shape (...))_: Displacement amplitude.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (..., dim, dim))_ Displacement operator.
@@ -297,18 +277,14 @@ def displace(
         >>> dq.displace(4, [0.1, 0.2]).shape
         (2, 4, 4)
     """
-    dtype = get_cdtype(dtype)
-
-    alpha = jnp.asarray(alpha, dtype=dtype)
+    alpha = jnp.asarray(alpha, dtype=cdtype())
     alpha = alpha[..., None, None]  # (..., 1, 1)
 
-    a = destroy(dim, dtype=dtype)  # (n, n)
+    a = destroy(dim)  # (n, n)
     return jax.scipy.linalg.expm(alpha * dag(a) - alpha.conj() * a)
 
 
-def squeeze(
-    dim: int, z: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array:
+def squeeze(dim: int, z: ArrayLike) -> Array:
     r"""Returns the squeezing operator of complex squeezing amplitude $z$.
 
     It is defined by
@@ -320,7 +296,6 @@ def squeeze(
     Args:
         dim: Dimension of the Hilbert space.
         z _(array_like of shape (...))_: Squeezing amplitude.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (..., dim, dim))_ Squeezing operator.
@@ -334,19 +309,15 @@ def squeeze(
         >>> dq.squeeze(4, [0.1, 0.2]).shape
         (2, 4, 4)
     """
-    dtype = get_cdtype(dtype)
-
-    z = jnp.asarray(z, dtype=dtype)
+    z = jnp.asarray(z, dtype=cdtype())
     z = z[..., None, None]  # (..., 1, 1)
 
-    a = destroy(dim, dtype=dtype)  # (n, n)
+    a = destroy(dim)  # (n, n)
     a2 = a @ a
     return jax.scipy.linalg.expm(0.5 * (z.conj() * a2 - z * dag(a2)))
 
 
-def quadrature(
-    dim: int, phi: float, *, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array:
+def quadrature(dim: int, phi: float) -> Array:
     r"""Returns the quadrature operator of phase angle $\phi$.
 
     It is defined by $x_\phi = (e^{i\phi} a^\dag + e^{-i\phi} a) / 2$, where $a$ and
@@ -355,7 +326,6 @@ def quadrature(
     Args:
         dim: Dimension of the Hilbert space.
         phi: Phase angle.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (dim, dim))_ Quadrature operator.
@@ -370,17 +340,15 @@ def quadrature(
                [-0.+0.5j  ,  0.+0.j   , -0.-0.707j],
                [ 0.+0.j   , -0.+0.707j,  0.+0.j   ]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    a = destroy(dim, dtype=dtype)
+    a = destroy(dim)
     return 0.5 * (jnp.exp(1.0j * phi) * dag(a) + jnp.exp(-1.0j * phi) * a)
 
 
-def position(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def position(dim: int) -> Array:
     r"""Returns the position operator $x = (a^\dag + a) / 2$.
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (dim, dim))_ Position operator.
@@ -391,17 +359,15 @@ def position(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -
                [0.5  +0.j, 0.   +0.j, 0.707+0.j],
                [0.   +0.j, 0.707+0.j, 0.   +0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    a = destroy(dim, dtype=dtype)
+    a = destroy(dim)
     return 0.5 * (a + dag(a))
 
 
-def momentum(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def momentum(dim: int) -> Array:
     r"""Returns the momentum operator $p = i (a^\dag - a) / 2$.
 
     Args:
         dim: Dimension of the Hilbert space.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (dim, dim))_ Momentum operator.
@@ -412,18 +378,16 @@ def momentum(dim: int, *, dtype: jnp.complex64 | jnp.complex128 | None = None) -
                [0.+0.5j  , 0.+0.j   , 0.-0.707j],
                [0.+0.j   , 0.+0.707j, 0.+0.j   ]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    a = destroy(dim, dtype=dtype)
+    a = destroy(dim)
     return 0.5j * (dag(a) - a)
 
 
-def sigmax(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def sigmax() -> Array:
     r"""Returns the Pauli $\sigma_x$ operator.
 
     It is defined by $\sigma_x = \begin{pmatrix} 0 & 1 \\ 1 & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (2, 2))_ Pauli $\sigma_x$ operator.
@@ -433,17 +397,15 @@ def sigmax(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
         Array([[0.+0.j, 1.+0.j],
                [1.+0.j, 0.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    return jnp.array([[0.0, 1.0], [1.0, 0.0]], dtype=dtype)
+    return jnp.array([[0.0, 1.0], [1.0, 0.0]], dtype=cdtype())
 
 
-def sigmay(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def sigmay() -> Array:
     r"""Returns the Pauli $\sigma_y$ operator.
 
     It is defined by $\sigma_y = \begin{pmatrix} 0 & -i \\ i & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (2, 2))_ Pauli $\sigma_y$ operator.
@@ -453,17 +415,15 @@ def sigmay(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
         Array([[ 0.+0.j, -0.-1.j],
                [ 0.+1.j,  0.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    return jnp.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=dtype)
+    return jnp.array([[0.0, -1.0j], [1.0j, 0.0]], dtype=cdtype())
 
 
-def sigmaz(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def sigmaz() -> Array:
     r"""Returns the Pauli $\sigma_z$ operator.
 
     It is defined by $\sigma_z = \begin{pmatrix} 1 & 0 \\ 0 & -1 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (2, 2))_ Pauli $\sigma_z$ operator.
@@ -473,17 +433,15 @@ def sigmaz(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
         Array([[ 1.+0.j,  0.+0.j],
                [ 0.+0.j, -1.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    return jnp.array([[1.0, 0.0], [0.0, -1.0]], dtype=dtype)
+    return jnp.array([[1.0, 0.0], [0.0, -1.0]], dtype=cdtype())
 
 
-def sigmap(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def sigmap() -> Array:
     r"""Returns the Pauli raising operator $\sigma_+$.
 
     It is defined by $\sigma_+ = \begin{pmatrix} 0 & 1 \\ 0 & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (2, 2))_ Pauli $\sigma_+$ operator.
@@ -493,17 +451,15 @@ def sigmap(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
         Array([[0.+0.j, 1.+0.j],
                [0.+0.j, 0.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    return jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=dtype)
+    return jnp.array([[0.0, 1.0], [0.0, 0.0]], dtype=cdtype())
 
 
-def sigmam(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
+def sigmam() -> Array:
     r"""Returns the Pauli lowering operator $\sigma_-$.
 
     It is defined by $\sigma_- = \begin{pmatrix} 0 & 0 \\ 1 & 0 \end{pmatrix}$.
 
     Args:
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (2, 2))_ Pauli $\sigma_-$ operator.
@@ -513,13 +469,10 @@ def sigmam(*, dtype: jnp.complex64 | jnp.complex128 | None = None) -> Array:
         Array([[0.+0.j, 0.+0.j],
                [1.+0.j, 0.+0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    return jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=dtype)
+    return jnp.array([[0.0, 0.0], [1.0, 0.0]], dtype=cdtype())
 
 
-def hadamard(
-    n: int = 1, *, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array:
+def hadamard(n: int = 1) -> Array:
     r"""Returns the Hadamard transform on $n$ qubits.
 
     For a single qubit, it is defined by
@@ -536,7 +489,6 @@ def hadamard(
 
     Args:
         n: Number of qubits to act on.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (2^n, 2^n))_ Hadamard transform operator.
@@ -551,7 +503,6 @@ def hadamard(
                [ 0.5+0.j,  0.5+0.j, -0.5+0.j, -0.5+0.j],
                [ 0.5+0.j, -0.5+0.j, -0.5+0.j,  0.5-0.j]], dtype=complex64)
     """
-    dtype = get_cdtype(dtype)
-    H1 = jnp.array([[1.0, 1.0], [1.0, -1.0]], dtype=dtype) / jnp.sqrt(2)
+    H1 = jnp.array([[1.0, 1.0], [1.0, -1.0]], dtype=cdtype()) / jnp.sqrt(2)
     Hs = jnp.broadcast_to(H1, (n, 2, 2))  # (n, 2, 2)
     return tensor(*Hs)

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -126,7 +126,7 @@ def snap_gate(phase: ArrayLike) -> Array:
         >>> dq.snap_gate([[0, 1, 2], [2, 3, 4]]).shape
         (2, 3, 3)
     """
-    phase = jnp.asarray(phase)
+    phase = jnp.asarray(phase, dtype=cdtype())
     # batched construct diagonal array
     bdiag = jnp.vectorize(jnp.diag, signature='(a)->(a,a)')
     return bdiag(jnp.exp(1j * phase))

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -8,7 +8,7 @@ from jaxtyping import ArrayLike, PRNGKeyArray
 from ..utils.operators import displace
 from ..utils.states import fock
 from ..utils.utils import tensor, tobra
-from .array_types import dtype_complex_to_real, get_cdtype, get_rdtype
+from .array_types import cdtype
 
 __all__ = ['rand_real', 'rand_complex', 'snap_gate', 'cd_gate']
 
@@ -19,7 +19,6 @@ def rand_real(
     *,
     min: float = 0.0,
     max: float = 1.0,
-    dtype: jnp.float32 | jnp.float64 | None = None,
 ) -> Array:
     r"""Returns an array filled with uniformly distributed random real numbers.
 
@@ -31,7 +30,6 @@ def rand_real(
         shape _(int or tuple of ints)_: Shape of the returned array.
         min: Minimum (inclusive) value.
         max: Maximum (exclusive) value.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (*shape))_ Array filled with random real numbers.
@@ -42,19 +40,13 @@ def rand_real(
         Array([[3.22 , 1.613, 0.967, 4.432, 4.21 ],
                [0.96 , 1.726, 1.262, 3.16 , 3.274]], dtype=float32)
     """
-    dtype = get_rdtype(dtype)
     shape = (shape,) if isinstance(shape, int) else shape
-
     # sample uniformly in [min, max)
-    return jax.random.uniform(key, shape=shape, dtype=dtype, minval=min, maxval=max)
+    return jax.random.uniform(key, shape=shape, minval=min, maxval=max)
 
 
 def rand_complex(
-    key: PRNGKeyArray,
-    shape: int | tuple[int, ...],
-    *,
-    rmax: float = 1.0,
-    dtype: jnp.complex64 | jnp.complex128 | None = None,
+    key: PRNGKeyArray, shape: int | tuple[int, ...], *, rmax: float = 1.0
 ) -> Array:
     r"""Returns an array filled with random complex numbers uniformly distributed in
     the complex plane.
@@ -93,7 +85,6 @@ def rand_complex(
         key: A PRNG key used as the random key.
         shape _(int or tuple of ints)_: Shape of the returned array.
         rmax: Maximum magnitude.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (*shape))_ Array filled with random complex numbers.
@@ -104,18 +95,13 @@ def rand_complex(
         Array([[ 1.341+4.17j ,  3.978-0.979j, -2.592-0.946j],
                [-4.428+1.744j, -0.53 +1.668j,  2.582+0.65j ]], dtype=complex64)
     """
-    cdtype = get_cdtype(dtype)
-    rdtype = dtype_complex_to_real(cdtype)
     shape = (shape,) if isinstance(shape, int) else shape
-
     # sample uniformly in the unit L2 ball and scale
-    x = rmax * jax.random.ball(key, 2, shape=shape, dtype=rdtype)
+    x = rmax * jax.random.ball(key, 2, shape=shape)
     return x[..., 0] + 1j * x[..., 1]
 
 
-def snap_gate(
-    phase: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array:
+def snap_gate(phase: ArrayLike) -> Array:
     r"""Returns a SNAP gate.
 
     The *selective number-dependent arbitrary phase* (SNAP) gate imparts a different
@@ -128,7 +114,6 @@ def snap_gate(
     Args:
         phase _(array_like of shape (..., n))_: Phase for each Fock state. The last
             dimension of the array _n_ defines the Hilbert space dimension.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (..., n, n))_ SNAP gate operator.
@@ -141,17 +126,13 @@ def snap_gate(
         >>> dq.snap_gate([[0, 1, 2], [2, 3, 4]]).shape
         (2, 3, 3)
     """
-    cdtype = get_cdtype(dtype)
-    rdtype = dtype_complex_to_real(cdtype)
-    phase = jnp.asarray(phase, dtype=rdtype)
+    phase = jnp.asarray(phase)
     # batched construct diagonal array
     bdiag = jnp.vectorize(jnp.diag, signature='(a)->(a,a)')
     return bdiag(jnp.exp(1j * phase))
 
 
-def cd_gate(
-    dim: int, alpha: ArrayLike, *, dtype: jnp.complex64 | jnp.complex128 | None = None
-) -> Array:
+def cd_gate(dim: int, alpha: ArrayLike) -> Array:
     r"""Returns a conditional displacement gate.
 
     The *conditional displacement* (CD) gate displaces an oscillator conditioned on
@@ -165,7 +146,6 @@ def cd_gate(
     Args:
         dim: Dimension of the oscillator Hilbert space.
         alpha _(array_like of shape (...))_: Displacement amplitude.
-        dtype: Complex data type of the returned array.
 
     Returns:
         _(array of shape (..., n, n))_ CD gate operator (acting on the oscillator + TLS
@@ -180,10 +160,9 @@ def cd_gate(
         >>> dq.cd_gate(3, [0.1, 0.2]).shape
         (2, 6, 6)
     """  # noqa: E501
-    dtype = get_cdtype(dtype)
-    alpha = jnp.asarray(alpha, dtype=dtype)
-    g = fock(2, 0, dtype=dtype)  # (2, 1)
-    e = fock(2, 1, dtype=dtype)  # (2, 1)
-    disp_plus = displace(dim, alpha / 2, dtype=dtype)  # (..., dim, dim)
-    disp_minus = displace(dim, -alpha / 2, dtype=dtype)  # (..., dim, dim)
+    alpha = jnp.asarray(alpha, dtype=cdtype())
+    g = fock(2, 0)  # (2, 1)
+    e = fock(2, 1)  # (2, 1)
+    disp_plus = displace(dim, alpha / 2)  # (..., dim, dim)
+    disp_minus = displace(dim, -alpha / 2)  # (..., dim, dim)
     return tensor(disp_plus, g @ tobra(g)) + tensor(disp_minus, e @ tobra(e))

--- a/dynamiqs/utils/wigners.py
+++ b/dynamiqs/utils/wigners.py
@@ -9,7 +9,7 @@ from jax import numpy as jnp
 from jax.scipy.linalg import toeplitz
 from jaxtyping import ArrayLike
 
-from .array_types import dtype_complex_to_real, dtype_real_to_complex
+from .array_types import cdtype
 from .operators import eye
 from .utils import isdm, isket, todm
 
@@ -48,9 +48,8 @@ def wigner(
     """
     state = jnp.asarray(state)
 
-    rdtype = dtype_complex_to_real(state.dtype)
-    xvec = jnp.linspace(-xmax, xmax, npixels, dtype=rdtype)
-    yvec = jnp.linspace(-ymax, ymax, npixels, dtype=rdtype)
+    xvec = jnp.linspace(-xmax, xmax, npixels)
+    yvec = jnp.linspace(-ymax, ymax, npixels)
 
     if method == 'clenshaw':
         state = todm(state)
@@ -151,7 +150,7 @@ def _fock_to_position(n: int, positions: Array) -> Array:
     oscillator of dimension n, as evaluated at the specific position values provided.
     """
     n_positions = positions.shape[0]
-    U = jnp.zeros((n, n_positions), dtype=dtype_real_to_complex(positions.dtype))
+    U = jnp.zeros((n, n_positions), dtype=cdtype())
     U = U.at[0].set(jnp.pi ** (-0.25) * jnp.exp(-0.5 * positions**2))
 
     if n == 1:

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -5,6 +5,7 @@ import qutip as qt
 from pytest import approx
 
 import dynamiqs as dq
+from dynamiqs.utils.array_types import cdtype
 
 
 def test_ket_fidelity_correctness():
@@ -89,10 +90,8 @@ def test_ket_dm_fidelity_batching():
 
 
 def test_hadamard():
-    c64 = jnp.complex64
-
     # one qubit
-    H1 = 2 ** (-1 / 2) * jnp.array([[1, 1], [1, -1]], dtype=c64)
+    H1 = 2 ** (-1 / 2) * jnp.array([[1, 1], [1, -1]], dtype=cdtype())
     assert jnp.allclose(dq.hadamard(1), H1)
 
     # two qubits
@@ -103,7 +102,7 @@ def test_hadamard():
             [1, 1, -1, -1],
             [1, -1, -1, 1],
         ],
-        dtype=c64,
+        dtype=cdtype(),
     )
     assert jnp.allclose(dq.hadamard(2), H2)
 
@@ -119,7 +118,7 @@ def test_hadamard():
             [1, 1, -1, -1, -1, -1, 1, 1],
             [1, -1, -1, 1, -1, 1, 1, -1],
         ],
-        dtype=c64,
+        dtype=cdtype(),
     )
     assert jnp.allclose(dq.hadamard(3), H3)
 


### PR DESCRIPTION
On top of #440.

As discussed tgther, this is now fixed by a global option that we can query using `cdtype()`.