### PR TITLE
JIT wigners

### DIFF
--- a/dynamiqs/utils/wigners.py
+++ b/dynamiqs/utils/wigners.py
@@ -13,17 +13,17 @@ from .array_types import cdtype
 from .operators import eye
 from .utils import isdm, isket, todm
 
-__all__ = ["wigner"]
+__all__ = ['wigner']
 
 
-@partial(jax.jit, static_argnames=("npixels", "method"))
-@partial(jnp.vectorize, signature="(n,m)->(k),(l),(k,l)", excluded={1, 2, 3})
+@partial(jax.jit, static_argnames=('npixels', 'method'))
+@partial(jnp.vectorize, signature='(n,m)->(k),(l),(k,l)', excluded={1, 2, 3})
 def wigner(
     state: ArrayLike,
     xmax: float = 6.2832,
     ymax: float = 6.2832,
     npixels: int = 200,
-    method: Literal["clenshaw", "fft"] = "clenshaw",
+    method: Literal['clenshaw', 'fft'] = 'clenshaw',
     g: float = 2.0,
 ) -> tuple[Array, Array, Array]:
     r"""Compute the Wigner distribution of a ket or density matrix.
@@ -51,18 +51,18 @@ def wigner(
     xvec = jnp.linspace(-xmax, xmax, npixels)
     yvec = jnp.linspace(-ymax, ymax, npixels)
 
-    if method == "clenshaw":
+    if method == 'clenshaw':
         state = todm(state)
         w = _wigner_clenshaw(state, xvec, yvec, g)
-    elif method == "fft":
+    elif method == 'fft':
         if isket(state):
             w, yvec = _wigner_fft_psi(state, xvec, g)
         elif isdm(state):
             w, yvec = _wigner_fft_dm(state, xvec, g)
         else:
             raise ValueError(
-                "Argument `state` must be a ket or density matrix, but has shape"
-                f" {state.shape}."
+                'Argument `state` must be a ket or density matrix, but has shape'
+                f' {state.shape}.'
             )
     else:
         raise ValueError(
@@ -76,58 +76,60 @@ def _wigner_clenshaw(
     rho: ArrayLike, xvec: ArrayLike, yvec: ArrayLike, g: float
 ) -> Array:
     """Compute the wigner distribution of a density matrix using the iterative method
-    of QuTiP based on the Clenshaw summation algorithm."""
+    of QuTiP based on the Clenshaw summation algorithm.
+    """
     rho = jnp.asarray(rho)
     xvec = jnp.asarray(xvec)
     yvec = jnp.asarray(yvec)
     n = rho.shape[-1]
 
-    x, p = jnp.meshgrid(xvec, yvec, indexing="ij")
+    x, p = jnp.meshgrid(xvec, yvec, indexing='ij')
     a = 0.5 * g * (x + 1.0j * p)
     a2 = jnp.abs(a) ** 2
 
     w = 2 * rho[0, -1] * jnp.ones_like(a)
     rho = rho * (2 * jnp.ones((n, n)) - eye(n))
 
-    def loop(i, w):
+    def loop(i: int, w: Array) -> Array:
         i = n - 2 - i
         w = w * (2 * a * (i + 1) ** (-0.5))
-        w = w + (_laguerre_series(i, 4 * a2, rho, n))
-        return w
+        return w + (_laguerre_series(i, 4 * a2, rho, n))
 
     w = lax.fori_loop(-1, n - 1, loop, w)
 
     return (w.real * jnp.exp(-2 * a2) * 0.5 * g**2 / jnp.pi).T
 
 
-def _diag_element(mat: jnp.array, diag: int, element: int):
+def _diag_element(mat: jnp.array, diag: int, element: int) -> float:
     r"""Return the element of a matrix `mat` at `jnp.diag(mat, diag)[element]`.
-    This function is jittable for `diag` while it is not for the `jnp.diag` version."""
-    assert mat.shape[0] == mat.shape[1], "Matrix must be square."
+    This function is jittable for `diag` while it is not for the `jnp.diag` version.
+    """
+    assert mat.shape[0] == mat.shape[1], 'Matrix must be square.'
     n = mat.shape[0]
     element = jax.lax.select(element < 0, n - jnp.abs(diag) - jnp.abs(element), element)
     return mat[jnp.maximum(-diag, 0) + element, jnp.maximum(diag, 0) + element]
 
 
-def _laguerre_series(i, x, rho, n):
+def _laguerre_series(i: int, x: Array, rho: Array, n: int) -> Array:
     r"""Evaluate a polynomial series of the form `$\sum_n c_n L_n^i$` where `$L_n$` is
-    such that `$L_n^i = (-1)^n \sqrt(i!n!/(i+n)!) LaguerreL[n,i,x]$`."""
+    such that `$L_n^i = (-1)^n \sqrt(i!n!/(i+n)!) LaguerreL[n,i,x]$`.
+    """
 
-    def n_1():
+    def n_1() -> Array:
         return _diag_element(rho, i, 0) * jnp.ones_like(x)
 
