### PR TITLE
Replace adjoint by checkpointed autograd

### DIFF
--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -34,7 +34,7 @@ class DiffraxSolver(BaseSolver):
 
             if self.gradient is None:
                 adjoint = dx.RecursiveCheckpointAdjoint()
-            if isinstance(self.gradient, CheckpointAutograd):
+            elif isinstance(self.gradient, CheckpointAutograd):
                 adjoint = dx.RecursiveCheckpointAdjoint(self.gradient.ncheckpoints)
             elif isinstance(self.gradient, Autograd):
                 adjoint = dx.DirectAdjoint()

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -5,7 +5,7 @@ import warnings
 import diffrax as dx
 from jaxtyping import PyTree
 
-from ..gradient import Adjoint, Autograd
+from ..gradient import Autograd, CheckpointAutograd
 from .abstract_solver import BaseSolver
 
 
@@ -34,10 +34,10 @@ class DiffraxSolver(BaseSolver):
 
             if self.gradient is None:
                 adjoint = dx.RecursiveCheckpointAdjoint()
+            if isinstance(self.gradient, CheckpointAutograd):
+                adjoint = dx.RecursiveCheckpointAdjoint(self.gradient.ncheckpoints)
             elif isinstance(self.gradient, Autograd):
-                adjoint = dx.RecursiveCheckpointAdjoint()
-            elif isinstance(self.gradient, Adjoint):
-                adjoint = dx.BacksolveAdjoint()
+                adjoint = dx.DirectAdjoint()
 
             # === solve differential equation with diffrax
             solution = dx.diffeqsolve(

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import equinox as eqx
 
 
@@ -9,5 +11,5 @@ class Autograd(Gradient):
     pass
 
 
-class Adjoint(Gradient):
-    pass
+class CheckpointAutograd(Gradient):
+    ncheckpoints: int | None = None

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -10,7 +10,7 @@ from .gradient import Autograd, CheckpointAutograd, Gradient
 
 # === generic solvers options
 class Solver(eqx.Module):
-    SUPPORTED_GRADIENT: ClassVar[tuple[Type[Gradient]]] = ()
+    SUPPORTED_GRADIENT: ClassVar[tuple[Type[Gradient], ...]] = ()
 
     @classmethod
     def supports_gradient(cls, gradient: Gradient | None) -> bool:

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Tsit5
 
 from ..solver_tester import SolverTester
@@ -15,5 +15,6 @@ class TestMEAdaptive(SolverTester):
         self._test_correctness(system, Tsit5())
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Tsit5(), Autograd())
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_gradient(self, system, gradient):
+        self._test_gradient(system, Tsit5(), gradient)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
@@ -14,6 +14,7 @@ class TestMEEuler(SolverTester):
         self._test_correctness(system, solver, esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [ocavity, otdqubit])
-    def test_autograd(self, system):
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_gradient(self, system, gradient):
         solver = Euler(dt=1e-4)
-        self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)
+        self._test_gradient(system, solver, gradient, rtol=1e-2, atol=1e-2)

--- a/tests/mesolve/test_propagator.py
+++ b/tests/mesolve/test_propagator.py
@@ -9,5 +9,5 @@ class TestMEPropagator(SolverTester):
     def test_correctness(self):
         self._test_correctness(ocavity, Propagator())
 
-    def test_autograd(self):
+    def test_gradient(self):
         self._test_gradient(ocavity, Propagator(), Autograd())

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Tsit5
 
 from ..solver_tester import SolverTester
@@ -15,5 +15,6 @@ class TestSEAdaptive(SolverTester):
         self._test_correctness(system, Tsit5())
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
-    def test_autograd(self, system):
-        self._test_gradient(system, Tsit5(), Autograd())
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_gradient(self, system, gradient):
+        self._test_gradient(system, Tsit5(), gradient)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd
 from dynamiqs.solver import Euler
 
 from ..solver_tester import SolverTester
@@ -14,6 +14,7 @@ class TestSEEuler(SolverTester):
         self._test_correctness(system, solver, esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [cavity, tdqubit])
-    def test_autograd(self, system):
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_gradient(self, system, gradient):
         solver = Euler(dt=1e-4)
-        self._test_gradient(system, solver, Autograd(), rtol=1e-2, atol=1e-2)
+        self._test_gradient(system, solver, gradient, rtol=1e-2, atol=1e-2)

--- a/tests/sesolve/test_propagator.py
+++ b/tests/sesolve/test_propagator.py
@@ -9,5 +9,5 @@ class TestSEPropagator(SolverTester):
     def test_correctness(self):
         self._test_correctness(cavity, Propagator())
 
-    def test_autograd(self):
+    def test_gradient(self):
         self._test_gradient(cavity, Propagator(), Autograd())


### PR DESCRIPTION
Replaces https://github.com/dynamiqs/dynamiqs/pull/455 (see description there) by @gautierronan. Replaces the previous replacement #459.

All solvers have to deal with `gradient` being one of `SUPPORTED_GRADIENT` or `None`.