### PR TITLE
New ODE solvers: Dopri8 and Tsit5

### DIFF
--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -65,10 +65,9 @@ class EulerSolver(DiffraxSolver):
         self.max_steps = 100_000  # todo: fix hard-coded max_steps
 
 
-class Dopri5Solver(DiffraxSolver):
+class AdaptiveSolver(DiffraxSolver):
     def __init__(self, *args):
         super().__init__(*args)
-        self.diffrax_solver = dx.Dopri5()
         self.stepsize_controller = dx.PIDController(
             rtol=self.solver.rtol,
             atol=self.solver.atol,
@@ -78,3 +77,15 @@ class Dopri5Solver(DiffraxSolver):
         )
         self.dt0 = None
         self.max_steps = self.solver.max_steps
+
+
+class Dopri5Solver(AdaptiveSolver):
+    diffrax_solver = dx.Dopri5()
+
+
+class Dopri8Solver(AdaptiveSolver):
+    diffrax_solver = dx.Dopri8()
+
+
+class Tsit5Solver(AdaptiveSolver):
+    diffrax_solver = dx.Tsit5()

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -5,7 +5,13 @@ import jax.numpy as jnp
 from jaxtyping import PyTree, Scalar
 
 from ..core.abstract_solver import MESolver
-from ..core.diffrax_solver import DiffraxSolver, Dopri5Solver, EulerSolver
+from ..core.diffrax_solver import (
+    DiffraxSolver,
+    Dopri5Solver,
+    Dopri8Solver,
+    EulerSolver,
+    Tsit5Solver,
+)
 from ..time_array import TimeArray
 from ..utils.utils import dag
 
@@ -40,4 +46,12 @@ class MEEuler(MEDiffraxSolver, EulerSolver):
 
 
 class MEDopri5(MEDiffraxSolver, Dopri5Solver):
+    pass
+
+
+class MEDopri8(MEDiffraxSolver, Dopri8Solver):
+    pass
+
+
+class METsit5(MEDiffraxSolver, Tsit5Solver):
     pass

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -26,7 +26,7 @@ def mesolve(
     tsave: ArrayLike,
     *,
     exp_ops: list[ArrayLike] | None = None,
-    solver: Solver = Dopri5(),
+    solver: Solver = Tsit5(),
     gradient: Gradient | None = None,
     options: Options = Options(),
 ):
@@ -58,7 +58,7 @@ def _mesolve(
     psi0: ArrayLike,
     tsave: ArrayLike,
     exp_ops: list[ArrayLike] | None = None,
-    solver: Solver = Dopri5(),
+    solver: Solver = Tsit5(),
     gradient: Gradient | None = None,
     options: Options = Options(),
 ) -> Result:

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -10,11 +10,11 @@ from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
 from ..result import Result
-from ..solver import Dopri5, Euler, Propagator, Solver
+from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import TimeArray
 from ..utils.array_types import cdtype
 from ..utils.utils import todm
-from .mediffrax import MEDopri5, MEEuler
+from .mediffrax import MEDopri5, MEDopri8, MEEuler, METsit5
 from .mepropagator import MEPropagator
 
 
