### PR TITLE
Update the API of TimeArray

### DIFF
--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -17,6 +17,7 @@ PATHS_TO_PARSE = [
     ('dynamiqs/utils/optimal_control.py', 'dq'),
     ('dynamiqs/utils/random.py', 'dq'),
     ('dynamiqs/plots/namespace.py', 'dq'),
+    ('dynamiqs/time_array.py', 'dq'),
     ('dynamiqs/solver.py', 'dq.solver'),
     ('dynamiqs/gradient.py', 'dq.gradient'),
 ]

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -65,13 +65,16 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
 
 ## Core
 
-### totime
+### Time Arrays
 
 ::: dynamiqs.time_array
     options:
         table: true
         members:
-        - totime
+        - constant
+        - pwc
+        - modulated
+        - timecallable
 
 ### Solvers (dq.solver)
 

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -65,7 +65,7 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
 
 ## Core
 
-### Time Arrays
+### Time-dependent arrays
 
 ::: dynamiqs.time_array
     options:

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -65,17 +65,6 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
 
 ## Core
 
-### Time-dependent arrays
-
-::: dynamiqs.time_array
-    options:
-        table: true
-        members:
-        - constant
-        - pwc
-        - modulated
-        - timecallable
-
 ### Solvers (dq.solver)
 
 ::: dynamiqs.solver
@@ -114,6 +103,17 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
         table: true
         members:
         - Result
+
+### Time-dependent arrays
+
+::: dynamiqs.time_array
+    options:
+        table: true
+        members:
+        - constant
+        - pwc
+        - modulated
+        - timecallable
 
 ## Utilities
 

--- a/docs/python_api/totime/totime.md
+++ b/docs/python_api/totime/totime.md
@@ -1,3 +1,0 @@
-::: dynamiqs.time_array.totime
-    options:
-        namespace: dq

--- a/docs/tutorials/defining-hamiltonians.md
+++ b/docs/tutorials/defining-hamiltonians.md
@@ -31,32 +31,32 @@ H = dq.sigmaz()
 
 ## Time-dependent Hamiltonians
 
-A time-dependent Hamiltonian can be defined using a Python function with signature `H(t: float, *args: ArrayLike) -> Array` that returns the Hamiltonian as a JAX array for any time `t`, which is then fed into `dq.totime`.
+A time-dependent Hamiltonian can be defined using a Python function with signature `H(t: float, *args: ArrayLike) -> Array` that returns the Hamiltonian as a JAX array for any time `t`, which is then fed into `dq.timecallable`.
 
 For instance, to define a time-dependent Hamiltonian $H = \sigma_z + \cos(t)\sigma_x$, you can use the following syntax:
 
 ```python
-H = dq.totime(lambda t, *args: dq.sigmaz() + jnp.cos(t) * dq.sigmax())
+H = dq.timecallable(lambda t: dq.sigmaz() + jnp.cos(t) * dq.sigmax())
 ```
 
 !!! Warning "Function returning non-array object"
     An error is raised if `H(t)` return a non-array object, or an array with a different `dtype` than the ones specified to the solver. This is enforced to avoid costly type or data type conversions at every time step of the numerical integration.
 
 ??? Note "Function with optional arguments"
-    To define a time-dependent Hamiltonian with additional arguments, you can use the optional `args` parameter of `dq.totime`.
+    To define a time-dependent Hamiltonian with additional arguments, you can use the optional `args` parameter of `dq.timecallable`.
     ```python
     def _H(t, omega):
         return dq.sigmaz() + jnp.cos(omega * t) * dq.sigmax()
     omega = 1.0
-    H = dq.totime(_H, omega)
+    H = dq.timecallable(_H, args=(omega,))
     ```
 
-    In addition, any array that you want to batch over should be passed as an extra argument to `dq.totime`. For instance,
+    In addition, any array that you want to batch over should be passed as an extra argument to `dq.timecallable`. For instance,
     ```python
     def _H(t, omega):
         return dq.sigmaz() + jnp.cos(jnp.expand_dims(omega, (-1, -2)) * t) * dq.sigmax()
     omegas = jnp.linspace(0.0, 2.0, 10)
-    H = dq.totime(_H, omegas)
+    H = dq.timecallable(_H, args=(omegas,))
     ```
 
 ## Piecewise constant Hamiltonians

--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -8,7 +8,6 @@ from .plots import *
 from .result import Result
 from .sesolve import sesolve
 from .time_array import *
-from .time_array import TimeArray, TimeArrayLike
 from .utils import *
 
 # get version from pyproject.toml

