### PR TITLE
Update Gradient namespace

### DIFF
--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -30,7 +30,8 @@ class PropagatorSolver(BaseSolver):
             res = self.save(y)
             return y, res
 
-        delta_ts = jnp.diff(self.ts, prepend=self.t0)
+        # we use `jnp.asarray` because of this bug (fixed in jax-0.4.24)
+        delta_ts = jnp.diff(self.ts, prepend=jnp.asarray(self.t0))
         ylast, saved = jax.lax.scan(propagate, self.y0, delta_ts)
 
         # === collect and return results

--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -30,7 +30,8 @@ class PropagatorSolver(BaseSolver):
             res = self.save(y)
             return y, res
 
-        # we use `jnp.asarray` because of this bug (fixed in jax-0.4.24)
+        # we use `jnp.asarray` because of the bug fixed here:
+        # https://github.com/google/jax/pull/19381 (fixed in jax-0.4.24)
         delta_ts = jnp.diff(self.ts, prepend=jnp.asarray(self.t0))
         ylast, saved = jax.lax.scan(propagate, self.y0, delta_ts)
 

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import equinox as eqx
 
 
@@ -9,5 +11,5 @@ class Autograd(Gradient):
     pass
 
 
-class Adjoint(Gradient):
-    pass
+class CheckpointAutograd(Gradient):
+    checkpoints: int | None = None

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -75,6 +75,7 @@ def _mesolve(
     solver_class = get_solver_class(solvers, solver)
 
     # === check gradient is supported
+    gradient = solver.DEFAULT_GRADIENT if gradient is None else gradient
     solver.assert_supports_gradient(gradient)
 
     # === init solver

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -59,6 +59,7 @@ def _sesolve(
     solver_class = get_solver_class(solvers, solver)
 
     # === check gradient is supported
+    gradient = solver.DEFAULT_GRADIENT if gradient is None else gradient
     solver.assert_supports_gradient(gradient)
 
     # === init solver

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -5,11 +5,12 @@ from typing import ClassVar, Literal
 import equinox as eqx
 from jaxtyping import Scalar
 
-from .gradient import Adjoint, Autograd, Gradient
+from .gradient import Autograd, CheckpointAutograd, Gradient
 
 
 class Solver(eqx.Module):
     SUPPORTED_GRADIENT: ClassVar[tuple[Gradient]] = ()
+    DEFAULT_GRADIENT: ClassVar[Gradient]
 
     @classmethod
     def supports_gradient(cls, gradient: Gradient | None) -> bool:
@@ -28,10 +29,12 @@ class Solver(eqx.Module):
 
 class Propagator(Solver):
     SUPPORTED_GRADIENT = (Autograd,)
+    DEFAULT_GRADIENT = Autograd()
 
 
 class _ODESolver(Solver):
-    SUPPORTED_GRADIENT = (Autograd, Adjoint)
+    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+    DEFAULT_GRADIENT = CheckpointAutograd()
 
 
 class _ODEFixedStep(_ODESolver):

--- a/tests/mesolve/test_dopri5.py
+++ b/tests/mesolve/test_dopri5.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Dopri5
 
 from ..solver_tester import SolverTester
@@ -13,5 +13,6 @@ class TestMEDopri5(SolverTester):
         self._test_correctness(system, Dopri5())
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Dopri5(), Autograd())
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_autograd(self, system, gradient):
+        self._test_gradient(system, Dopri5(), gradient)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
@@ -14,6 +14,7 @@ class TestMEEuler(SolverTester):
         self._test_correctness(system, solver, esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    def test_autograd(self, system):
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_autograd(self, system, gradient):
         solver = Euler(dt=1e-4)
-        self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)
+        self._test_gradient(system, solver, gradient, rtol=1e-2, atol=1e-2)

--- a/tests/sesolve/test_dopri5.py
+++ b/tests/sesolve/test_dopri5.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Dopri5
 
 from ..solver_tester import SolverTester
@@ -13,5 +13,6 @@ class TestSEDopri5(SolverTester):
         self._test_correctness(system, Dopri5())
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Dopri5(), Autograd())
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_autograd(self, system, gradient):
+        self._test_gradient(system, Dopri5(), gradient)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
@@ -14,6 +14,7 @@ class TestSEEuler(SolverTester):
         self._test_correctness(system, solver, esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
-    def test_autograd(self, system):
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_autograd(self, system, gradient):
         solver = Euler(dt=1e-4)
-        self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)
+        self._test_gradient(system, solver, gradient, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
Following the benchmark of `dx.RecursiveCheckpointAdjoint` (see below), this PR removes the adjoint method altogether (at least for now).

There are now two available gradient methods:
 - `Autograd` which correponds to the jax autograd, available in diffrax using `dx.DirectAdjoint`
 - `CheckpointAutograd` corresponding to `dx.RecursiveCheckpointAdjoint` (not available for our custom solvers, for now)

The first one seems fastest if memory is not an issue. The second one solves the memory problem similarly to the adjoint method, but probably better all-around.

NB: Also fix the `dq.expect` bug by using `jnp.einsum` and the `jnp.diff(..., prepend=...)` bug.

<details>
  <summary>Benchmark of gradients in diffrax on a small problem</summary>

```python
import jax
import jax.numpy as jnp
import diffrax as dx
import dynamiqs as dq
import functools
import timeit
import warnings


# create a simple quantum problem on which to test the adjoints
@functools.partial(jax.jit, static_argnums=(1, 2))
def run_mesolve(delta, adjoint, N):
    # make quantum problem
    a = dq.destroy(N)
    i = dq.eye(N)
    H = dq.dag(a) @ dq.dag(a) @ a @ a
    L = 0.1 * a @ a
    tsave = jnp.linspace(0.0, 10.0, 100)
    rho0 = dq.coherent_dm(N, 2.0)

    # initialize diffrax solver
    def vector_field(t, y, args):
        out = -1j * args[0] * H @ y + 0.5 * L @ y @ dq.dag(L) - 0.5 * dq.dag(L) @ L @ y
        return out + dq.dag(out)

    term = dx.ODETerm(vector_field)
    solver = dx.Dopri5()
    saveat = dx.SaveAt(ts=tsave)
    stepsize_controller = dx.PIDController(rtol=1e-5, atol=1e-7)

    # run solver
    with warnings.catch_warnings():
        warnings.simplefilter('ignore', UserWarning)
        solution = dx.diffeqsolve(
            term,
            solver,
            t0=tsave[0],
            t1=tsave[-1],
            dt0=None,
            y0=rho0,
            saveat=saveat,
            stepsize_controller=stepsize_controller,
            adjoint=adjoint,
            args=(delta,),
        )

    return dq.expect(a, solution.ys[-1]).real


# initialize parameters and grad function
N = 20
delta = 0.2
grad_mesolve = jax.grad(run_mesolve, argnums=0)

# time mesolve with BacksolveAdjoint (uncomment to test)
# print("BacksolveAdjoint")
# adjoint = dx.BacksolveAdjoint()
# %timeit grad_mesolve(delta, adjoint, N)

# time mesolve with DirectAdjoint (uncomment to test)
print("DirectAdjoint")
adjoint = dx.DirectAdjoint()
grad_mesolve(delta, adjoint, N) # jit compilation
%timeit -n 1 -r 1 grad_mesolve(delta, adjoint, N)

# time mesolve with RecursiveCheckpointAdjoint (uncomment to test)
print("RecursiveCheckpointAdjoint")
for n in range(10, 0, -1):
    print(f"== n = {n} ==")
    adjoint = dx.RecursiveCheckpointAdjoint(checkpoints=n)
    grad_mesolve(delta, adjoint, N) # jit compilation
    %timeit -n 1 -r 1 grad_mesolve(delta, adjoint, N)
```

```
DirectAdjoint
226 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)

RecursiveCheckpointAdjoint
== n = 10 ==
273 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 9 ==
261 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 8 ==
256 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 7 ==
279 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 6 ==
269 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 5 ==
294 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 4 ==
419 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 3 ==
869 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 2 ==
2.34 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
== n = 1 ==
6.75 s ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```
</details>