### PR TITLE
Fallback method for `dm_fidelity` on GPU

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -32,3 +32,8 @@ def check_time_array(x: Array, arg_name: str, allow_empty: bool = False):
         )
     if not jnp.all(x >= 0):
         raise ValueError(f'Argument `{arg_name}` must contain positive values only.')
+
+
+def on_cpu(x: Array) -> str:
+    # todo: this is a temporary solution, it won't work when we have multiple devices
+    return x.devices().pop().device_kind == 'cpu'


### PR DESCRIPTION
All the tests pass on GPU now 🎉 I tested that the computed fidelity is the same as qutip on 30 random density matrices, for both the CPU and GPU implementation.

Closes https://linear.app/dynamiqs/issue/DYN-158.