### PR TITLE
Speedup `Tr[A @ B]` by computing `(A * B).sum()`

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -159,6 +159,7 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
         members:
         - dag
         - mpow
+        - tracemm
         - trace
         - ptrace
         - tensor

--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -718,7 +718,7 @@ def overlap(x: ArrayLike, y: ArrayLike) -> Array:
     elif isket(y):
         return jnp.abs((dag(y) @ x @ y).squeeze((-1, -2)))
     else:
-        return trace(dag(x) @ y).squeeze((-1, -2)).real
+        return trace(dag(x) @ y).real
 
 
 def fidelity(x: ArrayLike, y: ArrayLike) -> Array:

--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -321,7 +321,7 @@ def _expect_single(O: Array, x: Array) -> Array:
     elif isbra(x):
         return (x @ O @ dag(x)).squeeze((-1, -2))
     elif isdm(x):
-        return trace(O @ x)  # tr(Ox)
+        return tracemm(O, x)  # tr(Ox)
     else:
         raise ValueError(
             'Argument `x` must be a ket, bra or density matrix, but has shape'
@@ -718,7 +718,7 @@ def overlap(x: ArrayLike, y: ArrayLike) -> Array:
     elif isket(y):
         return jnp.abs((dag(y) @ x @ y).squeeze((-1, -2)))
     else:
-        return trace(dag(x) @ y).real
+        return tracemm(dag(x), y).real
 
 
 def fidelity(x: ArrayLike, y: ArrayLike) -> Array:

--- a/dynamiqs/utils/utils.py
+++ b/dynamiqs/utils/utils.py
@@ -13,6 +13,7 @@ from .._utils import on_cpu
 __all__ = [
     'dag',
     'mpow',
+    'tracemm',
     'trace',
     'ptrace',
     'tensor',
@@ -79,6 +80,41 @@ def mpow(x: ArrayLike, n: int) -> Array:
     """
     x = jnp.asarray(x)
     return jnp.linalg.matrix_power(x, n)
+
+
+def tracemm(x: ArrayLike, y: ArrayLike) -> Array:
+    r"""Return $\tr{xy}$ (using a fast implementation).
+
+    The trace is computed as `(x * y).sum()` where `*` is the element-wise product.
+    For two matrices A and B:
+
+    $$
+        \tr{AB} = \sum_i (AB)_{ii}
+                = \sum_i \sum_j A_{ij} B_{ji}
+                = \sum_i \sum_j A_{ij} (B^\intercal)_{ij}
+                = \sum_i \sum_j (A * B^\intercal)_{ij}
+    $$
+
+    Notes:
+        The resulting time complexity for $n\times n$ matrices is $\mathcal{O}(n^2)$
+        instead of $\mathcal{O}(n^3)$ with the naïve formula.
+
+    Args:
+        x _(array_like of shape (..., n, n))_: Array.
+        y _(array_like of shape (..., n, n))_: Array.
+
+    Returns:
+        _(array of shape (...))_ Trace of `x @ y`.
+
+    Examples:
+        >>> x = jnp.ones((3, 3))
+        >>> y = jnp.ones((3, 3))
+        >>> dq.tracemm(x, y)
+        Array(9., dtype=float32)
+    """
+    x = jnp.asarray(x)
+    y = jnp.asarray(y)
+    return (x * y.mT).sum((-2, -1))
 
 
 def trace(x: ArrayLike) -> Array:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -173,6 +173,7 @@ nav:
           - Quantum utilities:
               - dag: python_api/utils/utils/dag.md
               - mpow: python_api/utils/utils/mpow.md
+              - tracemm: python_api/utils/utils/tracemm.md
               - trace: python_api/utils/utils/trace.md
               - ptrace: python_api/utils/utils/ptrace.md
               - tensor: python_api/utils/utils/tensor.md


### PR DESCRIPTION
Thanks for the tip @gaspardbb!

- I added this to the public API bc I think it's a fairly common operation.
- Fixed `overlap()` that had an extra incorrect `squeeze()` for density matrices.
- Used the new `tracemm()` in `expect()` and `overlap()`.

Benchmark for small matrices is already impressive (jitted on CPU):
```text
=== n=16
5.97 µs ± 159 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
5.31 µs ± 506 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
=== n=128
190 µs ± 2.99 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
19.9 µs ± 836 ns per loop (mean ± std. dev. of 7 runs, 100 loops each)
=== n=256
935 µs ± 85 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
96.1 µs ± 4.21 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Here's how the doc looks like:
![Screenshot 2024-02-28 at 20 24 34](https://github.com/dynamiqs/dynamiqs/assets/38159029/57c3db15-46b1-4b28-9c77-fd5cb5a51673)