@@ -71,7 +71,13 @@ def _mesolve(
     Es = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
 
     # === select solver class
-    solvers = {Euler: MEEuler, Dopri5: MEDopri5, Propagator: MEPropagator}
+    solvers = {
+        Euler: MEEuler,
+        Dopri5: MEDopri5,
+        Dopri8: MEDopri8,
+        Tsit5: METsit5,
+        Propagator: MEPropagator,
+    }
     solver_class = get_solver_class(solvers, solver)
 
     # === check gradient is supported

--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -4,7 +4,13 @@ import diffrax as dx
 from jaxtyping import PyTree, Scalar
 
 from ..core.abstract_solver import SESolver
-from ..core.diffrax_solver import DiffraxSolver, Dopri5Solver, EulerSolver
+from ..core.diffrax_solver import (
+    DiffraxSolver,
+    Dopri5Solver,
+    Dopri8Solver,
+    EulerSolver,
+    Tsit5Solver,
+)
 from ..time_array import TimeArray
 
 
@@ -30,4 +36,12 @@ class SEEuler(SEDiffraxSolver, EulerSolver):
 
 
 class SEDopri5(SEDiffraxSolver, Dopri5Solver):
+    pass
+
+
+class SEDopri8(SEDiffraxSolver, Dopri8Solver):
+    pass
+
+
+class SETsit5(SEDiffraxSolver, Tsit5Solver):
     pass

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -24,7 +24,7 @@ def sesolve(
     tsave: ArrayLike,
     *,
     exp_ops: list[ArrayLike] | None = None,
-    solver: Solver = Dopri5(),
+    solver: Solver = Tsit5(),
     gradient: Gradient | None = None,
     options: Options = Options(),
 ):
@@ -44,7 +44,7 @@ def _sesolve(
     psi0: ArrayLike,
     tsave: ArrayLike,
     exp_ops: list[ArrayLike] | None = None,
-    solver: Solver = Dopri5(),
+    solver: Solver = Tsit5(),
     gradient: Gradient | None = None,
     options: Options = Options(),
 ) -> Result:

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -10,10 +10,10 @@ from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
 from ..result import Result
-from ..solver import Dopri5, Euler, Propagator, Solver
+from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import TimeArray
 from ..utils.array_types import cdtype
-from .sediffrax import SEDopri5, SEEuler
+from .sediffrax import SEDopri5, SEDopri8, SEEuler, SETsit5
 from .sepropagator import SEPropagator
 
 
@@ -55,7 +55,13 @@ def _sesolve(
     Es = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
 
     # === select solver class
-    solvers = {Euler: SEEuler, Dopri5: SEDopri5, Propagator: SEPropagator}
+    solvers = {
+        Euler: SEEuler,
+        Dopri5: SEDopri5,
+        Dopri8: SEDopri8,
+        Tsit5: SETsit5,
+        Propagator: SEPropagator,
+    }
     solver_class = get_solver_class(solvers, solver)
 
     # === check gradient is supported

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -60,8 +60,8 @@ class Rouchon2(_ODEFixedStep):
 
 
 class _ODEAdaptiveStep(_ODESolver):
-    atol: float = 1e-6
     rtol: float = 1e-4
+    atol: float = 1e-6
     safety_factor: float = 0.9
     min_factor: float = 0.2
     max_factor: float = 5.0

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -70,3 +70,11 @@ class _ODEAdaptiveStep(_ODESolver):
 
 class Dopri5(_ODEAdaptiveStep):
     pass
+
+
+class Dopri8(_ODEAdaptiveStep):
+    pass
+
+
+class Tsit5(_ODEAdaptiveStep):
+    pass

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -60,8 +60,8 @@ class Rouchon2(_ODEFixedStep):
 
 
 class _ODEAdaptiveStep(_ODESolver):
-    atol: float = 1e-8
-    rtol: float = 1e-6
+    atol: float = 1e-6
+    rtol: float = 1e-4
     safety_factor: float = 0.9
     min_factor: float = 0.2
     max_factor: float = 5.0

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -1,17 +1,19 @@
 import pytest
 
 from dynamiqs.gradient import Autograd
-from dynamiqs.solver import Dopri5
+from dynamiqs.solver import Tsit5
 
 from ..solver_tester import SolverTester
 from .open_system import ocavity, otdqubit
 
+# we only test Tsit5 to keep the unit test suite fast
 
-class TestMEDopri5(SolverTester):
+
+class TestMEAdaptive(SolverTester):
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_correctness(self, system):
-        self._test_correctness(system, Dopri5())
+        self._test_correctness(system, Tsit5())
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
     def test_autograd(self, system):
-        self._test_gradient(system, Dopri5(), Autograd())
+        self._test_gradient(system, Tsit5(), Autograd())

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -1,17 +1,19 @@
 import pytest
 
 from dynamiqs.gradient import Autograd
-from dynamiqs.solver import Dopri5
+from dynamiqs.solver import Tsit5
 
 from ..solver_tester import SolverTester
 from .closed_system import cavity, tdqubit
 
+# we only test Tsit5 to keep the unit test suite fast
 
-class TestSEDopri5(SolverTester):
+
+class TestSEAdaptive(SolverTester):
     @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_correctness(self, system):
-        self._test_correctness(system, Dopri5())
+        self._test_correctness(system, Tsit5())
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
     def test_autograd(self, system):
-        self._test_gradient(system, Dopri5(), Autograd())
+        self._test_gradient(system, Tsit5(), Autograd())

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -23,7 +23,7 @@ class SolverTester(ABC):
         options: Options = Options(),
         ysave_atol: float = 1e-3,
         esave_rtol: float = 1e-3,
-        esave_atol: float = 1e-5,
+        esave_atol: float = 1e-4,
     ):
         result = system.run(solver, options=options)
 
@@ -51,7 +51,7 @@ class SolverTester(ABC):
         *,
         options: Options = Options(),
         rtol: float = 1e-3,
-        atol: float = 1e-5,
+        atol: float = 1e-4,
     ):
         def assert_allclose(pytree1, pytree2):
             # assert two pytrees are equal


