### PR TITLE
Add solver infos

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ print(result)
 ==== Result ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
+Infos   : 7 steps (7 accepted, 0 rejected)
 ```
 
 ### Compute gradients with respect to some parameters

--- a/docs/getting_started/examples.md
+++ b/docs/getting_started/examples.md
@@ -32,6 +32,7 @@ print(result)
 ==== Result ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
+Infos   : 7 steps (7 accepted, 0 rejected)
 ```
 
 ## Compute gradients with respect to some parameters

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -45,12 +45,12 @@ print(result)
 Solver  : Tsit5
 States  : Array complex64 (4, 11, 2, 1) | 0.69 Kb
 Expects : Array complex64 (4, 1, 11) | 0.34 Kb
+Infos   : avg. 6.0 steps (6.0 accepted, 0.0 rejected) | infos shape (4,)
 ```
 
 The returned `states` array has shape `(4, 11, 2, 1)` where `4` is the number of initial states, `11` is the number of saved states (the length of `tsave`) and `(2, 1)` is the shape of a single state.
 
 Similarly, `expects` has shape `(4, 1, 11)` where `4` is the number of initial states, `1` is the number of `exp_ops` operators (a single one here) and `11` is the number of saved expectation values (the length of `tsave`).
-
 
 !!! Note "Creating a batched array with JAX"
     To directly create a batched JAX array, use `jnp.stack`:

--- a/docs/tutorials/workflow.md
+++ b/docs/tutorials/workflow.md
@@ -84,6 +84,7 @@ print(result)
 Solver  : Dopri5
 States  : Array complex64 (101, 2, 1) | 1.58 Kb
 Expects : Array complex64 (1, 101) | 0.79 Kb
+Infos   : 56 steps (48 accepted, 8 rejected)
 ```
 
 ## 4. Analyze the results

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -44,14 +44,18 @@ class BaseSolver(AbstractSolver):
 
         return saved
 
-    def result(self, saved: dict[str, Array], ylast: Array) -> Result:
+    def result(
+        self, saved: dict[str, Array], ylast: Array, infos: PyTree | None = None
+    ) -> Result:
         ysave = saved.get('ysave', ylast)
         Esave = saved.get('Esave')
         extra = saved.get('extra')
         if Esave is not None:
             Esave = Esave.swapaxes(-1, -2)
         saved = Saved(ysave, Esave, extra)
-        return Result(self.ts, self.solver, self.gradient, self.options, saved)
+        return Result(
+            self.ts, self.solver, self.gradient, self.options, saved, infos=infos
+        )
 
 
 SESolver = BaseSolver

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import warnings
+from abc import abstractmethod
 
 import diffrax as dx
+import equinox as eqx
+from jax import Array
 from jaxtyping import PyTree
 
 from ..gradient import Autograd, CheckpointAutograd
@@ -57,19 +60,57 @@ class DiffraxSolver(BaseSolver):
         save_a, save_b = solution.ys
         saved = save_a
         ylast = save_b[0]  # (n, m)
-        return self.result(saved, ylast)
+        return self.result(saved, ylast, infos=self.infos(solution.stats))
+
+    @abstractmethod
+    def infos(self, stats: dict[str, Array]) -> PyTree:
+        pass
 
 
-class EulerSolver(DiffraxSolver):
+class FixedSolver(DiffraxSolver):
+    class Infos(eqx.Module):
+        nsteps: Array
+
+        def __str__(self) -> str:
+            if self.nsteps.ndim >= 1:
+                # note: fixed step solvers always make the same number of steps
+                return (
+                    f'{int(self.nsteps.mean())} steps | infos shape {self.nsteps.shape}'
+                )
+            return f'{self.nsteps} steps'
+
     def __init__(self, *args):
         super().__init__(*args)
-        self.diffrax_solver = dx.Euler()
         self.stepsize_controller = dx.ConstantStepSize()
         self.dt0 = self.solver.dt
         self.max_steps = 100_000  # TODO: fix hard-coded max_steps
 
+    def infos(self, stats: dict[str, Array]) -> PyTree:
+        return self.Infos(stats['num_steps'])
+
+
+class EulerSolver(FixedSolver):
+    diffrax_solver = dx.Euler()
+
 
 class AdaptiveSolver(DiffraxSolver):
+    class Infos(eqx.Module):
+        nsteps: Array
+        naccepted: Array
+        nrejected: Array
+
+        def __str__(self) -> str:
+            if self.nsteps.ndim >= 1:
+                return (
+                    f'avg. {self.nsteps.mean()} steps ({self.naccepted.mean()}'
+                    f' accepted, {self.nrejected.mean()} rejected) | infos shape'
+                    f' {self.nsteps.shape}'
+                )
+            return (
+                f'{self.nsteps} steps ({self.naccepted} accepted,'
+                f' {self.nrejected} rejected)'
+            )
+
     def __init__(self, *args):
         super().__init__(*args)
         self.stepsize_controller = dx.PIDController(
@@ -81,6 +122,11 @@ class AdaptiveSolver(DiffraxSolver):
         )
         self.dt0 = None
         self.max_steps = self.solver.max_steps
