### PR TITLE
Add glossary and tooltips

### DIFF
--- a/docs/tutorials/closed-system.md
+++ b/docs/tutorials/closed-system.md
@@ -89,7 +89,7 @@ There are two main types of ODE solvers:
 
 ## Using dynamiqs
 
-You can create the state and Hamiltonian using any array-like object (Python lists, NumPy and JAX arrays, QuTiP Qobjs). Let's take the example of a two-level system with a simple Hamiltonian:
+You can create the state and Hamiltonian using any array-like object. Let's take the example of a two-level system with a simple Hamiltonian:
 
 ```python
 import jax.numpy as jnp

--- a/docs/tutorials/open-system.md
+++ b/docs/tutorials/open-system.md
@@ -101,7 +101,7 @@ Also called the **quantum-jump** approach.
 
 ## Using dynamiqs
 
-You can create the state, Hamiltonian and jump operators using any array-like object (Python lists, NumPy and JAX arrays, QuTiP Qobjs). Let's take the example of a two-level system with a simple Hamiltonian and a single jump operator:
+You can create the state, Hamiltonian and jump operators using any array-like object. Let's take the example of a two-level system with a simple Hamiltonian and a single jump operator:
 
 ```python
 import jax.numpy as jnp

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -51,7 +51,7 @@ $$
 $$
 for any time $t$, where $O_0$ is a constant operator.
 
-In dynamiqs, constant operators can either be defined with **array-like objects** (e.g. Python lists, NumPy and JAX arrays, QuTiP Qobjs) or as [`TimeArray`][dynamiqs.TimeArray] objects (using the [`dq.constant()`][dynamiqs.constant] function).
+In dynamiqs, constant operators can either be defined with array-like objects or as [`TimeArray`][dynamiqs.TimeArray] objects (using the [`dq.constant()`][dynamiqs.constant] function).
 
 !!! Notes
     Common operators are available as utility functions, see the list of available operators in the [Python API](../python_api/index.md#operators).
@@ -90,7 +90,7 @@ $$
 $$
 where $c_k$ are constant values, $\Omega_{[t_k, t_{k+1}[}$ is the rectangular window function defined by $\Omega_{[t_a, t_b[}(t) = 1$ if $t \in [t_a, t_b[$ and $\Omega_{[t_a, t_b[}(t) = 0$ otherwise, and $O_0$ is a constant operator.
 
-In dynamiqs, PWC operators are defined by three **array-like objects** (e.g. Python lists, NumPy and JAX arrays, QuTiP Qobjs):
+In dynamiqs, PWC operators are defined by three array-like objects:
 
 - `times`: the time points $(t_0, \ldots, t_N)$ defining the boundaries of the time intervals, of shape _(N+1,)_,
 - `values`: the constant values $(c_0, \ldots, c_{N-1})$ for each time interval, of shape _(..., N)_,
@@ -213,7 +213,7 @@ Array([[1., 0.],
 ```
 
 !!! Warning "The function `f` must return a JAX array (not an array-like object!)"
-    An error is raised if the function `f` does not return a JAX array. This error includes other array-like objects (e.g. Python lists, NumPy arrays or QuTiP Qobjs). This is enforced to avoid costly conversions at every time step of the numerical integration.
+    An error is raised if the function `f` does not return a JAX array. This error includes other array-like objects. This is enforced to avoid costly conversions at every time step of the numerical integration.
 
 ??? Note "Function with additional arguments"
     To define a callable time-array with additional arguments, you can use the optional `args` parameter of [`dq.timecallable()`][dynamiqs.timecallable]:

--- a/docs/tutorials/workflow.md
+++ b/docs/tutorials/workflow.md
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 
 ## 1. Define the system
 
-After having imported the necessary packages, we can define our system, namely the initial state, the Hamiltonian, and the eventual loss operators. Common states and operators are already defined in dynamiqs, see the [API documentation](../python_api/index.md) for more details. Otherwise, you can define specific states and operators using any array-like objects, e.g. [NumPy](https://numpy.org/) or [JAX](https://jax.readthedocs.io/) arrays, Python lists, or [QuTiP](http://qutip.org/) Qobjs.
+After having imported the necessary packages, we can define our system, namely the initial state, the Hamiltonian, and the eventual loss operators. Common states and operators are already defined in dynamiqs, see the [API documentation](../python_api/index.md) for more details. Otherwise, you can define specific states and operators using any array-like objects.
 
 Here, we will use [`dq.fock()`][dynamiqs.fock] to define the initial state $\ket{\psi_0}=\ket{0}$, [`dq.sigmaz()`][dynamiqs.sigmaz] and [`dq.sigmax()`][dynamiqs.sigmax] to define the Hamiltonian $H = \delta \sigma_z + \Omega \sigma_x$.
 

--- a/includes/glossary.md
+++ b/includes/glossary.md
@@ -1,0 +1,6 @@
+*[array-like object]: e.g. Python list, NumPy and JAX array or QuTiP Qobj
+*[Array-like object]: e.g. Python list, NumPy and JAX array or QuTiP Qobj
+*[array-like objects]: e.g. Python lists, NumPy and JAX arrays or QuTiP Qobjs
+*[Array-like objects]: e.g. Python lists, NumPy and JAX arrays or QuTiP Qobjs
+*[PWC]: piecewise constant
+*[SME]: stochastic master equation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ theme:
     - navigation.top
     - search.suggest
     - content.code.copy
+    - content.tooltips
   icon:
     repo: fontawesome/brands/github
     admonition:
@@ -86,6 +87,10 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - pymdownx.caret
+  - pymdownx.snippets:
+      auto_append:
+        - includes/glossary.md
+  - abbr
   - attr_list
   - footnotes
   - md_in_html
@@ -95,6 +100,7 @@ extra_javascript:
   - https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.7/contrib/auto-render.min.js
 watch:
   - dynamiqs
+  - includes
 validation:
   nav:
     omitted_files: warn


### PR DESCRIPTION
Tooltip on hover on commonly used words (to avoid repeating ourselves everywhere).

Example:
<img width="711" alt="Screenshot 2024-03-13 at 14 55 13" src="https://github.com/dynamiqs/dynamiqs/assets/38159029/42d7038c-a4b1-4a86-ab30-ea3717414941">

Also in the API!
<img width="685" alt="Screenshot 2024-03-13 at 14 55 27" src="https://github.com/dynamiqs/dynamiqs/assets/38159029/c09ab9b5-dcce-472d-9fda-471c7f2356da">
