### PR TITLE
Batch expect

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -5,8 +5,6 @@ from typing import Any
 import jax.numpy as jnp
 from jaxtyping import Array
 
-from .utils.utils import dag, isket
-
 
 def type_str(type: Any) -> str:
     if type.__module__ in ('builtins', '__main__'):
@@ -34,10 +32,3 @@ def check_time_array(x: Array, arg_name: str, allow_empty: bool = False):
         )
     if not jnp.all(x >= 0):
         raise ValueError(f'Argument `{arg_name}` must contain positive values only.')
-
-
-def bexpect(O: Array, x: Array) -> Array:
-    # batched over O
-    if isket(x):
-        return jnp.einsum('ij,bjk,kl->b', dag(x), O, x)  # <x|O|x>
-    return jnp.einsum('bij,ji->b', O, x)  # tr(Ox)

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -6,12 +6,12 @@ import equinox as eqx
 from jax import Array
 from jaxtyping import PyTree
 
-from .._utils import bexpect
 from ..gradient import Gradient
 from ..options import Options
 from ..result import Result
 from ..solver import Solver
 from ..time_array import TimeArray
+from ..utils.utils import expect
 
 
 class AbstractSolver(eqx.Module):
@@ -34,7 +34,7 @@ class BaseSolver(AbstractSolver):
         if self.options.save_states:
             saved['ysave'] = y
         if self.Es is not None and len(self.Es) > 0:
-            saved['Esave'] = bexpect(self.Es, y)
+            saved['Esave'] = expect(self.Es, y)
         return saved
 
     def result(self, saved: dict[str, Array]) -> Result:


### PR DESCRIPTION
`dq.expect` now works for a list of operators.

Closes https://linear.app/dynamiqs/issue/DYN-113.