-    def n_2():
+    def n_2() -> Array:
         c0 = _diag_element(rho, i, 0)
         c1 = _diag_element(rho, i, 1)
         return (c0 - c1 * (i + 1 - x) * (i + 1) ** (-0.5)) * jnp.ones_like(x)
 
-    def n_other():
+    def n_other() -> Array:
         cm2 = _diag_element(rho, i, -2)
         cm1 = _diag_element(rho, i, -1)
         y0 = cm2 * jnp.ones_like(x)
         y1 = cm1 * jnp.ones_like(x)
 
-        def loop(k, args):
+        def loop(k: int, args: tuple[Array, Array]) -> tuple[Array, Array]:
             k = n - 2 - k
             y0, y1 = args
             ckm1 = _diag_element(rho, i, k - 1)

--- a/dynamiqs/utils/wigners.py
+++ b/dynamiqs/utils/wigners.py
@@ -13,17 +13,17 @@ from .array_types import cdtype
 from .operators import eye
 from .utils import isdm, isket, todm
 
-__all__ = ['wigner']
+__all__ = ["wigner"]
 
 
-@partial(jax.jit, static_argnames=('npixels', 'method'))
-@partial(jnp.vectorize, signature='(n,m)->(k),(l),(k,l)', excluded={1, 2, 3})
+@partial(jax.jit, static_argnames=("npixels", "method"))
+@partial(jnp.vectorize, signature="(n,m)->(k),(l),(k,l)", excluded={1, 2, 3})
 def wigner(
     state: ArrayLike,
     xmax: float = 6.2832,
     ymax: float = 6.2832,
     npixels: int = 200,
-    method: Literal['clenshaw', 'fft'] = 'clenshaw',
+    method: Literal["clenshaw", "fft"] = "clenshaw",
     g: float = 2.0,
 ) -> tuple[Array, Array, Array]:
     r"""Compute the Wigner distribution of a ket or density matrix.
@@ -51,18 +51,18 @@ def wigner(
     xvec = jnp.linspace(-xmax, xmax, npixels)
     yvec = jnp.linspace(-ymax, ymax, npixels)
 
-    if method == 'clenshaw':
+    if method == "clenshaw":
         state = todm(state)
         w = _wigner_clenshaw(state, xvec, yvec, g)
-    elif method == 'fft':
+    elif method == "fft":
         if isket(state):
             w, yvec = _wigner_fft_psi(state, xvec, g)
         elif isdm(state):
             w, yvec = _wigner_fft_dm(state, xvec, g)
         else:
             raise ValueError(
-                'Argument `state` must be a ket or density matrix, but has shape'
-                f' {state.shape}.'
+                "Argument `state` must be a ket or density matrix, but has shape"
+                f" {state.shape}."
             )
     else:
         raise ValueError(
@@ -76,44 +76,73 @@ def _wigner_clenshaw(
     rho: ArrayLike, xvec: ArrayLike, yvec: ArrayLike, g: float
 ) -> Array:
     """Compute the wigner distribution of a density matrix using the iterative method
-    of QuTiP based on the Clenshaw summation algorithm.
-    """
+    of QuTiP based on the Clenshaw summation algorithm."""
     rho = jnp.asarray(rho)
     xvec = jnp.asarray(xvec)
     yvec = jnp.asarray(yvec)
     n = rho.shape[-1]
 
-    x, p = jnp.meshgrid(xvec, yvec, indexing='ij')
+    x, p = jnp.meshgrid(xvec, yvec, indexing="ij")
     a = 0.5 * g * (x + 1.0j * p)
     a2 = jnp.abs(a) ** 2
 
     w = 2 * rho[0, -1] * jnp.ones_like(a)
     rho = rho * (2 * jnp.ones((n, n)) - eye(n))
-    for i in range(n - 2, -1, -1):
-        w *= 2 * a * (i + 1) ** (-0.5)
-        w += _laguerre_series(i, 4 * a2, jnp.diag(rho, k=i), n)
+
+    def loop(i, w):
+        i = n - 2 - i
+        w = w * (2 * a * (i + 1) ** (-0.5))
+        w = w + (_laguerre_series(i, 4 * a2, rho, n))
+        return w
+
+    w = lax.fori_loop(-1, n - 1, loop, w)
 
     return (w.real * jnp.exp(-2 * a2) * 0.5 * g**2 / jnp.pi).T
 
 