+
+    def infos(self, stats: dict[str, Array]) -> PyTree:
+        return self.Infos(
+            stats['num_steps'], stats['num_accepted_steps'], stats['num_rejected_steps']
+        )
 
 
 class Dopri5Solver(AdaptiveSolver):

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -79,6 +79,8 @@ def mesolve(
                 expectation values.
             - **extra** _(PyTree, optional)_ -- Extra data saved with `save_extra()` if
                 specified in `options`.
+            - **infos** _(PyTree, optional)_ -- Solver-dependent information on the
+                resolution.
             - **tsave** _(array of shape (nt,))_ -- Times for which states and
                 expectation values were saved.
             - **solver** _(Solver)_ -- Solver used.
@@ -99,7 +101,7 @@ def mesolve(
         False,
     )
     # the result is vectorized over `saved`
-    out_axes = Result(None, None, None, None, 0)
+    out_axes = Result(None, None, None, None, 0, 0)
 
     f = compute_vmap(_mesolve, options.cartesian_batching, is_batched, out_axes)
 

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -44,6 +44,7 @@ class Result(eqx.Module):
         states _(Array)_: Saved states.
         expects _(Array, optional)_: Saved expectation values.
         extra _(PyTree, optional)_: Extra data saved.
+        infos _(PyTree, optional)_: Solver-dependent information on the resolution.
         tsave _(Array)_: Times for which results were saved.
         solver _(Solver)_: Solver used.
         gradient _(Gradient)_: Gradient used.
@@ -55,6 +56,7 @@ class Result(eqx.Module):
     gradient: Gradient | None
     options: Options
     _saved: Saved
+    infos: PyTree | None = None
 
     @property
     def states(self) -> Array:
@@ -79,6 +81,7 @@ class Result(eqx.Module):
             'Extra   ': (
                 eqx.tree_pformat(self.extra) if self.extra is not None else None
             ),
+            'Infos   ': self.infos if self.infos is not None else None,
         }
         parts = {k: v for k, v in parts.items() if v is not None}
         parts_str = '\n'.join(f'{k}: {v}' for k, v in parts.items())

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -69,6 +69,8 @@ def sesolve(
                 expectation values.
             - **extra** _(PyTree, optional)_ -- Extra data saved with `save_extra()` if
                 specified in `options`.
+            - **infos** _(PyTree, optional)_ -- Solver-dependent information on the
+                resolution.
             - **tsave** _(array of shape (nt,))_ -- Times for which results were saved.
             - **solver** _(Solver)_ -- Solver used.
             - **gradient** _(Gradient)_ -- Gradient used.
@@ -78,7 +80,7 @@ def sesolve(
     # we vectorize over H and psi0, all other arguments are not vectorized
     is_batched = (H.ndim > 2, psi0.ndim > 2, False, False, False, False, False)
     # the result is vectorized over `saved`
-    out_axes = Result(None, None, None, None, 0)
+    out_axes = Result(None, None, None, None, 0, 0)
     f = compute_vmap(_sesolve, options.cartesian_batching, is_batched, out_axes)
 
     # === apply vectorized function


### PR DESCRIPTION
The `Result` object now holds a `infos` attribute gathering the solver info. For batched simulation, the `infos` are batched for each batch element (like the returned states and expects), because the solver infos is specific to each simulation. I propose a condensed printing in results to see the average step size quickly, people can always dive in `result.infos` if they want finer grained details.

Implementation: each solver defines what is the `infos` it stores, and the short printed version.

Printing results now looks like
```
==== Result ====
Solver  : Dopri5
States  : Array complex64 (101, 2, 1) | 1.58 Kb
Expects : Array complex64 (1, 101) | 0.79 Kb
Infos   : 56 steps (48 accepted, 8 rejected)
```
or (for batched simulations)
```
==== Result ====
Solver  : Tsit5
States  : Array complex64 (4, 11, 2, 1) | 0.69 Kb
Expects : Array complex64 (4, 1, 11) | 0.34 Kb
Infos   : avg. 6.0 steps (6.0 accepted, 0.0 rejected) | infos shape (4,)
```


Here are all the output:
```
# fixed step
Infos   : 50 steps
# propagator
Infos   : 2 steps
# adaptive step
Infos   : 6 steps (6 accepted, 0 rejected)

# fixed step batched
Infos   : 50 steps | infos shape (2,)
# propagator batched
Infos   : avg. 2.0 steps | infos shape (2,)
# adaptive step batched
Infos   : avg. 22.5 steps (22.5 accepted, 0.0 rejected) | infos shape (2,)
```

Try with e.g. (by changing the solver)
```python
import dynamiqs as dq
import jax.numpy as jnp

n = 8
omega = 1.0
kappa = 0.1
alpha = 1.0

a = dq.destroy(n)
H = omega * dq.dag(a) @ a
H = jnp.array([omega * dq.dag(a) @ a, 10 * omega * dq.dag(a) @ a])
jump_ops = [jnp.sqrt(kappa) * a]
psi0 = dq.coherent(n, alpha)
tsave = jnp.linspace(0.5, 1.0, 3)
result = dq.mesolve(H, jump_ops, psi0, tsave)
```