### PR DESCRIPTION
This PR introduces new ODE solvers from diffrax, each having its own motivation:
- **Dopri8**: to have very accurate solutions for demanding tolerances (probably for `float64`). It may also serve as a reference to compare fidelities between other solvers.
- **Tsit5**: as a replacement to Dopri5, the ODE community says it's more efficient. I tested on a few examples, it is indeed slightly better (by a few % in speedup). We should keep Dopri5 though if we want to also compare eye-to-eye with QuTiP.

Sources:
- Patrick Kidger diffrax doc > https://docs.kidger.site/diffrax/usage/how-to-choose-a-solver/
- Christopher Rackauckas blog > https://www.stochasticlifestyle.com/comparison-differential-equation-solver-suites-matlab-r-julia-python-c-fortran/

I also propose to reduce the default rtol/atol to match the default precision (float32), the current default is a bit low compared with machine precision.

We're only missing implicit solvers (for stiff problems), see https://linear.app/dynamiqs/issue/DYN-159/add-implicit-ode-solvers.


<details>
  <summary>Quick comparison of Tsit5 and Dopri5 on mesolve</summary>

Lossy oscillator:
```python
import dynamiqs as dq
from jax import numpy as jnp

for n in [32, 64, 128]:
    print(f'=== n={n}')
    a = dq.destroy(n)
    delta = 1.0 * 2 * jnp.pi
    alpha0 = 2.0
    kappa = 1.0 * 2 * jnp.pi / 4
    H = delta * dq.dag(a) @ a
    Ls = [jnp.sqrt(kappa) * a, jnp.sqrt(kappa) * a]
    y0 = dq.coherent(n, alpha0)
    tsave = jnp.linspace(0, 1.0, 11)

    dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Tsit5()).ysave.block_until_ready()
    %timeit dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Tsit5()).ysave.block_until_ready()
    dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Dopri5()).ysave.block_until_ready()
    %timeit dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Dopri5()).ysave.block_until_ready()
```
```
=== n=32
16.8 ms ± 58 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
17.6 ms ± 23.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
=== n=64
37.6 ms ± 22.9 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
39 ms ± 52 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
=== n=128
47.8 ms ± 30 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
52.1 ms ± 28.7 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

Cat inflation:
```python
for n in [32, 64, 128]:
    print(f'=== n={n}')
    a = dq.destroy(n)
    alpha = 2.0
    k2 = 1.0
    H = dq.zero(n)
    Ls = [jnp.sqrt(k2) * (a @ a - alpha**2 * dq.eye(n))]
    y0 = dq.coherent(n, 0.0)
    tsave = jnp.linspace(0, 1 / k2, 11)
    dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Tsit5()).ysave.block_until_ready()
    %timeit dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Tsit5()).ysave.block_until_ready()
    dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Dopri5()).ysave.block_until_ready()
    %timeit dq.mesolve(H, Ls, y0, tsave, solver=dq.solver.Dopri5()).ysave.block_until_ready()
```
```
=== n=32
71.1 ms ± 38.2 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
75.6 ms ± 84.7 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
=== n=64
293 ms ± 544 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
305 ms ± 238 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
=== n=128
1.38 s ± 1.71 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
1.45 s ± 1.02 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

</details>