-def _laguerre_series(i: int, x: Array, c: Array, n: int) -> Array:
+def _diag_element(mat: jnp.array, diag: int, element: int):
+    r"""Return the element of a matrix `mat` at `jnp.diag(mat, diag)[element]`.
+    This function is jittable for `diag` while it is not for the `jnp.diag` version."""
+    assert mat.shape[0] == mat.shape[1], "Matrix must be square."
+    n = mat.shape[0]
+    element = jax.lax.select(element < 0, n - jnp.abs(diag) - jnp.abs(element), element)
+    return mat[jnp.maximum(-diag, 0) + element, jnp.maximum(diag, 0) + element]
+
+
+def _laguerre_series(i, x, rho, n):
     r"""Evaluate a polynomial series of the form `$\sum_n c_n L_n^i$` where `$L_n$` is
-    such that `$L_n^i = (-1)^n \sqrt(i!n!/(i+n)!) LaguerreL[n,i,x]$`.
-    """
-    if n == 1:
-        return c[0]
-    elif n == 2:
-        return c[0] - c[1] * (i + 1 - x) * (i + 1) ** (-0.5)
+    such that `$L_n^i = (-1)^n \sqrt(i!n!/(i+n)!) LaguerreL[n,i,x]$`."""
 
-    y0 = c[-2]
-    y1 = c[-1]
-    for k in range(n - 2, 0, -1):
-        y0, y1 = (
-            c[k - 1] - y1 * (k * (i + k) / ((i + k + 1) * (k + 1))) ** 0.5,
-            y0 - y1 * (i + 2 * k - x + 1) * ((i + k + 1) * (k + 1)) ** -0.5,
-        )
+    def n_1():
+        return _diag_element(rho, i, 0) * jnp.ones_like(x)
 
-    return y0 - y1 * (i + 1 - x) * (i + 1) ** (-0.5)
+    def n_2():
+        c0 = _diag_element(rho, i, 0)
+        c1 = _diag_element(rho, i, 1)
+        return (c0 - c1 * (i + 1 - x) * (i + 1) ** (-0.5)) * jnp.ones_like(x)
+
+    def n_other():
+        cm2 = _diag_element(rho, i, -2)
+        cm1 = _diag_element(rho, i, -1)
+        y0 = cm2 * jnp.ones_like(x)
+        y1 = cm1 * jnp.ones_like(x)
+
+        def loop(k, args):
+            k = n - 2 - k
+            y0, y1 = args
+            ckm1 = _diag_element(rho, i, k - 1)
+            y0, y1 = (
+                ckm1 - y1 * (k * (i + k) / ((i + k + 1) * (k + 1))) ** 0.5,
+                y0 - y1 * (i + 2 * k - x + 1) * ((i + k + 1) * (k + 1)) ** -0.5,
+            )
+            return y0, y1
+
+        y0, y1 = loop(0, (y0, y1))
+        y0, y1 = lax.fori_loop(0, n - 2, loop, (y0, y1))
+
+        return y0 - y1 * (i + 1 - x) * (i + 1) ** (-0.5)
+
+    return lax.cond(n == 1, n_1, lambda: lax.cond(n == 2, n_2, n_other))
 
 
 def _wigner_fft_psi(psi: Array, xvec: Array, g: float) -> tuple[Array, Array]:

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -4,6 +4,8 @@ import pytest
 from matplotlib import pyplot as plt
 
 from dynamiqs import coherent, plot_wigner, plot_wigner_mosaic, todm
+from dynamiqs.utils.wigners import _diag_element
+
 
 # TODO : add comparison with analytical wigner for coherent states and cat states
 
@@ -22,7 +24,7 @@ class TestPlots:
         # once the test is finished, pytest will go back here and run the code after
         # the yield statement
         yield
-        plt.close('all')
+        plt.close("all")
 
     def test_plot_wigner_psi(self):
         plot_wigner(self.psis[0])
@@ -35,3 +37,17 @@ class TestPlots:
 
     def test_plot_wigner_rhos(self):
         plot_wigner_mosaic(self.rhos)
+
+    def test_diag_element(self):
+        mat = jnp.arange(25).reshape(5, 5)
+        for diag in range(-4, 5):
+            diag_len = 5 - abs(diag)
+            for element in range(-diag_len + 1, diag_len):
+                assert (
+                    _diag_element(mat, diag, element) == np.diag(mat, diag)[element]
+                ), 'Failed for diag = {}, element = {}, expected "{}", got "{}"'.format(
+                    diag,
+                    element,
+                    np.diag(mat, diag)[element],
+                    _diag_element(mat, diag, element),
+                )

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -6,7 +6,6 @@ from matplotlib import pyplot as plt
 from dynamiqs import coherent, plot_wigner, plot_wigner_mosaic, todm
 from dynamiqs.utils.wigners import _diag_element
 
-
 # TODO : add comparison with analytical wigner for coherent states and cat states
 
 
@@ -24,7 +23,7 @@ class TestPlots:
         # once the test is finished, pytest will go back here and run the code after
         # the yield statement
         yield
-        plt.close("all")
+        plt.close('all')
 
     def test_plot_wigner_psi(self):
         plot_wigner(self.psis[0])


### PR DESCRIPTION
```python
state = dq.unit(dq.coherent(50, 3) + dq.coherent(50, -3))
%timeit dq.plot_wigner(state);plt.close()

>>> Before: 412 ms ± 75.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each) 
>>> After: 45.7 ms ± 722 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```