### PR TITLE
Fix QObjs/lists as input, and arbitrary batching over jump_ops

### DIFF
--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import get_args
-
 import jax
 import numpy as np
 from jaxtyping import ArrayLike
@@ -17,8 +15,10 @@ def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
     else:
         try:
             return _factory_constant(x)
-        except:
-            raise TypeError('Input must be already be a `TimeArray` or an array-like object.')
+        except TypeError:
+            raise TypeError(
+                'Input must be already be a `TimeArray` or an array-like object.'
+            )
 
 
 def get_solver_class(
@@ -36,22 +36,49 @@ def get_solver_class(
 def compute_vmap(
     f: callable,
     cartesian_batching: bool,
-    is_batched: list[bool],
+    is_batched: list[bool | list[bool]],
     out_axes: list[int | None],
 ) -> callable:
-    if any(is_batched):
+    is_batched_flat = flatten(is_batched)
+    if any(is_batched_flat):
         if cartesian_batching:
             # iteratively map over the first axis of each batched argument
-            idx_batched = np.where(is_batched)[0]
+            idx_batched = np.where(is_batched_flat)[0]
             # we apply the successive vmaps in reverse order, so that the output
             # batched dimensions are in the correct order
             for i in reversed(idx_batched):
-                in_axes = [None] * len(is_batched)
+                in_axes = [None] * len(is_batched_flat)
                 in_axes[i] = 0
+                # recover the original structure of the batched arguments
+                in_axes = unflatten(in_axes, is_batched)
+                # apply vmap
                 f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
         else:
             # map over the first axis of all batched arguments
-            in_axes = list(np.where(is_batched, 0, None))
+            in_axes = list(np.where(is_batched_flat, 0, None))
+            # recover the original structure of the batched arguments
+            in_axes = unflatten(in_axes, is_batched)
+            # apply vmap
             f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
 
     return f
+
+
+def flatten(lst):
+    result = []
+    for item in lst:
+        if isinstance(item, list):
+            result.extend(flatten(item))
+        else:
+            result.append(item)
+    return result
+
+
+def unflatten(flat_list, ref_list):
+    result = []
+    for item in ref_list:
+        if isinstance(item, list):
+            result.append(unflatten(flat_list, item))
+        else:
+            result.append(flat_list.pop(0))
+    return result

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -12,12 +12,13 @@ from .abstract_solver import AbstractSolver
 
 
 def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
-    if isinstance(x, get_args(ArrayLike)):
-        return _factory_constant(x)
-    elif isinstance(x, TimeArray):
+    if isinstance(x, TimeArray):
         return x
     else:
-        raise TypeError()  # todo: add error message
+        try:
+            return _factory_constant(x)
+        except:
+            raise TypeError('Input must be already be a `TimeArray` or an array-like object.')
 
 
 def get_solver_class(

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -38,11 +38,18 @@ def mesolve(
     tsave = jnp.asarray(tsave)
     exp_ops = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
 
+    # === check len(jump_ops) > 0
+    if len(jump_ops) == 0:
+        raise ValueError(
+            "At least one jump operator must be provided for `dq.mesolve`. If you don't"
+            ' need jump operators, consider using `dq.sesolve` instead.'
+        )
+
     # === vectorize function
     # we vectorize over H, jump_ops and rho0, all other arguments are not vectorized
     is_batched = (
         H.ndim > 2,
-        jump_ops_ndim > 3,  # todo: this is a temporary fix
+        [jump_op.ndim > 2 for jump_op in jump_ops],
         rho0.ndim > 2,
         False,
         False,
@@ -56,7 +63,16 @@ def mesolve(
     f = compute_vmap(_mesolve, options.cartesian_batching, is_batched, out_axes)
 
     # === apply vectorized function
-    return f(H, jump_ops, rho0, tsave, exp_ops, solver, gradient, options)
+    return f(
+        H,
+        jump_ops,
+        rho0,
+        tsave,
+        exp_ops,
+        solver,
+        gradient,
+        options,
+    )
 
 
 def _mesolve(

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -29,14 +29,21 @@ def mesolve(
     solver: Solver = Tsit5(),
     gradient: Gradient | None = None,
     options: Options = Options(),
-):
+) -> Result:
+    # === convert arguments
+    H = _astimearray(H)
+    jump_ops = [_astimearray(jump_op) for jump_op in jump_ops]
+    psi0 = jnp.asarray(psi0, dtype=cdtype())
+    rho0 = todm(psi0)
+    tsave = jnp.asarray(tsave)
+    exp_ops = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
+
     # === vectorize function
-    # we vectorize over H, jump_ops and psi0, all other arguments are not vectorized
-    jump_ops_ndim = _astimearray(jump_ops[0]).ndim + 1
+    # we vectorize over H, jump_ops and rho0, all other arguments are not vectorized
     is_batched = (
         H.ndim > 2,
         jump_ops_ndim > 3,  # todo: this is a temporary fix
-        psi0.ndim > 2,
+        rho0.ndim > 2,
         False,
         False,
         False,
@@ -49,27 +56,19 @@ def mesolve(
     f = compute_vmap(_mesolve, options.cartesian_batching, is_batched, out_axes)
 
     # === apply vectorized function
-    return f(H, jump_ops, psi0, tsave, exp_ops, solver, gradient, options)
+    return f(H, jump_ops, rho0, tsave, exp_ops, solver, gradient, options)
 
 
 def _mesolve(
-    H: ArrayLike | TimeArray,
-    jump_ops: list[ArrayLike | TimeArray],
-    psi0: ArrayLike,
+    H: TimeArray,
+    jump_ops: list[TimeArray],
+    rho0: ArrayLike,
     tsave: ArrayLike,
     exp_ops: list[ArrayLike] | None = None,
     solver: Solver = Tsit5(),
     gradient: Gradient | None = None,
     options: Options = Options(),
 ) -> Result:
-    # === convert arguments
-    H = _astimearray(H)
-    Ls = [_astimearray(L) for L in jump_ops]
-    y0 = jnp.asarray(psi0, dtype=cdtype())
-    y0 = todm(y0)
-    ts = jnp.asarray(tsave)
-    Es = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
-
     # === select solver class
     solvers = {
         Euler: MEEuler,
@@ -84,7 +83,7 @@ def _mesolve(
     solver.assert_supports_gradient(gradient)
 
     # === init solver
-    solver = solver_class(ts, y0, H, Es, solver, gradient, options, Ls)
+    solver = solver_class(tsave, rho0, H, exp_ops, solver, gradient, options, jump_ops)
 
     # === run solver
     result = solver.run()

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -10,51 +10,57 @@ def test_batching(cartesian_batching):
     n = 8
     nt = 11
     nH = 3
-    nLs = 4 if cartesian_batching else nH
-    npsi0 = 5 if cartesian_batching else nH
-    nEs = 6
+    nL1 = 4 if cartesian_batching else nH
+    nL2 = 5 if cartesian_batching else nH
+    npsi0 = 6 if cartesian_batching else nH
+    nEs = 7
 
     options = dq.options.Options(cartesian_batching=cartesian_batching)
 
     # create random objects
-    k1, k2, k3, k4 = jax.random.split(jax.random.PRNGKey(42), 4)
+    k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(42), 5)
     H = dq.rand_herm(k1, (nH, n, n))
-    Ls = dq.rand_herm(k2, (nLs, 2, n, n))
-    exp_ops = dq.rand_complex(k3, (nEs, n, n))
-    psi0 = dq.rand_ket(k4, (npsi0, n, 1))
+    Ls = [dq.rand_herm(k2, (nL1, n, n)), dq.rand_herm(k3, (nL2, n, n))]
+    exp_ops = dq.rand_complex(k4, (nEs, n, n))
+    psi0 = dq.rand_ket(k5, (npsi0, n, 1))
     tsave = jnp.linspace(0, 0.01, nt)
 
     # no batching
-    result = dq.mesolve(H[0], Ls[0], psi0[0], tsave, exp_ops=exp_ops, options=options)
+    Ls0 = [L[0] for L in Ls]
+    result = dq.mesolve(H[0], Ls0, psi0[0], tsave, exp_ops=exp_ops, options=options)
     assert result.ysave.shape == (nt, n, n)
     assert result.Esave.shape == (nEs, nt)
 
     # H batched
-    result = dq.mesolve(H, Ls[0], psi0[0], tsave, exp_ops=exp_ops, options=options)
+    result = dq.mesolve(H, Ls0, psi0[0], tsave, exp_ops=exp_ops, options=options)
     assert result.ysave.shape == (nH, nt, n, n)
     assert result.Esave.shape == (nH, nEs, nt)
 
     # Ls batched
     result = dq.mesolve(H[0], Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.ysave.shape == (nLs, nt, n, n)
-    assert result.Esave.shape == (nLs, nEs, nt)
+    if cartesian_batching:
+        assert result.ysave.shape == (nL1, nL2, nt, n, n)
+        assert result.Esave.shape == (nL1, nL2, nEs, nt)
+    else:
+        assert result.ysave.shape == (nH, nt, n, n)
+        assert result.Esave.shape == (nH, nEs, nt)
 
     # psi0 batched
-    result = dq.mesolve(H[0], Ls[0], psi0, tsave, exp_ops=exp_ops, options=options)
+    result = dq.mesolve(H[0], Ls0, psi0, tsave, exp_ops=exp_ops, options=options)
     assert result.ysave.shape == (npsi0, nt, n, n)
     assert result.Esave.shape == (npsi0, nEs, nt)
 
     # H and Ls batched
     result = dq.mesolve(H, Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.ysave.shape == (nH, nLs, nt, n, n)
-        assert result.Esave.shape == (nH, nLs, nEs, nt)
+        assert result.ysave.shape == (nH, nL1, nL2, nt, n, n)
+        assert result.Esave.shape == (nH, nL1, nL2, nEs, nt)
     else:
         assert result.ysave.shape == (nH, nt, n, n)
         assert result.Esave.shape == (nH, nEs, nt)
 
     # H and psi0 batched
-    result = dq.mesolve(H, Ls[0], psi0, tsave, exp_ops=exp_ops, options=options)
+    result = dq.mesolve(H, Ls0, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
         assert result.ysave.shape == (nH, npsi0, nt, n, n)
         assert result.Esave.shape == (nH, npsi0, nEs, nt)
@@ -65,8 +71,8 @@ def test_batching(cartesian_batching):
     # H, Ls and psi0 batched
     result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.ysave.shape == (nH, nLs, npsi0, nt, n, n)
-        assert result.Esave.shape == (nH, nLs, npsi0, nEs, nt)
+        assert result.ysave.shape == (nH, nL1, nL2, npsi0, nt, n, n)
+        assert result.Esave.shape == (nH, nL1, nL2, npsi0, nEs, nt)
     else:
         assert result.ysave.shape == (nH, nt, n, n)
         assert result.Esave.shape == (nH, nEs, nt)


### PR DESCRIPTION
This PR achieves two things:
- 51824b8679a9faac690e6170ba32f739d0677a2b: fixes arbitrary array-like objects as input to sesolve/mesolve
- d2ce02dea1f242e01c389108e5f061ee79de4734: fixes the arbitrary batching over jump_ops. Now we can have as many jump_ops batched as we want (or not), and the result will match the structure. 

Quick test (on top of the library tests):
```python
import dynamiqs as dq
import jax.numpy as jnp

N = 10
a = dq.destroy(10)
H = dq.dag(a) @ a
psi0 = dq.coherent(10, 1.0)
tsave = jnp.linspace(0, 1.0, 11)

# simple batching
jump_ops = [jnp.stack([0.1 * a, 0.2 * a])]
result = dq.mesolve(H, jump_ops, psi0, tsave)
print(result)

# double batching
jump_ops = [
    jnp.stack([0.1 * a, 0.2 * a]),
    jnp.stack([0.01 * dq.dag(a), 0.02 * dq.dag(a)]),
]
result = dq.mesolve(H, jump_ops, psi0, tsave)
print(result)

# cartesian batching=False
jump_ops = [
    jnp.stack([0.1 * a, 0.2 * a]),
    jnp.stack([0.01 * dq.dag(a), 0.02 * dq.dag(a)]),
]
options = dq.Options(cartesian_batching=False)
result = dq.mesolve(H, jump_ops, psi0, tsave, options=options)
print(result)
```
```
==== Result ====
Solver  : Tsit5
States  : Array complex64 (2, 11, 10, 10) | 17.19 Kb
==== Result ====
Solver  : Tsit5
States  : Array complex64 (2, 2, 11, 10, 10) | 34.38 Kb
==== Result ====
Solver  : Tsit5
States  : Array complex64 (2, 11, 10, 10) | 17.19 Kb
```