### PR TITLE
Fix propagator bug

### DIFF
--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -32,7 +32,7 @@ class PropagatorSolver(BaseSolver):
 
         # we use `jnp.asarray(self.t0)` because of the bug fixed here:
         # https://github.com/google/jax/pull/19381 (fixed in jax-0.4.24)
-        delta_ts = jnp.diff(self.ts, prepend=jnp.asarray(self.t0))
+        delta_ts = jnp.diff(self.ts, prepend=jnp.asarray(self.t0).reshape(-1))
         ylast, saved = jax.lax.scan(propagate, self.y0, delta_ts)
 
         # === collect and return results


### PR DESCRIPTION
`ValueError: Zero-dimensional arrays cannot be concatenated.` due to the fact that `np.array(scalar)` returns an array with no shape