### PR TITLE
Start moving documentation to JAX

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,21 @@
 
 [![ci](https://github.com/dynamiqs/dynamiqs/actions/workflows/ci.yml/badge.svg)](https://github.com/dynamiqs/dynamiqs/actions/workflows/ci.yml?query=branch%3Amain)  ![python version](https://img.shields.io/badge/python-3.9%2B-blue) [![chat](https://badgen.net/badge/icon/on%20slack?icon=slack&label=chat&color=orange)](https://join.slack.com/t/dynamiqs-org/shared_invite/zt-1z4mw08mo-qDLoNx19JBRtKzXlmlFYLA) [![license: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-yellow)](https://github.com/dynamiqs/dynamiqs/blob/main/LICENSE) [![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
-High-performance quantum systems simulation with PyTorch.
+High-performance quantum systems simulation with JAX.
 
-The **dynamiqs** library enables GPU simulation of large quantum systems, and computation of gradients based on the evolved quantum state. Differentiable solvers are available for the Schrödinger equation, the Lindblad master equation, and the stochastic master equation. The library is fully built on PyTorch and can efficiently run on CPUs and GPUs.
+The **dynamiqs** library enables GPU simulation of large quantum systems, and computation of gradients based on the evolved quantum state. Differentiable solvers are available for the Schrödinger equation, the Lindblad master equation, and the stochastic master equation. The library is fully built on JAX and can efficiently run on CPUs and GPUs.
 
-:hammer_and_wrench: This library is under active development and while the APIs and solvers are still finding their footing, we're working hard to make it worth the wait. Check back soon for the grand opening!
+> [!WARNING]
+> This library is under active development and while the APIs and solvers are still finding their footing, we're working hard to make it worth the wait. Check back soon for the grand opening!
 
 Some exciting features of dynamiqs include:
 
-- Running simulations on **GPUs**, with a significant speedup for large Hilbert space dimensions.
+- Running simulations on **GPUs** and **TPUs**, with a significant speedup for large Hilbert space dimensions.
 - **Batching** many simulations of different Hamiltonians, jump operators or initial states to run them concurrently.
 - Exploring solvers **tailored to quantum** simulations that preserve the properties of the state, such as trace and positivity.
 - Computing **gradients** of any function of the evolved quantum state with respect to any parameter of the Hamiltonian, jump operators, or initial state.
-- Using the library as a drop-in replacement for [QuTiP](https://qutip.org/) by directly passing QuTiP-defined quantum objects to our solvers.
-- Implementing your own solvers with ease by subclassing our base solver class and focusing directly on the solver logic.
-- Enjoy reading our carefully crafted documentation on our website: <https://www.dynamiqs.org>.
 
-We hope that this library will prove beneficial to the community for e.g. simulations of large quantum systems, gradient-based parameter estimation, or large-scale quantum optimal control.
+We hope that this library will prove beneficial to the community for e.g. simulations of large quantum systems, batched simulations of time-varying problems, gradient-based parameter estimation, or large-scale quantum optimal control.
 
 ## Installation
 
@@ -36,29 +34,24 @@ pip install git+https://github.com/dynamiqs/dynamiqs.git
 
 ### Simulate a lossy quantum harmonic oscillator
 
-This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$ using QuTiP-defined objects:
+This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$.
 
 ```python
 import dynamiqs as dq
-import numpy as np
-import qutip as qt
-import torch
+import jax.numpy as jnp
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128      # Hilbert space dimension
+omega = 1.0  # frequency
+kappa = 0.1  # decay rate
+alpha = 1.0  # initial coherent state amplitude
 
-# QuTiP operators, initial state and saving times
-a = qt.destroy(n)
-H = omega * a.dag() * a
-jump_ops = [np.sqrt(kappa) * a]
-psi0 = qt.coherent(n, alpha0)
-tsave = np.linspace(0, 1.0, 101)
-
-# run on GPU if available, otherwise on CPU
-torch.set_default_device('cuda' if torch.cuda.is_available() else 'cpu')
+# initialize operators, state and saving times
+a = dq.destroy(n)
+H = omega * dq.dag(a) @ a
+jump_ops = [jnp.sqrt(kappa) * a]
+psi0 = dq.coherent(n, alpha)
+tsave = jnp.linspace(0, 1.0, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -66,56 +59,48 @@ print(result)
 ```
 
 ```text
-|██████████| 100.0% - time 00:00/00:00
 ==== Result ====
-Method       : Dopri5
-Start        : 2023-09-10 16:57:34
-End          : 2023-09-10 16:57:35
-Total time   : 0.48 s
-states       : Tensor (101, 128, 128) | 12.62 Mb
+Solver  : Tsit5
+States  : Array complex64 (101, 128, 128) | 12.62 Mb
 ```
 
 ### Compute gradients with respect to some parameters
 
-Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha_0$. For this computation, we will define the objects with dynamiqs:
+Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha$. For this computation, we will define the objects with dynamiqs:
 
 ```python
 import dynamiqs as dq
-import torch
+import jax.numpy as jnp
+import jax
 
 # parameters
-n = 128
-omega = 1.0
-kappa = torch.tensor([0.1], requires_grad=True)
-alpha0 = torch.tensor([1.0], requires_grad=True)
+n = 128      # Hilbert space dimension
+omega = 1.0  # frequency
+kappa = 0.1  # decay rate
+alpha = 1.0  # initial coherent state amplitude
 
-# dynamiqs operators, initial state and saving times
-a = dq.destroy(n)
-H = omega * dq.dag(a) @ a
-jump_ops = [torch.sqrt(kappa) * a]
-psi0 = dq.coherent(n, alpha0)
-tsave = torch.linspace(0, 1.0, 101)
+def population(omega, kappa, alpha):
+    """Return the population inside the cavity after time evolution."""
+    # initialize operators, state and saving times
+    a = dq.destroy(n)
+    H = omega * dq.dag(a) @ a
+    jump_ops = [jnp.sqrt(kappa) * a]
+    psi0 = dq.coherent(n, alpha)
+    tsave = jnp.linspace(0, 1.0, 101)
 
-# run on GPU if available, otherwise on CPU
-torch.set_default_device('cuda' if torch.cuda.is_available() else 'cpu')
+    # run simulation
+    result = dq.mesolve(H, jump_ops, psi0, tsave)
 
-# run simulation
-result = dq.mesolve(
-    H, jump_ops, psi0, tsave,
-    gradient=dq.gradient.Autograd(),
-    options=dict(verbose=False),
-)
+    return dq.expect(dq.dag(a) @ a, result.states[-1]).real
 
-# gradient computation
-loss = dq.expect(dq.dag(a) @ a, result.states[-1]).real
-loss.backward()
-print(kappa.grad)
-print(alpha0.grad)
+# compute gradient with respect to kappa and alpha
+grad_population = jax.grad(population, argnums=(1, 2))
+print(grad_population(omega, kappa, alpha))
 ```
 
 ```text
-tensor([-0.9048])
-tensor([1.8097])
+(Array(-0.90483725, dtype=float32, weak_type=True), Array(1.8096755, dtype=float32, weak_type=True))
+
 ```
 
 ## Let's talk!

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Some exciting features of dynamiqs include:
 - **Batching** many simulations of different Hamiltonians, jump operators or initial states to run them concurrently.
 - Exploring solvers **tailored to quantum** simulations that preserve the properties of the state, such as trace and positivity.
 - Computing **gradients** of any function of the evolved quantum state with respect to any parameter of the Hamiltonian, jump operators, or initial state.
+- Implementing your own solvers with ease by subclassing our base solver class and focusing directly on the solver logic.
+- Enjoy reading our carefully crafted documentation on our website: <https://www.dynamiqs.org>.
 
 We hope that this library will prove beneficial to the community for e.g. simulations of large quantum systems, batched simulations of time-varying problems, gradient-based parameter estimation, or large-scale quantum optimal control.
 
@@ -46,7 +48,7 @@ omega = 1.0  # frequency
 kappa = 0.1  # decay rate
 alpha = 1.0  # initial coherent state amplitude
 
-# initialize operators, state and saving times
+# initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
@@ -80,8 +82,8 @@ kappa = 0.1  # decay rate
 alpha = 1.0  # initial coherent state amplitude
 
 def population(omega, kappa, alpha):
-    """Return the population inside the cavity after time evolution."""
-    # initialize operators, state and saving times
+    """Return the oscillator population after time evolution."""
+    # initialize operators, initial state and saving times
     a = dq.destroy(n)
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
@@ -91,16 +93,20 @@ def population(omega, kappa, alpha):
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)
 
-    return dq.expect(dq.dag(a) @ a, result.states[-1]).real
+    return dq.expect(dq.number(n), result.states[-1]).real
 
 # compute gradient with respect to kappa and alpha
-grad_population = jax.grad(population, argnums=(1, 2))
-print(grad_population(omega, kappa, alpha))
+grad_population = jax.grad(population, argnums=(0, 1, 2))
+grads = grad_population(omega, kappa, alpha)
+print(f'Gradient w.r.t. omega={grads[0]:.2f}')
+print(f'Gradient w.r.t. kappa={grads[1]:.2f}')
+print(f'Gradient w.r.t. alpha={grads[2]:.2f}')
 ```
 
 ```text
-(Array(-0.90483725, dtype=float32, weak_type=True), Array(1.8096755, dtype=float32, weak_type=True))
-
+Gradient w.r.t. omega=0.00
+Gradient w.r.t. kappa=-0.90
+Gradient w.r.t. alpha=1.81
 ```
 
 ## Let's talk!

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ States  : Array complex64 (101, 128, 128) | 12.62 Mb
 
 ### Compute gradients with respect to some parameters
 
-Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha$. For this computation, we will define the objects with dynamiqs:
+Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha$.
 
 ```python
 import dynamiqs as dq
@@ -95,7 +95,7 @@ def population(omega, kappa, alpha):
 
     return dq.expect(dq.number(n), result.states[-1]).real
 
-# compute gradient with respect to kappa and alpha
+# compute gradient with respect to omega, kappa and alpha
 grad_population = jax.grad(population, argnums=(0, 1, 2))
 grads = grad_population(omega, kappa, alpha)
 print(f'Gradient w.r.t. omega={grads[0]:.2f}')

--- a/docs/getting_started/examples.md
+++ b/docs/getting_started/examples.md
@@ -4,29 +4,24 @@ First time using dynamiqs? Below are a few basic examples to help you get starte
 
 ## Simulate a lossy quantum harmonic oscillator
 
-This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$ using QuTiP-defined objects:
+This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$.
 
 ```python
 import dynamiqs as dq
-import numpy as np
-import qutip as qt
-import torch
+import jax.numpy as jnp
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128      # Hilbert space dimension
+omega = 1.0  # frequency
+kappa = 0.1  # decay rate
+alpha = 1.0  # initial coherent state amplitude
 
-# QuTiP operators, initial state and saving times
-a = qt.destroy(n)
-H = omega * a.dag() * a
-jump_ops = [np.sqrt(kappa) * a]
-psi0 = qt.coherent(n, alpha0)
-tsave = np.linspace(0, 1.0, 101)
-
-# run on GPU if available, otherwise on CPU
-torch.set_default_device('cuda' if torch.cuda.is_available() else 'cpu')
+# initialize operators, state and saving times
+a = dq.destroy(n)
+H = omega * dq.dag(a) @ a
+jump_ops = [jnp.sqrt(kappa) * a]
+psi0 = dq.coherent(n, alpha)
+tsave = jnp.linspace(0, 1.0, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -34,54 +29,45 @@ print(result)
 ```
 
 ```text
-|██████████| 100.0% - time 00:00/00:00
 ==== Result ====
-Method       : Dopri5
-Start        : 2023-09-10 16:57:34
-End          : 2023-09-10 16:57:35
-Total time   : 0.48 s
-states       : Tensor (101, 128, 128) | 12.62 Mb
+Solver  : Tsit5
+States  : Array complex64 (101, 128, 128) | 12.62 Mb
 ```
 
 ## Compute gradients with respect to some parameters
 
-Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha_0$. For this computation, we will define the objects with dynamiqs:
+Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha$. For this computation, we will define the objects with dynamiqs:
 
 ```python
 import dynamiqs as dq
-import torch
+import jax.numpy as jnp
+import jax
 
 # parameters
-n = 128
-omega = 1.0
-kappa = torch.tensor([0.1], requires_grad=True)
-alpha0 = torch.tensor([1.0], requires_grad=True)
+n = 128      # Hilbert space dimension
+omega = 1.0  # frequency
+kappa = 0.1  # decay rate
+alpha = 1.0  # initial coherent state amplitude
 
-# dynamiqs operators, initial state and saving times
-a = dq.destroy(n)
-H = omega * dq.dag(a) @ a
-jump_ops = [torch.sqrt(kappa) * a]
-psi0 = dq.coherent(n, alpha0)
-tsave = torch.linspace(0, 1.0, 101)
+def population(omega, kappa, alpha):
+    """Return the population inside the cavity after time evolution."""
+    # initialize operators, state and saving times
+    a = dq.destroy(n)
+    H = omega * dq.dag(a) @ a
+    jump_ops = [jnp.sqrt(kappa) * a]
+    psi0 = dq.coherent(n, alpha)
+    tsave = jnp.linspace(0, 1.0, 101)
 
-# run on GPU if available, otherwise on CPU
-torch.set_default_device('cuda' if torch.cuda.is_available() else 'cpu')
+    # run simulation
+    result = dq.mesolve(H, jump_ops, psi0, tsave)
 
-# run simulation
-result = dq.mesolve(
-    H, jump_ops, psi0, tsave,
-    gradient=dq.gradient.Autograd(),
-    options=dict(verbose=False),
-)
+    return dq.expect(dq.dag(a) @ a, result.states[-1]).real
 
-# gradient computation
-loss = dq.expect(dq.dag(a) @ a, result.states[-1]).real
-loss.backward()
-print(kappa.grad)
-print(alpha0.grad)
+# compute gradient with respect to kappa and alpha
+grad_population = jax.grad(population, argnums=(1, 2))
+print(grad_population(omega, kappa, alpha))
 ```
 
 ```text
-tensor([-0.9048])
-tensor([1.8097])
+(Array(-0.90483725, dtype=float32, weak_type=True), Array(1.8096755, dtype=float32, weak_type=True))
 ```

--- a/docs/getting_started/examples.md
+++ b/docs/getting_started/examples.md
@@ -16,7 +16,7 @@ omega = 1.0  # frequency
 kappa = 0.1  # decay rate
 alpha = 1.0  # initial coherent state amplitude
 
-# initialize operators, state and saving times
+# initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
@@ -50,8 +50,8 @@ kappa = 0.1  # decay rate
 alpha = 1.0  # initial coherent state amplitude
 
 def population(omega, kappa, alpha):
-    """Return the population inside the cavity after time evolution."""
-    # initialize operators, state and saving times
+    """Return the oscillator population after time evolution."""
+    # initialize operators, initial state and saving times
     a = dq.destroy(n)
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
@@ -61,13 +61,18 @@ def population(omega, kappa, alpha):
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)
 
-    return dq.expect(dq.dag(a) @ a, result.states[-1]).real
+    return dq.expect(dq.number(n), result.states[-1]).real
 
 # compute gradient with respect to kappa and alpha
-grad_population = jax.grad(population, argnums=(1, 2))
-print(grad_population(omega, kappa, alpha))
+grad_population = jax.grad(population, argnums=(0, 1, 2))
+grads = grad_population(omega, kappa, alpha)
+print(f'Gradient w.r.t. omega={grads[0]:.2f}')
+print(f'Gradient w.r.t. kappa={grads[1]:.2f}')
+print(f'Gradient w.r.t. alpha={grads[2]:.2f}')
 ```
 
 ```text
-(Array(-0.90483725, dtype=float32, weak_type=True), Array(1.8096755, dtype=float32, weak_type=True))
+Gradient w.r.t. omega=0.00
+Gradient w.r.t. kappa=-0.90
+Gradient w.r.t. alpha=1.81
 ```

--- a/docs/getting_started/examples.md
+++ b/docs/getting_started/examples.md
@@ -36,7 +36,7 @@ States  : Array complex64 (101, 128, 128) | 12.62 Mb
 
 ## Compute gradients with respect to some parameters
 
-Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha$. For this computation, we will define the objects with dynamiqs:
+Suppose that in the above example, we want to compute the gradient of the number of photons in the final state, $\bar{n} = \mathrm{Tr}[a^\dagger a \rho(t_f)]$, with respect to the decay rate $\kappa$ and the initial coherent state amplitude $\alpha$.
 
 ```python
 import dynamiqs as dq
@@ -63,7 +63,7 @@ def population(omega, kappa, alpha):
 
     return dq.expect(dq.number(n), result.states[-1]).real
 
-# compute gradient with respect to kappa and alpha
+# compute gradient with respect to omega, kappa and alpha
 grad_population = jax.grad(population, argnums=(0, 1, 2))
 grads = grad_population(omega, kappa, alpha)
 print(f'Gradient w.r.t. omega={grads[0]:.2f}')

--- a/docs/getting_started/sharp-bits.md
+++ b/docs/getting_started/sharp-bits.md
@@ -20,11 +20,12 @@ In QuTiP, adding a scalar to a `QObj` performs an implicit multiplication of the
 >>> I = dq.eye(2)
 >>> sz = dq.sigmaz()
 >>> sz - 2 * I  # correct
-tensor([[-1.+0.j,  0.+0.j],
-        [ 0.+0.j, -3.+0.j]])
+Array([[-1.+0.j,  0.+0.j],
+       [ 0.+0.j, -3.+0.j]], dtype=complex64)
+
 >>> sz - 2  # incorrect
-tensor([[-1.+0.j, -2.+0.j],
-        [-2.+0.j, -3.+0.j]])
+Array([[-1.+0.j, -2.+0.j],
+       [-2.+0.j, -3.+0.j]], dtype=complex64)
 ```
 
 ### Multiplying two operators
@@ -34,22 +35,22 @@ In QuTiP, the `*` symbol is used to multiply two operators. This convention also
 ```pycon
 >>> sx = dq.sigmax()
 >>> sx @ sx  # correct
-tensor([[1.+0.j, 0.+0.j],
-        [0.+0.j, 1.+0.j]])
+Array([[1.+0.j, 0.+0.j],
+       [0.+0.j, 1.+0.j]], dtype=complex64)
 >>> sx * sx  # incorrect
-tensor([[0.+0.j, 1.+0.j],
-        [1.+0.j, 0.+0.j]])
+Array([[0.+0.j, 1.+0.j],
+       [1.+0.j, 0.+0.j]], dtype=complex64)
 ```
 
 Likewise, you should use `dq.mpow()` instead of `**` (element-wise power) to compute the power of a matrix:
 
 ```pycon
 >>> dq.mpow(sx, 2)  # correct
-tensor([[1.+0.j, 0.+0.j],
-        [0.+0.j, 1.+0.j]])
+Array([[1.+0.j, 0.+0.j],
+       [0.+0.j, 1.+0.j]], dtype=complex64)
 >>> sx**2  # incorrect
-tensor([[0.+0.j, 1.+0.j],
-        [1.+0.j, 0.+0.j]])
+Array([[0.+0.j, 1.+0.j],
+       [1.+0.j, 0.+0.j]], dtype=complex64)
 ```
 
 ### Computing the adjoint

--- a/docs/getting_started/sharp-bits.md
+++ b/docs/getting_started/sharp-bits.md
@@ -14,7 +14,7 @@ The syntax in dynamiqs is similar to [QuTiP](http://qutip.org/), a popular Pytho
 
 ### Adding a scalar to an operator
 
-In QuTiP, adding a scalar to a `QObj` performs an implicit multiplication of the scalar with the identity matrix. This convention differs from the one adopted by common scientific libraries such as NumPy, PyTorch, SciPy or JAX. In dynamiqs, adding a scalar to an array performs an element-wise addition. To achieve the same result as in QuTiP, you must **explicitly multiply the scalar with the identity matrix**:
+In QuTiP, adding a scalar to a `QObj` performs an implicit multiplication of the scalar with the identity matrix. This convention differs from the one adopted by common scientific libraries such as NumPy, PyTorch or JAX. In dynamiqs, adding a scalar to an array performs an element-wise addition. To achieve the same result as in QuTiP, you must **explicitly multiply the scalar with the identity matrix**:
 
 ```pycon
 >>> I = dq.eye(2)

--- a/docs/getting_started/sharp-bits.md
+++ b/docs/getting_started/sharp-bits.md
@@ -2,11 +2,8 @@
 
 This page highlight common pitfalls that users may encounter when learning to use dynamiqs.
 
-In dynamiqs we use PyTorch tensors to represent quantum states and operators. A PyTorch tensor is very similar to a NumPy array, and most NumPy functions have a PyTorch equivalent. However, PyTorch tensors can be stored on GPU, and can be attached to a *computation graph* to compute gradients. This makes them very powerful, but also introduces some subtleties that you should be aware of.
-
 ```python
 import dynamiqs as dq
-import torch
 ```
 
 ## Main differences with QuTiP
@@ -17,7 +14,7 @@ The syntax in dynamiqs is similar to [QuTiP](http://qutip.org/), a popular Pytho
 
 ### Adding a scalar to an operator
 
-In QuTiP, adding a scalar to a `QObj` performs an implicit multiplication of the scalar with the identity matrix. This convention differs from the one adopted by common scientific libraries such as NumPy and PyTorch. In dynamiqs, adding a scalar to a tensor performs an element-wise addition. To achieve the same result as in QuTiP, you must **explicitly multiply the scalar with the identity matrix**:
+In QuTiP, adding a scalar to a `QObj` performs an implicit multiplication of the scalar with the identity matrix. This convention differs from the one adopted by common scientific libraries such as NumPy, PyTorch, SciPy or JAX. In dynamiqs, adding a scalar to a tensor performs an element-wise addition. To achieve the same result as in QuTiP, you must **explicitly multiply the scalar with the identity matrix**:
 
 ```pycon
 >>> I = dq.eye(2)
@@ -57,34 +54,11 @@ tensor([[0.+0.j, 1.+0.j],
 
 ### Computing the adjoint
 
-Use `dq.dag(x)`, `x.mH` or `x.adjoint()` instead of `x.dag()` to get the hermitian conjugate of `x`.
+Use `dq.dag(x)` or `x.T.conj()` instead of `x.dag()` to get the hermitian conjugate of `x`.
 
 ??? Note "Why is there no `.dag()` method in dynamiqs?"
-    To guarantee optimum performances and straightforward compatibility with the PyTorch ecosystem, dynamiqs does not subclass PyTorch tensors. As a consequence, we can't define a custom `.dag()` method on tensors.
+    To guarantee optimum performances and straightforward compatibility with the JAX ecosystem, dynamiqs does not subclass JAX arrays. As a consequence, we can't define a custom `.dag()` method on tensors. Note that this will possibly change in the future, as we are working on an extension that will allow defining custom methods on arrays.
 
-## Use a NumPy function
-
-A PyTorch tensor bears a strong resemblance to a NumPy array, and they support similar methods, but they are not interchangeable. If you need to apply a NumPy function to a tensor, you must first convert it to a NumPy array using `x.numpy()`.
-
-!!! Warning
-    There are two situations when you should not convert a tensor to a NumPy array:
-
-    - **If you run the simulation on a GPU**: the conversion will move the tensor to the CPU, which might heavily slow down your computation.
-    - **If you need to compute gradients**: the conversion will detach the tensor from the computation graph, which will prevent you from computing gradients.
-
-    Remember that you should solely use PyTorch functions if you use a GPU or compute gradients.
-
-    If in any case you're sure that you want to perform the conversion, use `x.numpy(force=True)` to detach the tensor from the computation graph, move it to the CPU and convert it to a NumPy array.
-
-## RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn
-
-This error is raised when you try to compute gradients with respect to a tensor that is not attached to the computation graph. There are a few common situations when you can encounter this error:
-
-- You forgot to specify the gradient algorithm, it must be explicitely specified in [`dq.sesolve()`](../python_api/solvers/sesolve.md), [`dq.mesolve()`](../python_api/solvers/mesolve.md) or [`dq.smesolve()`](../python_api/solvers/smesolve.md) using the `gradient` argument, for example with `gradient=dq.gradient.Autograd()` to use PyTorch autograd library.
-- You forgot to set `requires_grad=True` on the parameters with respect to which you want to compute the gradient.
-- You converted a tensor to a NumPy array at some point in the computation (see the previous section [Use a NumPy function](#use-a-numpy-function)).
-
-See the [Computing gradients](/tutorials/computing-gradients.html) tutorial for more details on how to compute gradients with dynamiqs.
 
 ## Using a for loop
 

--- a/docs/getting_started/sharp-bits.md
+++ b/docs/getting_started/sharp-bits.md
@@ -14,7 +14,7 @@ The syntax in dynamiqs is similar to [QuTiP](http://qutip.org/), a popular Pytho
 
 ### Adding a scalar to an operator
 
-In QuTiP, adding a scalar to a `QObj` performs an implicit multiplication of the scalar with the identity matrix. This convention differs from the one adopted by common scientific libraries such as NumPy, PyTorch, SciPy or JAX. In dynamiqs, adding a scalar to a tensor performs an element-wise addition. To achieve the same result as in QuTiP, you must **explicitly multiply the scalar with the identity matrix**:
+In QuTiP, adding a scalar to a `QObj` performs an implicit multiplication of the scalar with the identity matrix. This convention differs from the one adopted by common scientific libraries such as NumPy, PyTorch, SciPy or JAX. In dynamiqs, adding a scalar to an array performs an element-wise addition. To achieve the same result as in QuTiP, you must **explicitly multiply the scalar with the identity matrix**:
 
 ```pycon
 >>> I = dq.eye(2)
@@ -55,10 +55,10 @@ Array([[0.+0.j, 1.+0.j],
 
 ### Computing the adjoint
 
-Use `dq.dag(x)` or `x.T.conj()` instead of `x.dag()` to get the hermitian conjugate of `x`.
+Use `dq.dag(x)` or `x.mT.conj()` instead of `x.dag()` to get the hermitian conjugate of `x`.
 
 ??? Note "Why is there no `.dag()` method in dynamiqs?"
-    To guarantee optimum performances and straightforward compatibility with the JAX ecosystem, dynamiqs does not subclass JAX arrays. As a consequence, we can't define a custom `.dag()` method on tensors. Note that this will possibly change in the future, as we are working on an extension that will allow defining custom methods on arrays.
+    To guarantee optimum performances and straightforward compatibility with the JAX ecosystem, dynamiqs does not subclass JAX arrays. As a consequence, we can't define a custom `.dag()` method on arrays. Note that this will possibly change in the future, as we are working on an extension that will allow defining custom methods on arrays.
 
 
 ## Using a for loop

--- a/docs/getting_started/whatis.md
+++ b/docs/getting_started/whatis.md
@@ -9,7 +9,7 @@ The **dynamiqs** library enables GPU simulation of large quantum systems, and co
 
 Some exciting features of dynamiqs include:
 
-- Running simulations on **GPUs**, with a significant speedup for large Hilbert space dimensions.
+- Running simulations on **GPUs** and **TPUs**, with a significant speedup for large Hilbert space dimensions.
 - **Batching** many simulations of different Hamiltonians, jump operators or initial states to run them concurrently.
 - Exploring solvers **tailored to quantum** simulations that preserve the properties of the state, such as trace and positivity.
 - Computing **gradients** of any function of the evolved quantum state with respect to any parameter of the Hamiltonian, jump operators, or initial state.

--- a/docs/getting_started/whatis.md
+++ b/docs/getting_started/whatis.md
@@ -1,8 +1,8 @@
 # What is dynamiqs ?
 
-dynamiqs is a high-performance quantum systems simulation library based on PyTorch.
+dynamiqs is a high-performance quantum systems simulation library based on JAX.
 
-The **dynamiqs** library enables GPU simulation of large quantum systems, and computation of gradients based on the evolved quantum state. Differentiable solvers are available for the Schrödinger equation, the Lindblad master equation, and the stochastic master equation. The library is fully built on PyTorch and can efficiently run on CPUs and GPUs.
+The **dynamiqs** library enables GPU simulation of large quantum systems, and computation of gradients based on the evolved quantum state. Differentiable solvers are available for the Schrödinger equation, the Lindblad master equation, and the stochastic master equation. The library is fully built on JAX and can efficiently run on CPUs and GPUs.
 
 !!! Warning
     This library is under active development and while the APIs and solvers are still finding their footing, we're working hard to make it worth the wait. Check back soon for the grand opening!
@@ -13,7 +13,5 @@ Some exciting features of dynamiqs include:
 - **Batching** many simulations of different Hamiltonians, jump operators or initial states to run them concurrently.
 - Exploring solvers **tailored to quantum** simulations that preserve the properties of the state, such as trace and positivity.
 - Computing **gradients** of any function of the evolved quantum state with respect to any parameter of the Hamiltonian, jump operators, or initial state.
-- Using the library as a drop-in replacement for [QuTiP](https://qutip.org/) by directly passing QuTiP-defined quantum objects to our solvers.
-- Implementing your own solvers with ease by subclassing our base solver class and focusing directly on the solver logic.
 
-We hope that this library will prove beneficial to the community for e.g. simulations of large quantum systems, gradient-based parameter estimation, or large-scale quantum optimal control.
+We hope that this library will prove beneficial to the community for e.g. simulations of large quantum systems, batched simulations of time-varying problems, gradient-based parameter estimation, or large-scale quantum optimal control.

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -56,7 +56,7 @@
             GPU Accelerated
         </h3>
         <p>
-            Transition seamlessly between CPU and GPU simulations, and run batches of simulations at once.
+            Transition seamlessly between CPU, GPU and TPU simulations, and run batches of simulations at once.
         </p>
         <p>
             <a href="../getting_started/index.html">

--- a/docs/overrides/home.html
+++ b/docs/overrides/home.html
@@ -16,7 +16,7 @@
         </div>
         <div class="tx-hero__content">
           <h1> dynamiqs </h1>
-          <p>High-performance quantum systems simulation with PyTorch.</p>
+          <p>High-performance quantum systems simulation with JAX.</p>
           <a href="{{ page.next_page.url | url }}" title="{{ page.next_page.title | striptags }}" class="md-button md-button--primary">
             Get started
           </a>
@@ -56,7 +56,7 @@
             GPU Accelerated
         </h3>
         <p>
-            Transition seamlessly between CPU and GPU simulations, and run batches of simulations in one go.
+            Transition seamlessly between CPU and GPU simulations, and run batches of simulations at once.
         </p>
         <p>
             <a href="../getting_started/index.html">
@@ -66,14 +66,14 @@
     </div>
     <div class="feature-item">
         <h3>
-            Built on PyTorch
+            Built on JAX
         </h3>
         <p>
-            Benefit from the PyTorch ecosystem, built for both researchers and industry players.
+            Benefit from the JAX ecosystem, built for both high-performance numerical computing and machine learning.
         </p>
         <p>
-            <a href="https://pytorch.org/docs/stable/index.html">
-                PyTorch Documentation
+            <a href="https://jax.readthedocs.io/en/latest/">
+                JAX documentation
             </a>
         </p>
     </div>

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -1,17 +1,16 @@
 # Batching simulations
 
-Batching can be used to **run multiple independent simulations simultaneously**, and can dramatically speedup simulations, especially on GPUs. In this tutorial, we explain how to batch quantum simulations in dynamiqs.
+Batching can be used to **run multiple independent simulations simultaneously**, and can dramatically speedup simulations, especially on GPU/TPUs. In this tutorial, we explain how to batch quantum simulations in dynamiqs.
 
 ```python
-import torch
 import dynamiqs as dq
+import jax.numpy as jnp
 import timeit
-from math import pi, sqrt
 ```
 
 ## Batching in dynamiqs
 
-To simulate multiple Hamiltonians, you can pass a list of Hamiltonians for the argument `H` to [`dq.sesolve()`](../python_api/solvers/sesolve.md), [`dq.mesolve()`](../python_api/solvers/mesolve.md) or [`dq.smesolve()`](../python_api/solvers/smesolve.md). You can also pass a list of initial states for the argument `psi0` (or `rho0` for open systems) to simulate multiple initial states. In this case, we say that the simulation is *batched*.
+To simulate multiple Hamiltonians, you can pass an array of Hamiltonians for the argument `H` to [`dq.sesolve()`](../python_api/solvers/sesolve.md), [`dq.mesolve()`](../python_api/solvers/mesolve.md) or [`dq.smesolve()`](../python_api/solvers/smesolve.md). You can also pass an array of initial states for the argument `psi0` (or `rho0` for open systems) to simulate multiple initial states. In this case, we say that the simulation is *batched*.
 
 !!! Note "Result of a batched simulation"
     When a simulation is batched in dynamiqs, the result of the simulation is a batched tensor (a multi-dimensional array) that contains all the individual simulations results. The resulting `states` object has shape `(bH?, bstate?, nt, n, m)` where
@@ -32,47 +31,49 @@ g = dq.fock(2, 0)
 e = dq.fock(2, 1)
 plus = dq.unit(g + e)
 minus = dq.unit(g - e)
-psi0 = [g, e, plus, minus]  # shape (4, 2, 1)
+psi0 = jnp.stack([g, e, plus, minus])  # shape (4, 2, 1)
 
 H = dq.sigmaz()
-tsave = torch.linspace(0, 1, 11)  # shape (11)
+tsave = jnp.linspace(0, 1, 11)  # shape (11)
 exp_ops = [dq.sigmaz()]  # shape (1, 2, 2)
 result = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops)
+print(result)
 ```
 
-```pycon
->>> result.states.shape
-torch.Size([4, 11, 2, 1])
+```
+==== Result ====
+Solver  : Tsit5
+States  : Array complex64 (4, 11, 2, 1) | 0.69 Kb
+Expects : Array complex64 (4, 1, 11) | 0.34 Kb
 ```
 
 The returned `states` Tensor has shape `(4, 11, 2, 1)` where `4` is the number of initial states, `11` is the number of saved states (the length of `tsave`) and `(2, 1)` is the shape of a single state.
 
-```pycon
->>> result.expects.shape
-torch.Size([4, 1, 11])
-```
-
 Similarly, `expects` has shape `(4, 1, 11)` where `4` is the number of initial states, `1` is the number of `exp_ops` operators (a single one here) and `11` is the number of saved expectation values (the length of `tsave`).
 
-!!! Note "Creating a batched tensor with PyTorch"
-    To directly create a batched PyTorch tensor, use `torch.stack`:
+
+!!! Note "Creating a batched tensor with JAX"
+    To directly create a batched JAX tensor, use `jnp.stack`:
 
     ```python
     H0 = dq.sigmaz()
     H1 = dq.sigmax()
-    H = torch.stack([H0 + 0.1 * H1, H0 + 0.2 * H1, H0 + 0.3 * H1])  # shape (3, 2, 2)
+    H = jnp.stack([H0 + 0.1 * H1, H0 + 0.2 * H1, H0 + 0.3 * H1])  # shape (3, 2, 2)
     ```
 
-    or PyTorch broadcasting semantics:
+    or JAX broadcasting semantics:
 
     ```python
-    amplitudes = torch.linspace(0.1, 0.3, 3)
+    amplitudes = jnp.linspace(0.1, 0.3, 3)
     H = H0 + amplitudes[:, None, None] * H1  # shape (3, 2, 2)
     ```
 
+<!-- skip until smesolve is written again
 ## Batching over stochastic trajectories (SME)
 
 For the diffusive stochastic master equation solver, many stochastic trajectories must often be solved to obtain faithful statistics of the evolved density matrix. In this case, dynamiqs also provides batching over trajectories to run them simultaneously. This is performed automatically by setting the value of the `ntrajs` argument in [`dq.smesolve()`](../python_api/solvers/smesolve.md). The resulting `states` object has shape `(bH?, brho?, ntrajs, nt, n, n)`.
+
+-->
 
 ## Why batching?
 
@@ -91,30 +92,28 @@ Let's quickly benchmark the speedup obtained by batching a simple simulation:
 n = 16
 
 # Hamiltonians
-amplitudes = torch.linspace(-1, 1, 11)
+amplitudes = jnp.linspace(-1, 1, 11)
 a = dq.destroy(n)
-H = amplitudes[:, None, None] * (a + a.mH)  # shape (11, 16, 16)
+H = amplitudes[:, None, None] * (a + dq.dag(a))  # shape (11, 16, 16)
 
 # jump operator
-jump_ops = [sqrt(0.1) * a]
+jump_ops = [jnp.sqrt(0.1) * a]
 
 # initial states
-angles = torch.linspace(0, 2 * pi, 11)
-alphas = 2.0 * torch.exp(1j * angles)
-rho0 = torch.stack([dq.coherent_dm(n, a) for a in alphas])  # shape (11, 16, 16)
+angles = jnp.linspace(0, 2 * pi, 11)
+alphas = 2.0 * jnp.exp(1j * angles)
+rho0 = jnp.stack([dq.coherent_dm(n, a) for a in alphas])  # shape (11, 16, 16)
 
 # time vector
-tsave = torch.linspace(0, 1, 11)
+tsave = jnp.linspace(0, 1, 11)
 
-def run_unbatched(device):
-    options=dict(device=device, verbose=False)
+def run_unbatched():
     for i in range(H.shape[0]):
         for j in range(rho0.shape[0]):
-            dq.mesolve(H[i], jump_ops, rho0[j], tsave, options=options)
+            dq.mesolve(H[i], jump_ops, rho0[j], tsave)
 
-def run_batched(device):
-    options=dict(device=device, verbose=False)
-    dq.mesolve(H, jump_ops, rho0, tsave, options=options)
+def run_batched():
+    dq.mesolve(H, jump_ops, rho0, tsave)
 ```
 
 So we want to run a total of `11 * 11 = 121` simulations. Let's compare how long it takes to run them unbatched vs batched on CPU[^1]:
@@ -124,23 +123,23 @@ So we want to run a total of `11 * 11 = 121` simulations. Let's compare how long
 
 ```pycon
 >>> %timeit run_unbatched('cpu')
-1.78 s ± 184 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+119 ms ± 9.18 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 >>> %timeit run_batched('cpu')
-284 ms ± 129 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+56.5 ms ± 539 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
 ```
 
-Even with this simple example, we gain a **factor x6** in speedup just from batching.
+Even with this simple example, we gain a **factor x2** in speedup just from batching.
 
 The result is even more striking on GPU[^2]:
 [^2]: NVIDIA GeForce RTX 4090.
 
 ```pycon
 >>> %timeit run_unbatched('cuda')
-1.51 s ± 1.98 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
+439 ms ± 692 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
 >>> %timeit run_batched('cuda')
-20.1 ms ± 78.7 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
+6.29 ms ± 160 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
 ```
 
-On the GPU, because we save costly data transfers with the CPU and do N-D matrices multiplications, we gain a **factor x75** in speedup!
+On the GPU, because we save costly data transfers with the CPU and do N-D matrices multiplications, we gain a **factor x70** in speedup!
 
 <!-- skip: end -->

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -100,7 +100,7 @@ H = amplitudes[:, None, None] * (a + dq.dag(a))  # shape (11, 16, 16)
 jump_ops = [jnp.sqrt(0.1) * a]
 
 # initial states
-angles = jnp.linspace(0, 2 * pi, 11)
+angles = jnp.linspace(0, 2 * jnp.pi, 11)
 alphas = 2.0 * jnp.exp(1j * angles)
 rho0 = jnp.stack([dq.coherent_dm(n, a) for a in alphas])  # shape (11, 16, 16)
 
@@ -122,9 +122,9 @@ So we want to run a total of `11 * 11 = 121` simulations. Let's compare how long
 <!-- skip: start -->
 
 ```pycon
->>> %timeit run_unbatched('cpu')
+>>> %timeit run_unbatched()
 119 ms ± 9.18 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
->>> %timeit run_batched('cpu')
+>>> %timeit run_batched()
 56.5 ms ± 539 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
 ```
 
@@ -134,9 +134,9 @@ The result is even more striking on GPU[^2]:
 [^2]: NVIDIA GeForce RTX 4090.
 
 ```pycon
->>> %timeit run_unbatched('cuda')
+>>> %timeit run_unbatched()
 439 ms ± 692 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
->>> %timeit run_batched('cuda')
+>>> %timeit run_batched()
 6.29 ms ± 160 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
 ```
 

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -47,7 +47,7 @@ States  : Array complex64 (4, 11, 2, 1) | 0.69 Kb
 Expects : Array complex64 (4, 1, 11) | 0.34 Kb
 ```
 
-The returned `states` Array has shape `(4, 11, 2, 1)` where `4` is the number of initial states, `11` is the number of saved states (the length of `tsave`) and `(2, 1)` is the shape of a single state.
+The returned `states` array has shape `(4, 11, 2, 1)` where `4` is the number of initial states, `11` is the number of saved states (the length of `tsave`) and `(2, 1)` is the shape of a single state.
 
 Similarly, `expects` has shape `(4, 1, 11)` where `4` is the number of initial states, `1` is the number of `exp_ops` operators (a single one here) and `11` is the number of saved expectation values (the length of `tsave`).
 

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -68,7 +68,7 @@ Similarly, `expects` has shape `(4, 1, 11)` where `4` is the number of initial s
     H = H0 + amplitudes[:, None, None] * H1  # shape (3, 2, 2)
     ```
 
-<!-- skip until smesolve is written again
+<!-- remove until smesolve is written again
 ## Batching over stochastic trajectories (SME)
 
 For the diffusive stochastic master equation solver, many stochastic trajectories must often be solved to obtain faithful statistics of the evolved density matrix. In this case, dynamiqs also provides batching over trajectories to run them simultaneously. This is performed automatically by setting the value of the `ntrajs` argument in [`dq.smesolve()`](../python_api/solvers/smesolve.md). The resulting `states` object has shape `(bH?, brho?, ntrajs, nt, n, n)`.

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -13,7 +13,7 @@ import timeit
 To simulate multiple Hamiltonians, you can pass an array of Hamiltonians for the argument `H` to [`dq.sesolve()`](../python_api/solvers/sesolve.md), [`dq.mesolve()`](../python_api/solvers/mesolve.md) or [`dq.smesolve()`](../python_api/solvers/smesolve.md). You can also pass an array of initial states for the argument `psi0` (or `rho0` for open systems) to simulate multiple initial states. In this case, we say that the simulation is *batched*.
 
 !!! Note "Result of a batched simulation"
-    When a simulation is batched in dynamiqs, the result of the simulation is a batched tensor (a multi-dimensional array) that contains all the individual simulations results. The resulting `states` object has shape `(bH?, bstate?, nt, n, m)` where
+    When a simulation is batched in dynamiqs, the result of the simulation is a batched array (a multi-dimensional array) that contains all the individual simulations results. The resulting `states` object has shape `(bH?, bstate?, nt, n, m)` where
 
     - `bH` is the number of Hamiltonians,
     - `bstate` is the number of initial states,
@@ -47,13 +47,13 @@ States  : Array complex64 (4, 11, 2, 1) | 0.69 Kb
 Expects : Array complex64 (4, 1, 11) | 0.34 Kb
 ```
 
-The returned `states` Tensor has shape `(4, 11, 2, 1)` where `4` is the number of initial states, `11` is the number of saved states (the length of `tsave`) and `(2, 1)` is the shape of a single state.
+The returned `states` Array has shape `(4, 11, 2, 1)` where `4` is the number of initial states, `11` is the number of saved states (the length of `tsave`) and `(2, 1)` is the shape of a single state.
 
 Similarly, `expects` has shape `(4, 1, 11)` where `4` is the number of initial states, `1` is the number of `exp_ops` operators (a single one here) and `11` is the number of saved expectation values (the length of `tsave`).
 
 
-!!! Note "Creating a batched tensor with JAX"
-    To directly create a batched JAX tensor, use `jnp.stack`:
+!!! Note "Creating a batched array with JAX"
+    To directly create a batched JAX array, use `jnp.stack`:
 
     ```python
     H0 = dq.sigmaz()
@@ -77,7 +77,7 @@ For the diffusive stochastic master equation solver, many stochastic trajectorie
 
 ## Why batching?
 
-When batching multiple simulations, the state is not a 2-D tensor that evolves in time but a N-D tensor which holds each independent simulation. This allows running **multiple simulations simultaneously** with great efficiency, especially on GPUs. Moreover, it usually simplifies the subsequent analysis of the simulation, because all the results are gathered in a single large array.
+When batching multiple simulations, the state is not a 2-D array that evolves in time but a N-D array which holds each independent simulation. This allows running **multiple simulations simultaneously** with great efficiency, especially on GPUs. Moreover, it usually simplifies the subsequent analysis of the simulation, because all the results are gathered in a single large array.
 
 Common use cases for batching include:
 
@@ -140,6 +140,6 @@ The result is even more striking on GPU[^2]:
 6.29 ms ± 160 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)
 ```
 
-On the GPU, because we save costly data transfers with the CPU and do N-D matrices multiplications, we gain a **factor x70** in speedup!
+On the GPU, because we remove latency between function calls, we gain a **factor x70** in speedup!
 
 <!-- skip: end -->

--- a/docs/tutorials/closed-system.md
+++ b/docs/tutorials/closed-system.md
@@ -103,8 +103,8 @@ res = dq.sesolve(H, psi0, tsave)  # run the simulation
 
 ```pycon
 >>> res.states[-1]                # print the final state
-Array([[0.5402927+0.8414829j],
-       [0.       +0.j       ]], dtype=complex64)
+Array([[0.54+0.841j],
+       [0.  +0.j   ]], dtype=complex64)
 ```
 
 If you want to know more about the available solvers or the different options, head to the [`dq.sesolve()`](../python_api/solvers/sesolve.md) API documentation.

--- a/docs/tutorials/closed-system.md
+++ b/docs/tutorials/closed-system.md
@@ -89,21 +89,22 @@ There are two main types of ODE solvers:
 
 ## Using dynamiqs
 
-You can create the state and Hamiltonian using any array-like object (Python lists, NumPy arrays, QuTiP quantum objects or PyTorch tensors). Let's take the example of a two-level system with a simple Hamiltonian:
+You can create the state and Hamiltonian using any array-like object (Python lists, NumPy or JAX arrays). Let's take the example of a two-level system with a simple Hamiltonian:
 
 ```python
-import numpy as np
+import jax.numpy as jnp
 import dynamiqs as dq
-psi0 = [[1], [0]]                 # initial state
-H = [[-1, 0], [0, 1]]             # Hamiltonian
-tsave = np.linspace(0, 1.0, 11)   # saving times
+
+psi0 = jnp.array([[1], [0]])      # initial state
+H = jnp.array([[-1, 0], [0, 1]])  # Hamiltonian
+tsave = jnp.linspace(0, 1.0, 11)  # saving times
 res = dq.sesolve(H, psi0, tsave)  # run the simulation
 ```
 
 ```pycon
 >>> res.states[-1]                # print the final state
-tensor([[0.540+0.841j],
-        [0.000+0.000j]])
+Array([[0.5402927+0.8414829j],
+       [0.       +0.j       ]], dtype=complex64)
 ```
 
 If you want to know more about the available solvers or the different options, head to the [`dq.sesolve()`](../python_api/solvers/sesolve.md) API documentation.

--- a/docs/tutorials/defining-hamiltonians.md
+++ b/docs/tutorials/defining-hamiltonians.md
@@ -1,36 +1,28 @@
 # Defining Hamiltonians
 
-In this short tutorial, we explain how to define Hamiltonians in dynamiqs. There are currently three ways: using array-like objects for constant Hamiltonians, defining a function for time-dependent Hamiltonians, and using a custom list format for piecewise constant Hamiltonians.
+In this short tutorial, we explain how to define Hamiltonians in dynamiqs. There are currently four ways: using array-like objects for constant Hamiltonians, defining a function or function-like coefficients for time-dependent Hamiltonians, and using a custom format for piecewise constant Hamiltonians.
 
 !!! Warning "Differences with QuTiP"
-    dynamiqs manipulates PyTorch tensors, which are different from QuTiP quantum objects. See in [The sharp bits 🔪](/getting_started/sharp-bits.html) page the main differences, briefly:
+    dynamiqs manipulates JAX arrays, which are different from QuTiP quantum objects. See in [The sharp bits 🔪](/getting_started/sharp-bits.html) page the main differences, briefly:
 
-    - use `A + 2 * dq.eye(n)` instead of `A + 2`
-    - use `A @ B` instead of `A * B`, and `dq.mpow(A, 4)` instead of `A**4`
-    - use `dq.dag(x)`, `x.mH` or `x.adjoint()` instead of `x.dag()`
+    - use `x + 2 * dq.eye(n)` instead of `x + 2`
+    - use `x @ y` instead of `x * y`, and `dq.mpow(x, 4)` instead of `x**4`
+    - use `dq.dag(x)`, `x.T.conj()` instead of `x.dag()`
 
 ## Constant Hamiltonians
 
-A constant Hamiltonian can be defined using **array-like objects**, i.e. Python lists, NumPy arrays, QuTiP quantum objects or PyTorch tensors. In all cases, the Hamiltonian is then converted internally into a PyTorch tensor for differentiability and GPU support. It is also possible to directly use dynamiqs [utility functions](../python_api/index.md) for common Hamiltonians.
+A constant Hamiltonian can be defined using **array-like objects**, i.e. NumPy and JAX arrays. In all cases, the Hamiltonian is then converted internally into a JAX array for differentiability and GPU/TPU support. It is also possible to directly use dynamiqs [utility functions](../python_api/index.md) for common Hamiltonians.
 
 For instance, to define the Pauli Z operator $H = \sigma_z$, you can use any of the following syntaxes:
 
 ```python
-# using Python lists
-H = [[1, 0], [0, -1]]
-
 # using NumPy arrays
 import numpy as np
 H = np.array([[1, 0], [0, -1]])
 
-# using QuTiP quantum objects
-import qutip as qt
-H = qt.Qobj([[1, 0], [0, -1]])
-H = qt.sigmaz()
-
 # using PyTorch tensors
-import torch
-H = torch.tensor([[1, 0], [0, -1]])
+import jax.numpy as jnp
+H = jnp.array([[1, 0], [0, -1]])
 
 # using dynamiqs
 import dynamiqs as dq
@@ -39,24 +31,23 @@ H = dq.sigmaz()
 
 ## Time-dependent Hamiltonians
 
-A time-dependent Hamiltonian can be defined using a Python function with signature `H(t: float) -> Tensor` that returns the Hamiltonian as a PyTorch tensor for any time `t`.
+A time-dependent Hamiltonian can be defined using a Python function with signature `H(t: float, *args: ArrayLike) -> Tensor` that returns the Hamiltonian as a JAX array for any time `t`, which is then fed into `dq.totime`.
 
 For instance, to define a time-dependent Hamiltonian $H = \sigma_z + \cos(t)\sigma_x$, you can use the following syntax:
 
 ```python
-def H(t):
-    return dq.sigmaz() + torch.cos(t) * dq.sigmax()
+H = dq.totime(lambda t, *args: dq.sigmaz() + jnp.cos(t) * dq.sigmax())
 ```
 
-!!! Warning "Function returning non-tensor object"
-    An error is raised if `H(t)` return a non-tensor object, or a tensor with a different `dtype` or `device` than the ones specified to the solver. This is enforced to avoid costly type, dtype or device conversions at every time step of the numerical integration.
+!!! Warning "Function returning non-array object"
+    An error is raised if `H(t)` return a non-array object, or an array with a different `dtype` than the ones specified to the solver. This is enforced to avoid costly type or data type conversions at every time step of the numerical integration.
 
 ??? Note "Function with optional arguments"
-    To define a time-dependent Hamiltonian with additional arguments, you can use Python's lambda:
+    To define a time-dependent Hamiltonian with additional arguments, you can use the optional `args` parameter of `dq.totime`.
     ```python
-    def H_args(t, omega):
-        return dq.sigmaz() + torch.cos(omega * t) * dq.sigmax()
-    H = lambda t: H_args(t, 1.0)
+    def _H(t, omega):
+        return dq.sigmaz() + jnp.cos(omega * t) * dq.sigmax()
+    H = dq.totime(_H, args=(1.0,))
     ```
 
 ## Piecewise constant Hamiltonians

--- a/docs/tutorials/defining-hamiltonians.md
+++ b/docs/tutorials/defining-hamiltonians.md
@@ -1,13 +1,13 @@
 # Defining Hamiltonians
 
-In this short tutorial, we explain how to define Hamiltonians in dynamiqs. There are currently four ways: using array-like objects for constant Hamiltonians, defining a function or function-like coefficients for time-dependent Hamiltonians, and using a custom format for piecewise constant Hamiltonians.
+In this short tutorial, we explain how to define Hamiltonians in dynamiqs. There are currently four ways: using array-like objects for constant Hamiltonians, defining a function for time-dependent Hamiltonians, defining time-dependent coefficients as functions that precede constant Hamiltonians, or using a custom format for piecewise constant Hamiltonians.
 
 !!! Warning "Differences with QuTiP"
     dynamiqs manipulates JAX arrays, which are different from QuTiP quantum objects. See in [The sharp bits 🔪](/getting_started/sharp-bits.html) page the main differences, briefly:
 
     - use `x + 2 * dq.eye(n)` instead of `x + 2`
     - use `x @ y` instead of `x * y`, and `dq.mpow(x, 4)` instead of `x**4`
-    - use `dq.dag(x)`, `x.T.conj()` instead of `x.dag()`
+    - use `dq.dag(x)`, `x.mT.conj()` instead of `x.dag()`
 
 ## Constant Hamiltonians
 
@@ -20,7 +20,7 @@ For instance, to define the Pauli Z operator $H = \sigma_z$, you can use any of 
 import numpy as np
 H = np.array([[1, 0], [0, -1]])
 
-# using PyTorch tensors
+# using JAX arrays
 import jax.numpy as jnp
 H = jnp.array([[1, 0], [0, -1]])
 
@@ -31,7 +31,7 @@ H = dq.sigmaz()
 
 ## Time-dependent Hamiltonians
 
-A time-dependent Hamiltonian can be defined using a Python function with signature `H(t: float, *args: ArrayLike) -> Tensor` that returns the Hamiltonian as a JAX array for any time `t`, which is then fed into `dq.totime`.
+A time-dependent Hamiltonian can be defined using a Python function with signature `H(t: float, *args: ArrayLike) -> Array` that returns the Hamiltonian as a JAX array for any time `t`, which is then fed into `dq.totime`.
 
 For instance, to define a time-dependent Hamiltonian $H = \sigma_z + \cos(t)\sigma_x$, you can use the following syntax:
 

--- a/docs/tutorials/open-system.md
+++ b/docs/tutorials/open-system.md
@@ -101,7 +101,7 @@ Also called the **quantum-jump** approach.
 
 ## Using dynamiqs
 
-You can create the state, Hamiltonian and jump operators using any array-like object (Python lists, NumPy arrays, QuTiP quantum objects or PyTorch tensors). Let's take the example of a two-level system with a simple Hamiltonian and a single jump operator:
+You can create the state, Hamiltonian and jump operators using any array-like object (NumPy or JAX arrays). Let's take the example of a two-level system with a simple Hamiltonian and a single jump operator:
 
 ```python
 import jax.numpy as jnp

--- a/docs/tutorials/open-system.md
+++ b/docs/tutorials/open-system.md
@@ -104,19 +104,20 @@ Also called the **quantum-jump** approach.
 You can create the state, Hamiltonian and jump operators using any array-like object (Python lists, NumPy arrays, QuTiP quantum objects or PyTorch tensors). Let's take the example of a two-level system with a simple Hamiltonian and a single jump operator:
 
 ```python
-import numpy as np
+import jax.numpy as jnp
 import dynamiqs as dq
-rho0 = [[1, 0], [0, 0]]                     # initial state
-H = [[-1, 0], [0, 1]]                       # Hamiltonian
-jump_ops = [[[0, 0], [1, 0]]]               # list of jump operators
-tsave = np.linspace(0, 1.0, 11)             # saving times
+
+rho0 = jnp.array([[1, 0], [0, 0]])                # initial state
+H = jnp.array([[-1, 0], [0, 1]])            # Hamiltonian
+jump_ops = jnp.array([[[0, 0], [1, 0]]])    # list of jump operators
+tsave = jnp.linspace(0, 1.0, 11)            # saving times
 res = dq.mesolve(H, jump_ops, rho0, tsave)  # run the simulation
 ```
 
 ```pycon
 >>> res.states[-1]                          # print the final state
-tensor([[0.368+0.j, 0.000+0.j],
-        [0.000+0.j, 0.632+0.j]])
+Array([[0.36788338+0.j, 0.        +0.j],
+       [0.        +0.j, 0.6321166 +0.j]], dtype=complex64)
 ```
 
 If you want to know more about the available solvers or the different options, head to the [`dq.mesolve()`](../python_api/solvers/mesolve.md) API documentation.

--- a/docs/tutorials/open-system.md
+++ b/docs/tutorials/open-system.md
@@ -116,8 +116,8 @@ res = dq.mesolve(H, jump_ops, rho0, tsave)  # run the simulation
 
 ```pycon
 >>> res.states[-1]                          # print the final state
-Array([[0.36788338+0.j, 0.        +0.j],
-       [0.        +0.j, 0.6321166 +0.j]], dtype=complex64)
+Array([[0.368+0.j, 0.   +0.j],
+       [0.   +0.j, 0.632+0.j]], dtype=complex64)
 ```
 
 If you want to know more about the available solvers or the different options, head to the [`dq.mesolve()`](../python_api/solvers/mesolve.md) API documentation.

--- a/docs/tutorials/workflow.md
+++ b/docs/tutorials/workflow.md
@@ -39,11 +39,11 @@ State of type <class 'jaxlib.xla_extension.ArrayImpl'> and shape (2, 1).
 Hamiltonian of type <class 'jaxlib.xla_extension.ArrayImpl'> and shape (2, 2).
 ```
 
-In dynamiqs, all quantum objects are defined directly with [JAX arrays](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.array.html), and without subclassing. This allows for easy interfacing with JAX utility functions, and avoids runtime overheads. Also, all quantum objects have at least two dimensions to avoid systematic reshaping or coding mistakes (e.g. trying to multiply a ket and an operator in the wrong order). In particular, kets have a shape `(..., N, 1)`. Note also that objects are single-precision (`float32` or `complex64`) by default.
+In dynamiqs, all quantum objects are defined directly with [JAX arrays](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.array.html), and without subclassing. This allows for easy interfacing with JAX utility functions, and avoids runtime overheads. Also, all quantum objects have at least two dimensions to avoid systematic reshaping or coding mistakes (e.g. trying to multiply a ket and an operator in the wrong order). In particular, kets have a shape `(..., n, 1)`. Note also that objects are single-precision (`float32` or `complex64`) by default.
 
 ## 2. Define the scope
 
-Next, we define the scope of the simulation. This includes the total duration of time evolution, the observables we want to measure and how often we measure them. Observables are defined similarly to the Hamiltonian, using Tensors and dynamiqs utility functions. The total duration and how often measurements are performed is defined in a single object named `tsave`. It is an arbitrary array of time points, of which `tsave[-1]` specifies the total duration of time evolution.
+Next, we define the scope of the simulation. This includes the total duration of time evolution, the observables we want to measure and how often we measure them. Observables are defined similarly to the Hamiltonian, using arrays and dynamiqs utility functions. The total duration and how often measurements are performed is defined in a single object named `tsave`. It is an arbitrary array of time points, of which `tsave[-1]` specifies the total duration of time evolution.
 
 We also need to specify the solver and options related to it, namely the method of integration and the eventual related parameters. The list of available solvers and their parameters is available in the [API documentation](../python_api/index.md).
 

--- a/docs/tutorials/workflow.md
+++ b/docs/tutorials/workflow.md
@@ -10,15 +10,14 @@ The core of dynamiqs is to solve quantum differential equations. This tutorial g
 In the rest of this tutorial, we go over these steps in detail, taking the example of the Rabi oscillations of a two-level system.
 
 ```python
-import torch
 import dynamiqs as dq
+import jax.numpy as jnp
 import matplotlib.pyplot as plt
-from math import sqrt
 ```
 
 ## 1. Define the system
 
-After having imported the necessary packages, we can define our system, namely the initial state, the Hamiltonian, and the eventual loss operators. Common states and operators are already defined in dynamiqs, see the [API documentation](../python_api/index.md) for more details. Otherwise, you can define specific states and operators using [NumPy](https://numpy.org/) arrays, [QuTiP](http://qutip.org/) objects, or [PyTorch](https://pytorch.org/) tensors.
+After having imported the necessary packages, we can define our system, namely the initial state, the Hamiltonian, and the eventual loss operators. Common states and operators are already defined in dynamiqs, see the [API documentation](../python_api/index.md) for more details. Otherwise, you can define specific states and operators using any array-like objects, e.g. [NumPy](https://numpy.org/) or [JAX](https://jax.readthedocs.io/) arrays.
 
 Here, we will use [`dq.fock`](../python_api/utils/states/fock.md) to define the initial state $\ket{\psi_0}=\ket{0}$, [`dq.sigmaz`](../python_api/utils/operators/sigmaz.md) and [`dq.sigmax`](../python_api/utils/operators/sigmax.md) to define the Hamiltonian $H = \delta \sigma_z + \Omega \sigma_x$.
 
@@ -36,45 +35,38 @@ print(f"Hamiltonian of type {type(H)} and shape {H.shape}.")
 ```
 
 ```text
-State of type <class 'torch.Tensor'> and shape torch.Size([2, 1]).
-Hamiltonian of type <class 'torch.Tensor'> and shape torch.Size([2, 2]).
+State of type <class 'jaxlib.xla_extension.ArrayImpl'> and shape (2, 1).
+Hamiltonian of type <class 'jaxlib.xla_extension.ArrayImpl'> and shape (2, 2).
 ```
 
-In dynamiqs, all quantum objects are defined directly with PyTorch [Tensors](https://pytorch.org/docs/stable/tensors.html), and without subclassing. This allows for easy interfacing with PyTorch utility functions, and avoids runtime overheads. Also, all quantum objects have at least two dimensions to avoid systematic reshaping or coding mistakes (e.g. trying to multiply a ket and an operator in the wrong order).
-In particular, kets have a shape `(..., N, 1)`.
+In dynamiqs, all quantum objects are defined directly with [JAX arrays](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.array.html), and without subclassing. This allows for easy interfacing with JAX utility functions, and avoids runtime overheads. Also, all quantum objects have at least two dimensions to avoid systematic reshaping or coding mistakes (e.g. trying to multiply a ket and an operator in the wrong order). In particular, kets have a shape `(..., N, 1)`. Note also that objects are single-precision (`float32` or `complex64`) by default.
 
 ## 2. Define the scope
 
 Next, we define the scope of the simulation. This includes the total duration of time evolution, the observables we want to measure and how often we measure them. Observables are defined similarly to the Hamiltonian, using Tensors and dynamiqs utility functions. The total duration and how often measurements are performed is defined in a single object named `tsave`. It is an arbitrary array of time points, of which `tsave[-1]` specifies the total duration of time evolution.
 
-We also need to specify the solver and options related to it, namely the method of integration and the eventual related parameters. The list of available solvers and their parameters is available in the [API documentation](../python_api/index.md) for each quantum differential equation.
+We also need to specify the solver and options related to it, namely the method of integration and the eventual related parameters. The list of available solvers and their parameters is available in the [API documentation](../python_api/index.md).
 
 ```python
 # define sampling times
 sim_time = 10.0  # total time of evolution
 num_save = 101  # number of time slots to save
-tsave = torch.linspace(0.0, sim_time, num_save)  # (can also be a list or a numpy.array)
+tsave = jnp.linspace(0.0, sim_time, num_save)  # can also be a list or a NumPy array
 
 # define list of observables
 exp_ops = [dq.sigmaz()]  # expectation value of sigma_z
 
 # define solver (Dormand-Prince of order 5, default solver)
-solver = dq.solver.Dopri5(rtol=1e-8, atol=1e-10)
-
-# optional parameters
-options = {
-    'dtype': torch.complex64,  # data type of the computation
-    'device': 'cpu',  # device to perform the computation on
-}
+solver = dq.solver.Dopri5(rtol=1e-6, atol=1e-8)
 ```
 
 ## 3. Run the simulation
 
-We can now run the simulation. This is done by calling the [`dq.sesolve()`](../python_api/solvers/sesolve.md) function, which returns an instance of the [`Result`](../python_api/index.md) class. This object contains the computed states, the observables, and various information about the solver. It also features utility methods to convert result Tensors to NumPy arrays or QuTiP objects.
+We can now run the simulation. This is done by calling the [`dq.sesolve()`](../python_api/solvers/sesolve.md) function, which returns an instance of the [`Result`](../python_api/index.md) class. This object contains the computed states, the observables, and various information about the solver.
 
 ```python
 # run simulation
-result = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops, solver=solver, options=options)
+result = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops, solver=solver)
 
 # print some information
 print(f"`result` is of type {type(result)}.")
@@ -84,28 +76,24 @@ print(result)
 ```
 
 ```text
-|██████████| 100.0% - time 00:00/00:00
-`result` is of type <class 'dynamiqs.solvers.result.Result'>.
+`result` is of type <class 'dynamiqs.result.Result'>.
 `result` has the following attributes:
-['_options', 'end_datetime', 'end_time', 'Esave', 'expects', 'gradient', 'load', 'Lmsave', 'measurements', 'options', 'save', 'solver', 'start_datetime', 'start_time', 'states', 'times', 'tmeas', 'to_numpy', 'to_qutip', 'total_time', 'tsave', 'ysave']
+['Esave', '_abc_impl', 'expects', 'gradient', 'options', 'solver', 'states', 'to_numpy', 'to_qutip', 'tsave', 'ysave']
 
 ==== Result ====
-Solver     : Dopri5
-Start      : 2023-11-06 19:17:45
-End        : 2023-11-06 19:17:45
-Total time : 0.08 s
-States     : Tensor (100, 2, 1) | 1.56 Kb
-Expects    : Tensor (1, 100) | 0.78 Kb
+Solver  : Dopri5
+States  : Array complex64 (101, 2, 1) | 1.58 Kb
+Expects : Array complex64 (1, 101) | 0.79 Kb
 ```
 
 ## 4. Analyze the results
 
-Finally, we can analyze the results in whichever relevant way. In our example, let us plot the $\braket{\sigma_z}$ observable as a function of time. To do so, we call `result.expects[0].real` which extracts the first measured observable (here, the only one) and plot its real part (our observable is hermitian, so measurements are real-valued). We compare to the expected analytical result.
+Finally, you can analyze the results in whichever way is most relevant to your application. In our example, let us plot the $\braket{\sigma_z}$ observable as a function of time. To do so, we call `result.expects[0].real` which extracts the first measured observable (here, the only one) and plot its real part (our observable is hermitian, so measurements are real-valued). We compare to the expected analytical result.
 
 ```python
 # analytical result
-Omega_star = sqrt(delta**2 + Omega**2)  # generalized Rabi frequency
-excited_pop = Omega / Omega_star * torch.sin(tsave * Omega_star)  # excited population
+Omega_star = jnp.sqrt(delta**2 + Omega**2)  # generalized Rabi frequency
+excited_pop = Omega / Omega_star * jnp.sin(tsave * Omega_star)  # excited population
 sigmaz_analytical = 1 - 2 * excited_pop**2  # expectation value of sigma_z
 
 # plot results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,9 +96,7 @@ cmd = 'echo "\n>>> pytest dynamiqs" && rm -f docs/figs-code/*.png && pytest dyna
 help = "check code docstrings examples (doctest)"
 
 [tool.taskipy.tasks.doctest-docs]
-# todo: reactivate when the documentation is ready
-# cmd = 'echo "\n>>> pytest docs" && rm -f docs/figs-docs/*.png && pytest docs'
-cmd = 'echo "\n>>> pytest docs" && rm -f docs/figs-docs/*.png && echo "temporarily skipped"'
+cmd = 'echo "\n>>> pytest docs" && rm -f docs/figs-docs/*.png && pytest docs'
 help = "check documentation examples (doctest)"
 
 [tool.taskipy.tasks.doctest]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "dynamiqs"
 version = "0.1.0"
 requires-python = ">=3.9"
-description = "Quantum systems simulation with PyTorch."
+description = "Quantum systems simulation with JAX."
 dependencies = [
     "qutip",
     "numpy",


### PR DESCRIPTION
First pass on the documentation. Had to remove a bunch of things that are not yet supported (e.g. smesolve or QuTiP and list objects as inputs). Still need to go over the Python API, but otherwise I think it's ok-ish for now.