### PR TITLE
Remove incomplete documentation on `jump_ops` batching

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -57,8 +57,8 @@ def mesolve(
 
     Args:
         H _(array-like or time-array of shape (bH?, n, n))_: Hamiltonian.
-        jump_ops _(list of array-like or time-array, of shape (nL, bL?, n, n))_: List
-            of jump operators.
+        jump_ops _(list of array-like or time-array, of shape (nL, n, n))_: List of
+            jump operators.
         rho0 _(array-like of shape (brho?, n, 1) or (brho?, n, n))_: Initial state.
         tsave _(array-like of shape (nt,))_: Times at which the states and expectation
             values are saved. The equation is solved from `tsave[0]` to `tsave[-1]`, or

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -91,8 +91,8 @@ def smesolve(
 
     Args:
         H _(array-like or time-array of shape (bH?, n, n))_: Hamiltonian.
-        jump_ops _(list of array-like or time-array, of shape (nL, bL?, n, n))_: List
-            of jump operators.
+        jump_ops _(list of array-like or time-array, of shape (nL, n, n))_: List of
+            jump operators.
         etas _(array-like of shape (nL,))_: Measurement efficiencies, must be of the
             same length as `jump_ops` with values between 0 and 1. For a purely
             dissipative loss channel, set the corresponding efficiency to 0. No


### PR DESCRIPTION
The only remaining bit speaking about `jump_ops` batching is 
<img width="654" alt="Screenshot 2024-02-25 at 00 46 11" src="https://github.com/dynamiqs/dynamiqs/assets/38159029/e3a4534e-cdc2-43c5-b0fe-a7725d91ea7e">
in `mesolve()`. I think we can keep it for now.

Related to https://linear.app/dynamiqs/issue/DYN-73/support-generalized-batching.