--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -7,7 +7,8 @@ from .options import Options
 from .plots import *
 from .result import Result
 from .sesolve import sesolve
-from .time_array import TimeArray, TimeArrayLike, totime
+from .time_array import *
+from .time_array import TimeArray, TimeArrayLike
 from .utils import *
 
 # get version from pyproject.toml

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -18,7 +18,7 @@ def obj_type_str(x: Any) -> str:
 
 
 def check_time_array(x: Array, arg_name: str, allow_empty: bool = False):
-    # check that a time array is valid (it must be a 1D array sorted in strictly
+    # check that a time-array is valid (it must be a 1D array sorted in strictly
     # ascending order and containing only positive values)
     if x.ndim != 1:
         raise ValueError(

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -5,7 +5,7 @@ from jaxtyping import ArrayLike
 
 from .._utils import obj_type_str
 from ..solver import Solver
-from ..time_array import TimeArray, _factory_constant
+from ..time_array import TimeArray, constant
 from .abstract_solver import AbstractSolver
 
 
@@ -14,7 +14,7 @@ def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
         return x
     else:
         try:
-            return _factory_constant(x)
+            return constant(x)
         except (TypeError, ValueError) as e:
             raise TypeError(
                 f'Argument must be an array-like or a time-array object, but has type'

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -48,7 +48,10 @@ def mesolve(
 
     Quote: Time-dependent Hamiltonian or jump operators
         If the Hamiltonian or the jump operators depend on time, they can be converted
-        to a time-array using [`dq.totime`](/python_api/totime/totime.html).
+        to time-arrays using [`dq.constant`](/python_api/time_array/constant.html),
+        [`dq.pwc`](/python_api/time_array/pwc.html),
+        [`dq.modulated`](/python_api/time_array/modulated.html), or
+        [`dq.timecallable`](/python_api/time_array/timecallable.html).
 
     Quote: Running multiple simulations concurrently
         The Hamiltonian `H`, the jump operators `jump_ops` and the initial density

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -48,10 +48,10 @@ def mesolve(
 
     Quote: Time-dependent Hamiltonian or jump operators
         If the Hamiltonian or the jump operators depend on time, they can be converted
-        to time-arrays using [`dq.constant`](/python_api/time_array/constant.html),
-        [`dq.pwc`](/python_api/time_array/pwc.html),
-        [`dq.modulated`](/python_api/time_array/modulated.html), or
-        [`dq.timecallable`](/python_api/time_array/timecallable.html).
+        to time-arrays using [`dq.constant()`](/python_api/time_array/constant.html),
+        [`dq.pwc()`](/python_api/time_array/pwc.html),
+        [`dq.modulated()`](/python_api/time_array/modulated.html), or
+        [`dq.timecallable()`](/python_api/time_array/timecallable.html).
 
     Quote: Running multiple simulations concurrently
         The Hamiltonian `H`, the jump operators `jump_ops` and the initial density

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -39,8 +39,11 @@ def sesolve(
     where $H(t)$ is the system's Hamiltonian at time $t$.
 
     Quote: Time-dependent Hamiltonian
-        If the Hamiltonian depends on time, it can be converted to a time-array object
-        using [`dq.totime()`](/python_api/totime/totime.html).
+        If the Hamiltonian depends on time, it can be converted to a time-array using
+        [`dq.constant`](/python_api/time_array/constant.html),
+        [`dq.pwc`](/python_api/time_array/pwc.html),
+        [`dq.modulated`](/python_api/time_array/modulated.html), or
+        [`dq.timecallable`](/python_api/time_array/timecallable.html).
 
     Quote: Running multiple simulations concurrently
         Both the Hamiltonian `H` and the initial state `psi0` can be batched to

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -40,10 +40,10 @@ def sesolve(
 
     Quote: Time-dependent Hamiltonian
         If the Hamiltonian depends on time, it can be converted to a time-array using
-        [`dq.constant`](/python_api/time_array/constant.html),
-        [`dq.pwc`](/python_api/time_array/pwc.html),
-        [`dq.modulated`](/python_api/time_array/modulated.html), or
-        [`dq.timecallable`](/python_api/time_array/timecallable.html).
+        [`dq.constant()`](/python_api/time_array/constant.html),
+        [`dq.pwc()`](/python_api/time_array/pwc.html),
+        [`dq.modulated()`](/python_api/time_array/modulated.html), or
+        [`dq.timecallable()`](/python_api/time_array/timecallable.html).
 
     Quote: Running multiple simulations concurrently
         Both the Hamiltonian `H` and the initial state `psi0` can be batched to

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -82,7 +82,10 @@ def smesolve(
 
     Quote: Time-dependent Hamiltonian or jump operators
         If the Hamiltonian or the jump operators depend on time, they can be converted
-        to a time-array using [`dq.totime`](/python_api/totime/totime.html).
+        to time-arrays using [`dq.constant`](/python_api/time_array/constant.html),
+        [`dq.pwc`](/python_api/time_array/pwc.html),
+        [`dq.modulated`](/python_api/time_array/modulated.html), or
+        [`dq.timecallable`](/python_api/time_array/timecallable.html).
 
     Quote: Running multiple simulations concurrently
         The Hamiltonian `H`, the jump operators `jump_ops` and the initial density

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -82,10 +82,10 @@ def smesolve(
 
     Quote: Time-dependent Hamiltonian or jump operators
         If the Hamiltonian or the jump operators depend on time, they can be converted
-        to time-arrays using [`dq.constant`](/python_api/time_array/constant.html),
-        [`dq.pwc`](/python_api/time_array/pwc.html),
-        [`dq.modulated`](/python_api/time_array/modulated.html), or
-        [`dq.timecallable`](/python_api/time_array/timecallable.html).
+        to time-arrays using [`dq.constant()`](/python_api/time_array/constant.html),
+        [`dq.pwc()`](/python_api/time_array/pwc.html),
+        [`dq.modulated()`](/python_api/time_array/modulated.html), or
+        [`dq.timecallable()`](/python_api/time_array/timecallable.html).
 
     Quote: Running multiple simulations concurrently
         The Hamiltonian `H`, the jump operators `jump_ops` and the initial density

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -346,12 +346,9 @@ class ConstantTimeArray(TimeArray):
 
 
 class PWCTimeArray(TimeArray):
-    # `array`` is made a static field such that `vmap` knows to not batch over it.
-    # However, this also implies that the function is re-jitted every time `array`
-    # changes. TODO: find a better way to handle this.
     times: Array  # (nv+1,)
     values: Array  # (..., nv)
-    array: Array = eqx.field(static=True)  # (n, n)
+    array: Array  # (n, n)
 
     @property
     def dtype(self) -> np.dtype:
@@ -410,11 +407,8 @@ class PWCTimeArray(TimeArray):
 
 
 class ModulatedTimeArray(TimeArray):
-    # `array`` is made a static field such that `vmap` knows to not batch over it.
-    # However, this also implies that the function is re-jitted every time `array`
-    # changes. TODO: find a better way to handle this.
     f: callable[[float, ...], Array]  # (...,)
-    array: Array = eqx.field(static=True)  # (n, n)
+    array: Array  # (n, n)
     args: tuple[PyTree]
 
     @property

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -14,7 +14,7 @@ from jaxtyping import PyTree, Scalar
 from ._utils import check_time_array, obj_type_str
 from .utils.array_types import ArrayLike, cdtype
 
-__all__ = ['constant', 'pwc', 'modulated', 'timecallable']
+__all__ = ['constant', 'pwc', 'modulated', 'timecallable', 'TimeArray', 'TimeArrayLike']
 
 TimeArrayLike = Union[
     ArrayLike,

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -26,7 +26,7 @@ TimeArrayLike = Union[
 
 
 def constant(array: ArrayLike) -> ConstantTimeArray:
-    """Instantiate a constant time array.
+    """Instantiate a constant time-array.
 
     Args:
         array: The constant array of shape _(..., n, n)_.
@@ -39,13 +39,13 @@ def constant(array: ArrayLike) -> ConstantTimeArray:
 
 
 def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
-    r"""Instantiate a piecewise-constant (PWC) time array.
+    r"""Instantiate a piecewise-constant (PWC) time-array.
 
-    A piecewise-constant (PWC) time array is defined by $A(t) = v_i A$ for $t \in [t_i,
+    A piecewise-constant (PWC) time-array is defined by $A(t) = v_i A$ for $t \in [t_i,
     t_{i+1}$, where $v_i$ is a constant value and $A$ is a constant array.
 
     Warning:
-        Batching is not yet supported for PWC time arrays. This should be fixed soon.
+        Batching is not yet supported for PWC time-arrays. This should be fixed soon.
 
     Args:
         times: The time points $t_i$ between which the PWC factor takes constant values,
@@ -82,14 +82,14 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
 def modulated(
     f: callable[[float, ...], Array], array: ArrayLike, *, args: tuple[PyTree] = ()
 ) -> ModulatedTimeArray:
-    r"""Instantiate a modulated time array.
+    r"""Instantiate a modulated time-array.
 
-    A modulated time array is defined by $A(t) = f(t) A$, where $f(t)$ is an arbitrary
+    A modulated time-array is defined by $A(t) = f(t) A$, where $f(t)$ is an arbitrary
     function of signature `(t: float, *args: PyTree) -> Array` with `Array` of shape
     `(...,)`, and $A$ is a constant array.
 
     Warning:
-        Batching is not yet supported for modulated time arrays. This should be fixed
+        Batching is not yet supported for modulated time-arrays. This should be fixed
         soon.
 
     Args:
@@ -104,7 +104,7 @@ def modulated(
     # check f is callable
     if not callable(f):
         raise TypeError(
-            'For a modulated time array `(f, array)`, argument `f` must'
+            'For a modulated time-array `(f, array)`, argument `f` must'
             f' be a function, but has type {obj_type_str(f)}.'
         )
 
@@ -112,7 +112,7 @@ def modulated(
     array = jnp.asarray(array, dtype=cdtype())
     if array.ndim != 2 or array.shape[-1] != array.shape[-2]:
         raise TypeError(
-            'For a modulated time array `(f, array)`, argument `array` must'
+            'For a modulated time-array `(f, array)`, argument `array` must'
             f' be a square matrix, but has shape {tuple(array.shape)}.'
         )
 
@@ -128,9 +128,9 @@ def modulated(
 def timecallable(
     f: callable[[float, ...], Array], *, args: tuple[PyTree] = ()
 ) -> CallableTimeArray:
-    r"""Instantiate a callable time array.
+    r"""Instantiate a callable time-array.
 
-    A callable time array is defined by $A(t) = f(t)$, where $f(t)$ is an arbitrary
+    A callable time-array is defined by $A(t) = f(t)$, where $f(t)$ is an arbitrary
     function of signature `(t: float, *args: PyTree) -> Array` with `Array` of shape
     `(..., n, n)`.
 
@@ -145,7 +145,7 @@ def timecallable(
     # check f is callable
     if not callable(f):
         raise TypeError(
-            'For a functional time array, argument `f` must be a function, but has type'
+            'For a callable time-array, argument `f` must be a function, but has type'
             f' {obj_type_str(f)}.'
         )
 

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -44,6 +44,9 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
     A piecewise-constant (PWC) time array is defined by $A(t) = v_i A$ for $t \in [t_i,
     t_{i+1}$, where $v_i$ is a constant value and $A$ is a constant array.
 
+    Warning:
+        Batching is not yet supported for PWC time arrays. This should be fixed soon.
+
     Args:
         times: The time points $t_i$ between which the PWC factor takes constant values,
             of shape _(nv+1,)_ where _nv_ is the number of time intervals.
@@ -84,6 +87,10 @@ def modulated(
     A modulated time array is defined by $A(t) = f(t) A$, where $f(t)$ is an arbitrary
     function of signature `(t: float, *args: PyTree) -> Array` with `Array` of shape
     `(...,)`, and $A$ is a constant array.
+
+    Warning:
+        Batching is not yet supported for modulated time arrays. This should be fixed
+        soon.
 
     Args:
         f: A function with signature `(t: float, *args: PyTree) -> Array` that returns

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -80,7 +80,7 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
 
 
 def modulated(
-    f: callable[[float, ...], Array], array: ArrayLike, *, args: tuple[PyTree]
+    f: callable[[float, ...], Array], array: ArrayLike, *, args: tuple[PyTree] = ()
 ) -> ModulatedTimeArray:
     r"""Instantiate a modulated time array.
 
@@ -126,7 +126,7 @@ def modulated(
 
 
 def timecallable(
-    f: callable[[float, ...], Array], *, args: tuple[PyTree]
+    f: callable[[float, ...], Array], *, args: tuple[PyTree] = ()
 ) -> CallableTimeArray:
     r"""Instantiate a callable time array.
 

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -145,11 +145,10 @@ def _factory_pwc(x: tuple[ArrayLike, ArrayLike, ArrayLike]) -> PWCTimeArray:
 
     # values
     values = jnp.asarray(values, dtype=cdtype())
-    if values.shape[0] != len(times) - 1:
+    if values.shape[-1] != len(times) - 1:
         raise TypeError(
             'For a PWC array `(times, values, array)`, argument `values` must'
-            ' have shape `(len(times)-1, ...)`, but has shape'
-            f' {tuple(values.shape)}.'
+            f' have shape `(..., len(times)-1)`, but has shape {tuple(values.shape)}.'
         )
 
     # array

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -17,10 +17,10 @@ from .utils.array_types import ArrayLike, cdtype
 __all__ = ['constant', 'pwc', 'modulated', 'timecallable', 'TimeArray', 'TimeArrayLike']
 
 TimeArrayLike = Union[
-    ArrayLike,
-    Callable[[float, ...], Array],
-    tuple[ArrayLike, ArrayLike, ArrayLike],
-    tuple[Callable[[float, ...], Array], ArrayLike],
+    ArrayLike,  # constant
+    tuple[ArrayLike, ArrayLike, ArrayLike],  # pwc
+    tuple[Callable[[float, ...], Array], ArrayLike],  # modulated
+    Callable[[float, ...], Array],  # timecallable
     'TimeArray',
 ]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,7 +130,11 @@ nav:
           - mesolve: python_api/solvers/mesolve.md
           - smesolve: python_api/solvers/smesolve.md
       - Core:
-          - totime: python_api/totime/totime.md
+          - Time Arrays:
+              - constant: python_api/time_array/constant.md
+              - pwc: python_api/time_array/pwc.md
+              - modulated: python_api/time_array/modulated.md
+              - timecallable: python_api/time_array/timecallable.md
           - Solvers (dq.solver):
               - Tsit5: python_api/solver/Tsit5.md
               - Dopri5: python_api/solver/Dopri5.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,7 +130,7 @@ nav:
           - mesolve: python_api/solvers/mesolve.md
           - smesolve: python_api/solvers/smesolve.md
       - Core:
-          - Time Arrays:
+          - Time-dependent arrays:
               - constant: python_api/time_array/constant.md
               - pwc: python_api/time_array/pwc.md
               - modulated: python_api/time_array/modulated.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,11 +130,6 @@ nav:
           - mesolve: python_api/solvers/mesolve.md
           - smesolve: python_api/solvers/smesolve.md
       - Core:
-          - Time-dependent arrays:
-              - constant: python_api/time_array/constant.md
-              - pwc: python_api/time_array/pwc.md
-              - modulated: python_api/time_array/modulated.md
-              - timecallable: python_api/time_array/timecallable.md
           - Solvers (dq.solver):
               - Tsit5: python_api/solver/Tsit5.md
               - Dopri5: python_api/solver/Dopri5.md
@@ -148,6 +143,11 @@ nav:
               - CheckpointAutograd: python_api/gradient/CheckpointAutograd.md
           - Options: python_api/options/Options.md
           - Result: python_api/result/Result.md
+          - Time-dependent arrays:
+              - constant: python_api/time_array/constant.md
+              - pwc: python_api/time_array/pwc.md
+              - modulated: python_api/time_array/modulated.md
+              - timecallable: python_api/time_array/timecallable.md
       - Utilities:
           - Operators:
               - eye: python_api/utils/operators/eye.md

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -136,7 +136,7 @@ class OTDQubit(OpenSystem):
 
     def H(self, params: PyTree):
         f = lambda t, eps, omega: eps * jnp.cos(omega * t) * dq.sigmax()
-        return dq.totime(f, params.eps, params.omega)
+        return dq.timecallable(f, args=(params.eps, params.omega))
 
     def Ls(self, params: PyTree) -> list[ArrayLike | TimeArray]:
         return [jnp.sqrt(params.gamma) * dq.sigmax()]

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -112,7 +112,7 @@ class TDQubit(ClosedSystem):
 
     def H(self, params: PyTree) -> TimeArray:
         f = lambda t, eps, omega: eps * jnp.cos(omega * t) * dq.sigmax()
-        return dq.totime(f, params.eps, params.omega)
+        return dq.timecallable(f, args=(params.eps, params.omega))
 
     def y0(self, params: PyTree) -> Array:  # noqa: ARG002
         return dq.fock(2, 0)


### PR DESCRIPTION
Following discussion with @pierreguilmin, here is an update on the API of `dq.totime` to make it more granular (and easier to document+use, hopefully).

This also fixes a bug with jitting PWC and Modulated TimeArrays, but makes the `vmap` bug come back. However, I know how to fix it (it should be quite easy and clean too), but for now I'm just putting up a warning in the doc. When we've settled on the TimeArray implementation, then I will fix it.

You can review commit by commit.