### PR TITLE
Minor technical fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ docs/figs-code/**
 !docs/figs-code/.gitkeep
 docs/figs-docs/**
 !docs/figs-docs/.gitkeep
+
+# temporary directiry
+.tmp/**

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -23,7 +23,7 @@ class AbstractSolver(eqx.Module):
 class BaseSolver(AbstractSolver):
     ts: Array
     y0: Array
-    H: Array | TimeArray
+    H: TimeArray
     Es: Array
     solver: Solver
     gradient: Gradient | None
@@ -62,4 +62,4 @@ SESolver = BaseSolver
 
 
 class MESolver(BaseSolver):
-    Ls: list[Array | TimeArray]
+    Ls: list[TimeArray]

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -33,6 +33,10 @@ class BaseSolver(AbstractSolver):
     def t0(self) -> Scalar:
         return self.ts[0] if self.options.t0 is None else self.options.t0
 
+    @property
+    def t1(self) -> Scalar:
+        return self.ts[-1]
+
     def save(self, y: Array) -> dict[str, Array]:
         saved = {}
         if self.options.save_states:

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -17,7 +17,7 @@ class DiffraxSolver(BaseSolver):
     stepsize_controller: dx.AbstractAdaptiveStepSizeController
     dt0: float | None
     max_steps: int
-    term: dx.ODETerm
+    terms: dx.AbstractTerm
 
     def __init__(self, *args):
         # this dummy init is needed because of the way the class hierarchy is set up,
@@ -44,7 +44,7 @@ class DiffraxSolver(BaseSolver):
 
             # === solve differential equation with diffrax
             solution = dx.diffeqsolve(
-                self.term,
+                self.terms,
                 self.diffrax_solver,
                 t0=self.t0,
                 t1=self.ts[-1],

--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -28,6 +28,7 @@ class PropagatorSolver(BaseSolver):
 
     def __init__(self, *args):
         super().__init__(*args)
+
         # check that Hamiltonian is time-independent
         if not isinstance(self.H, ConstantTimeArray):
             raise TypeError(
@@ -64,14 +65,15 @@ class PropagatorSolver(BaseSolver):
 SEPropagatorSolver = PropagatorSolver
 
 
-class MEPropagatorSolver(MESolver, PropagatorSolver):
+class MEPropagatorSolver(PropagatorSolver, MESolver):
     def __init__(self, *args):
-        MESolver.__init__(self, *args)
-        PropagatorSolver.__init__(self, *args[:-1])
+        super().__init__(*args)
+
         # check that jump operators are time-independent
         if not all(isinstance(L, ConstantTimeArray) for L in self.Ls):
             raise TypeError(
                 'Solver `Propagator` requires time-independent jump operators.'
             )
+
         # extract the constant arrays from the `ConstantTimeArray` objects
         self.Ls = [L.x for L in self.Ls]

--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -33,6 +33,8 @@ class PropagatorSolver(BaseSolver):
             raise TypeError(
                 'Solver `Propagator` requires a time-independent Hamiltonian.'
             )
+
+        # extract the constant array from the `ConstantTimeArray` object
         self.H = self.H.x
 
     def run(self) -> PyTree:
@@ -71,4 +73,5 @@ class MEPropagatorSolver(MESolver, PropagatorSolver):
             raise TypeError(
                 'Solver `Propagator` requires time-independent jump operators.'
             )
+        # extract the constant arrays from the `ConstantTimeArray` objects
         self.Ls = [L.x for L in self.Ls]

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -10,56 +10,61 @@ class Gradient(eqx.Module):
 
 
 class Autograd(Gradient):
+    """Standard automatic differentiation of JAX.
+
+    With this option, the gradient is computed by automatically differentiating
+    through the internals of the solver.
+
+    Note: For Diffrax-based solvers
+        This falls back to the
+        [`diffrax.DirectAdjoint`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.DirectAdjoint)
+        option.
+    """
+
+    # dummy init to have the signature in the documentation
     def __init__(self):
-        """Standard automatic differentiation of JAX.
-
-        With this option, the gradient is computed by automatically differentiating
-        through the internals of the solver.
-
-        Note: For Diffrax-based solvers
-            This falls back to the
-            [`diffrax.DirectAdjoint`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.DirectAdjoint)
-            option.
-        """
+        pass
 
 
 class CheckpointAutograd(Gradient):
-    ncheckpoints: int | None
+    """Checkpointed automatic differentiation.
 
+    With this option, the gradient is computed by automatically differentiating
+    through the internals of the solver. The difference with the standard automatic
+    differentiation (see [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd]) is
+    that a checkpointing scheme is used to reduce the memory usage of the
+    backpropagation.
+
+    Note:
+        For most problems this is the preferred technique for backpropagating
+        through the quantum solvers.
+
+    Warning:
+        This cannot be forward-mode autodifferentiated (e.g. using
+        [`jax.jvp`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jvp.html)
+        ). Try using [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] if that
+        is something you need.
+
+
+    Note: For Diffrax-based solvers
+        This falls back to the
+        [`diffrax.RecursiveCheckpointAdjoint`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.RecursiveCheckpointAdjoint)
+        option.
+
+    Args:
+        ncheckpoints: Number of checkpoints to use. The amount of memory used by
+            the differential equation solve will be roughly equal to the number of
+            checkpoints multiplied by the size of the state. You can speed up
+            backpropagation by allocating more checkpoints, so it makes sense to
+            set as many checkpoints as you have memory for. This value is set to
+            `None` by default, in which case it will be set to `log(max_steps)`,
+            for which a theoretical result is available guaranteeing that
+            backpropagation will take `O(n_steps log(n_steps))` time in the number
+            of steps `n_steps <= max_steps`.
+    """
+
+    ncheckpoints: int | None = None
+
+    # dummy init to have the signature in the documentation
     def __init__(self, ncheckpoints: int | None = None):
-        """Checkpointed automatic differentiation.
-
-        With this option, the gradient is computed by automatically differentiating
-        through the internals of the solver. The difference with the standard automatic
-        differentiation (see [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd]) is
-        that a checkpointing scheme is used to reduce the memory usage of the
-        backpropagation.
-
-        Note:
-            For most problems this is the preferred technique for backpropagating
-            through the quantum solvers.
-
-        Warning:
-            This cannot be forward-mode autodifferentiated (e.g. using
-            [`jax.jvp`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jvp.html)
-            ). Try using [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] if that
-            is something you need.
-
-
-        Note: For Diffrax-based solvers
-            This falls back to the
-            [`diffrax.RecursiveCheckpointAdjoint`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.RecursiveCheckpointAdjoint)
-            option.
-
-        Args:
-            ncheckpoints: Number of checkpoints to use. The amount of memory used by
-                the differential equation solve will be roughly equal to the number of
-                checkpoints multiplied by the size of the state. You can speed up
-                backpropagation by allocating more checkpoints, so it makes sense to
-                set as many checkpoints as you have memory for. This value is set to
-                `None` by default, in which case it will be set to `log(max_steps)`,
-                for which a theoretical result is available guaranteeing that
-                backpropagation will take `O(n_steps log(n_steps))` time in the number
-                of steps `n_steps <= max_steps`.
-        """
         self.ncheckpoints = ncheckpoints

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -39,7 +39,7 @@ class MEDiffraxSolver(DiffraxSolver, MESolver):
         def vector_field(t, y, _):  # noqa: ANN001, ANN202
             Ls = jnp.stack([L(t) for L in self.Ls])
             Lsd = dag(Ls)
-            LdL = (Lsd @ Ls).sum(axis=0)
+            LdL = (Lsd @ Ls).sum(0)
             tmp = (-1j * self.H(t) - 0.5 * LdL) @ y + 0.5 * (Ls @ y @ Lsd).sum(0)
             return tmp + dag(tmp)
 

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -38,7 +38,7 @@ class LindbladTerm(dx.ODETerm):
 class MEDiffraxSolver(DiffraxSolver, MESolver):
     def __init__(self, *args):
         super().__init__(*args)
-        self.term = LindbladTerm(H=self.H, Ls=self.Ls)
+        self.terms = LindbladTerm(H=self.H, Ls=self.Ls)
 
 
 class MEEuler(MEDiffraxSolver, EulerSolver):

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -15,10 +15,10 @@ from ..utils.utils import dag
 
 
 class MEDiffraxSolver(DiffraxSolver, MESolver):
-    def __init__(self, *args):
-        super().__init__(*args)
+    @property
+    def terms(self) -> dx.AbstractTerm:
+        # define Lindblad term drho/dt
 
-        # === define Lindblad term drho/dt
         def vector_field(t, y, _):  # noqa: ANN001, ANN202
             # drho/dt = -i [H, rho] + L @ rho @ Ld - 0.5 Ld @ L @ rho - 0.5 rho @ Ld @ L
             #         = {(-i H - 0.5 Ld @ L) @ rho + 0.5 L @ rho @ Ld} + h.c.
@@ -28,7 +28,7 @@ class MEDiffraxSolver(DiffraxSolver, MESolver):
             tmp = (-1j * self.H(t) - 0.5 * LdL) @ y + 0.5 * (Ls @ y @ Lsd).sum(0)
             return tmp + dag(tmp)
 
-        self.terms = dx.ODETerm(vector_field)
+        return dx.ODETerm(vector_field)
 
 
 class MEEuler(MEDiffraxSolver, EulerSolver):

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -9,11 +9,28 @@ __all__ = ['Options']
 
 
 class Options(eqx.Module):
-    save_states: bool
-    verbose: bool
-    cartesian_batching: bool
-    t0: Scalar | None
-    save_extra: callable[[Array], PyTree] | None
+    """Generic options for the quantum solvers.
+
+    Args:
+        save_states: If `True`, the state is saved at every time in `tsave`,
+            otherwise only the final state is returned.
+        verbose: If `True`, print information about the integration, otherwise
+            nothing is printed.
+        cartesian_batching: If `True`, batched arguments are treated as separated
+            batch dimensions, otherwise the batching is performed over a single
+            shared batched dimension.
+        t0: Initial time. If `None`, defaults to the first time in `tsave`.
+        save_extra _(function, optional)_: A function with signature
+            `f(Array) -> PyTree` that takes a state as input and returns a PyTree.
+            This can be used to save additional arbitrary data during the
+            integration.
+    """
+
+    save_states: bool = True
+    verbose: bool = True
+    cartesian_batching: bool = True
+    t0: Scalar | None = None
+    save_extra: callable[[Array], PyTree] | None = None
 
     def __init__(
         self,
@@ -23,28 +40,12 @@ class Options(eqx.Module):
         t0: Scalar | None = None,
         save_extra: callable[[Array], PyTree] | None = None,
     ):
-        """Generic options for the quantum solvers.
-
-        Args:
-            save_states: If `True`, the state is saved at every time in `tsave`,
-                otherwise only the final state is returned.
-            verbose: If `True`, print information about the integration, otherwise
-                nothing is printed.
-            cartesian_batching: If `True`, batched arguments are treated as separated
-                batch dimensions, otherwise the batching is performed over a single
-                shared batched dimension.
-            t0: Initial time. If `None`, defaults to the first time in `tsave`.
-            save_extra _(function, optional)_: A function with signature
-                `f(Array) -> PyTree` that takes a state as input and returns a PyTree.
-                This can be used to save additional arbitrary data during the
-                integration.
-        """
         self.save_states = save_states
         self.verbose = verbose
         self.cartesian_batching = cartesian_batching
         self.t0 = t0
+
+        # make `save_extra` a valid Pytree with `jax.tree_util.Partial`
         if save_extra is not None:
-            # use `jax.tree_util.Partial` to make `save_extra` a valid Pytree
-            self.save_extra = jax.tree_util.Partial(save_extra)
-        else:
-            self.save_extra = save_extra
+            save_extra = jax.tree_util.Partial(save_extra)
+        self.save_extra = save_extra

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import equinox as eqx
 import jax
 from jax import Array
-from jaxtyping import PyTree, Scalar
+from jaxtyping import PyTree, ScalarLike
 
 __all__ = ['Options']
 
@@ -29,7 +29,7 @@ class Options(eqx.Module):
     save_states: bool = True
     verbose: bool = True
     cartesian_batching: bool = True
-    t0: Scalar | None = None
+    t0: ScalarLike | None = None
     save_extra: callable[[Array], PyTree] | None = None
 
     def __init__(
@@ -37,7 +37,7 @@ class Options(eqx.Module):
         save_states: bool = True,
         verbose: bool = True,
         cartesian_batching: bool = True,
-        t0: Scalar | None = None,
+        t0: ScalarLike | None = None,
         save_extra: callable[[Array], PyTree] | None = None,
     ):
         self.save_states = save_states

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -27,8 +27,8 @@ def memory_str(x: Array) -> str:
         return f'{mem / 1024**3:.2f} Gb'
 
 
-def array_str(x: Array) -> str:
-    return f'Array {x.dtype} {tuple(x.shape)} | {memory_str(x)}'
+def array_str(x: Array | None) -> str | None:
+    return None if x is None else f'Array {x.dtype} {tuple(x.shape)} | {memory_str(x)}'
 
 
 class Saved(NamedTuple):
@@ -77,7 +77,7 @@ class Result(eqx.Module):
                 type(self.gradient).__name__ if self.gradient is not None else None
             ),
             'States  ': array_str(self.states),
-            'Expects ': array_str(self.expects) if self.expects is not None else None,
+            'Expects ': array_str(self.expects),
             'Extra   ': (
                 eqx.tree_pformat(self.extra) if self.extra is not None else None
             ),

--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -28,7 +28,7 @@ class SchrodingerTerm(dx.ODETerm):
 class SEDiffraxSolver(DiffraxSolver, SESolver):
     def __init__(self, *args):
         super().__init__(*args)
-        self.term = SchrodingerTerm(self.H)
+        self.terms = SchrodingerTerm(self.H)
 
 
 class SEEuler(SEDiffraxSolver, EulerSolver):

--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import diffrax as dx
-from jaxtyping import PyTree, Scalar
 
 from ..core.abstract_solver import SESolver
 from ..core.diffrax_solver import (
@@ -11,24 +10,16 @@ from ..core.diffrax_solver import (
     EulerSolver,
     Tsit5Solver,
 )
-from ..time_array import TimeArray
-
-
-class SchrodingerTerm(dx.ODETerm):
-    H: TimeArray  # (n, n)
-    vector_field: callable[[Scalar, PyTree, PyTree], PyTree]
-
-    def __init__(self, H: TimeArray):
-        self.H = H
-
-    def vector_field(self, t: Scalar, psi: PyTree, _args: PyTree) -> PyTree:
-        return -1j * self.H(t) @ psi
 
 
 class SEDiffraxSolver(DiffraxSolver, SESolver):
     def __init__(self, *args):
         super().__init__(*args)
-        self.terms = SchrodingerTerm(self.H)
+
+        # === define Schrödinger term d|psi>/dt = - i H |psi>
+        vector_field = lambda t, y, _: -1j * self.H(t) @ y
+
+        self.terms = dx.ODETerm(vector_field)
 
 
 class SEEuler(SEDiffraxSolver, EulerSolver):

--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -13,13 +13,11 @@ from ..core.diffrax_solver import (
 
 
 class SEDiffraxSolver(DiffraxSolver, SESolver):
-    def __init__(self, *args):
-        super().__init__(*args)
-
-        # === define Schrödinger term d|psi>/dt = - i H |psi>
+    @property
+    def terms(self) -> dx.AbstractTerm:
+        # define Schrödinger term d|psi>/dt = - i H |psi>
         vector_field = lambda t, y, _: -1j * self.H(t) @ y
-
-        self.terms = dx.ODETerm(vector_field)
+        return dx.ODETerm(vector_field)
 
 
 class SEEuler(SEDiffraxSolver, EulerSolver):

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -82,13 +82,8 @@ class _ODEAdaptiveStep(_ODESolver):
     max_steps: int = 100_000
 
 
-# === diffrax-based solvers options
-class _DiffraxSolver(Solver):
-    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
-
-
 # === public solvers options
-class Euler(_DiffraxSolver, _ODEFixedStep):
+class Euler(_ODEFixedStep):
     """Euler method (fixed step size ODE solver).
 
     This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
@@ -101,21 +96,25 @@ class Euler(_DiffraxSolver, _ODEFixedStep):
         dt _(float)_: Fixed time step.
     """  # noqa: E501
 
+    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
-        _ODEFixedStep.__init__(self, dt)
+        super().__init__(dt)
 
 
-class Rouchon1(_DiffraxSolver, _ODEFixedStep):
+class Rouchon1(_ODEFixedStep):
     """First-order Rouchon method (fixed step size ODE solver).
 
     Warning:
         This solver has not been ported to JAX yet.
     """
 
+    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
-        _ODEFixedStep.__init__(self, dt)
+        super().__init__(dt)
 
     # normalize: The default scheme is trace-preserving at first order only. This
     # parameter sets the normalisation behaviour:
@@ -130,19 +129,21 @@ class Rouchon1(_DiffraxSolver, _ODEFixedStep):
     # normalize: Literal['sqrt', 'cholesky'] | None = None
 
 
-class Rouchon2(_DiffraxSolver, _ODEFixedStep):
+class Rouchon2(_ODEFixedStep):
     """Second-order Rouchon method (fixed step size ODE solver).
 
     Warning:
         This solver has not been ported to JAX yet.
     """
 
+    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
-        _ODEFixedStep.__init__(self, dt)
+        super().__init__(dt)
 
 
-class Dopri5(_DiffraxSolver, _ODEAdaptiveStep):
+class Dopri5(_ODEAdaptiveStep):
     """Dormand-Prince method of order 5 (adaptive step size ODE solver).
 
     This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
@@ -157,6 +158,8 @@ class Dopri5(_DiffraxSolver, _ODEAdaptiveStep):
         max_steps: Maximum number of steps.
     """  # noqa: E501
 
+    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+
     # dummy init to have the signature in the documentation
     def __init__(
         self,
@@ -167,12 +170,10 @@ class Dopri5(_DiffraxSolver, _ODEAdaptiveStep):
         max_factor: float = 5.0,
         max_steps: int = 100_000,
     ):
-        _ODEAdaptiveStep.__init__(
-            self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
-        )
+        super().__init__(rtol, atol, safety_factor, min_factor, max_factor, max_steps)
 
 
-class Dopri8(_DiffraxSolver, _ODEAdaptiveStep):
+class Dopri8(_ODEAdaptiveStep):
     """Dormand-Prince method of order 8 (adaptive step size ODE solver).
 
     This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
@@ -187,6 +188,8 @@ class Dopri8(_DiffraxSolver, _ODEAdaptiveStep):
         max_steps: Maximum number of steps.
     """  # noqa: E501
 
+    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+
     # dummy init to have the signature in the documentation
     def __init__(
         self,
@@ -197,12 +200,10 @@ class Dopri8(_DiffraxSolver, _ODEAdaptiveStep):
         max_factor: float = 5.0,
         max_steps: int = 100_000,
     ):
-        _ODEAdaptiveStep.__init__(
-            self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
-        )
+        super().__init__(rtol, atol, safety_factor, min_factor, max_factor, max_steps)
 
 
-class Tsit5(_DiffraxSolver, _ODEAdaptiveStep):
+class Tsit5(_ODEAdaptiveStep):
     """Tsitouras method of order 5 (adaptive step size ODE solver).
 
     This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
@@ -217,6 +218,8 @@ class Tsit5(_DiffraxSolver, _ODEAdaptiveStep):
         max_steps: Maximum number of steps.
     """  # noqa: E501
 
+    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+
     # dummy init to have the signature in the documentation
     def __init__(
         self,
@@ -227,6 +230,4 @@ class Tsit5(_DiffraxSolver, _ODEAdaptiveStep):
         max_factor: float = 5.0,
         max_steps: int = 100_000,
     ):
-        _ODEAdaptiveStep.__init__(
-            self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
-        )
+        super().__init__(rtol, atol, safety_factor, min_factor, max_factor, max_steps)

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -9,9 +9,13 @@ from .gradient import Autograd, CheckpointAutograd, Gradient
 __all__ = ['Propagator', 'Euler', 'Rouchon1', 'Rouchon2', 'Dopri5', 'Dopri8', 'Tsit5']
 
 
+_TupleGradient = tuple[type[Gradient], ...]
+
+
 # === generic solvers options
 class Solver(eqx.Module):
-    SUPPORTED_GRADIENT: ClassVar[tuple[type[Gradient], ...]] = ()
+    # should be eqx.AbstractClassVar, but this conflicts with the __future__ imports
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient]
 
     @classmethod
     def supports_gradient(cls, gradient: Gradient | None) -> bool:  # noqa: ANN102
@@ -57,7 +61,7 @@ class Propagator(Solver):
         operators. Piecewise-constant problems will also be supported in the future.
     """
 
-    SUPPORTED_GRADIENT = (Autograd,)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd,)
 
     # dummy init to have the signature in the documentation
     def __init__(self):
@@ -96,7 +100,7 @@ class Euler(_ODEFixedStep):
         dt _(float)_: Fixed time step.
     """  # noqa: E501
 
-    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
@@ -110,7 +114,7 @@ class Rouchon1(_ODEFixedStep):
         This solver has not been ported to JAX yet.
     """
 
-    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
@@ -136,7 +140,7 @@ class Rouchon2(_ODEFixedStep):
         This solver has not been ported to JAX yet.
     """
 
-    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
@@ -158,7 +162,7 @@ class Dopri5(_ODEAdaptiveStep):
         max_steps: Maximum number of steps.
     """  # noqa: E501
 
-    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -188,7 +192,7 @@ class Dopri8(_ODEAdaptiveStep):
         max_steps: Maximum number of steps.
     """  # noqa: E501
 
-    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -218,7 +222,7 @@ class Tsit5(_ODEAdaptiveStep):
         max_steps: Maximum number of steps.
     """  # noqa: E501
 
-    SUPPORTED_GRADIENT = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
 
     # dummy init to have the signature in the documentation
     def __init__(

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -30,35 +30,38 @@ class Solver(eqx.Module):
 
 # === propagator solvers options
 class Propagator(Solver):
+    r"""Quantum propagator method.
+
+    Explicitly compute the propagator to evolve the state between each time in
+    `tsave`.
+
+    For the Schrödinger equation with constant Hamiltonian $H$, the propagator to
+    evolve the state from time $t_0$ to time $t_1$ is an $n\times n$ matrix given by
+    $$
+        U(t_0, t_1) = \exp(-i (t_1 - t_0) H).
+    $$
+
+    For the Lindblad master equation with constant Liouvillian $\mathcal{L}$, the
+    problem is vectorized and the propagator to evolve the state from time $t_0$ to
+    time $t_1$ is an $n^2\times n^2$ matrix given by
+    $$
+        \mathcal{U}(t_0, t_1) = \exp((t_1 - t_0)\mathcal{L}).
+    $$
+
+    Warning:
+        This solver is not recommended for open systems of large dimension, due to
+        the $\mathcal{O}(n^6)$ scaling of computing the Liouvillian exponential.
+
+    Warning: Constant Hamiltonian and jump operators only
+        The propagator method only supports constant Hamiltonian and jump
+        operators. Piecewise-constant problems will also be supported in the future.
+    """
+
     SUPPORTED_GRADIENT = (Autograd,)
 
+    # dummy init to have the signature in the documentation
     def __init__(self):
-        r"""Quantum propagator method.
-
-        Explicitly compute the propagator to evolve the state between each time in
-        `tsave`.
-
-        For the Schrödinger equation with constant Hamiltonian $H$, the propagator to
-        evolve the state from time $t_0$ to time $t_1$ is an $n\times n$ matrix given by
-        $$
-            U(t_0, t_1) = \exp(-i (t_1 - t_0) H).
-        $$
-
-        For the Lindblad master equation with constant Liouvillian $\mathcal{L}$, the
-        problem is vectorized and the propagator to evolve the state from time $t_0$ to
-        time $t_1$ is an $n^2\times n^2$ matrix given by
-        $$
-            \mathcal{U}(t_0, t_1) = \exp((t_1 - t_0)\mathcal{L}).
-        $$
-
-        Warning:
-            This solver is not recommended for open systems of large dimension, due to
-            the $\mathcal{O}(n^6)$ scaling of computing the Liouvillian exponential.
-
-        Warning: Constant Hamiltonian and jump operators only
-            The propagator method only supports constant Hamiltonian and jump
-            operators. Piecewise-constant problems will also be supported in the future.
-        """
+        pass
 
 
 # === generic ODE solvers options
@@ -86,28 +89,32 @@ class _DiffraxSolver(Solver):
 
 # === public solvers options
 class Euler(_DiffraxSolver, _ODEFixedStep):
+    """Euler method (fixed step size ODE solver).
+
+    This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
+    [`diffrax.Euler`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Euler).
+
+    Warning:
+        This solver is not recommended for general use.
+
+    Args:
+        dt _(float)_: Fixed time step.
+    """  # noqa: E501
+
+    # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
-        """Euler method (fixed step size ODE solver).
-
-        This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
-        [`diffrax.Euler`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Euler).
-
-        Warning:
-            This solver is not recommended for general use.
-
-        Args:
-            dt _(float)_: Fixed time step.
-        """  # noqa: E501
         _ODEFixedStep.__init__(self, dt)
 
 
 class Rouchon1(_DiffraxSolver, _ODEFixedStep):
-    def __init__(self, dt: float):
-        """First-order Rouchon method (fixed step size ODE solver).
+    """First-order Rouchon method (fixed step size ODE solver).
 
-        Warning:
-            This solver has not been ported to JAX yet.
-        """
+    Warning:
+        This solver has not been ported to JAX yet.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self, dt: float):
         _ODEFixedStep.__init__(self, dt)
 
     # normalize: The default scheme is trace-preserving at first order only. This
@@ -124,16 +131,33 @@ class Rouchon1(_DiffraxSolver, _ODEFixedStep):
 
 
 class Rouchon2(_DiffraxSolver, _ODEFixedStep):
-    def __init__(self, dt: float):
-        """Second-order Rouchon method (fixed step size ODE solver).
+    """Second-order Rouchon method (fixed step size ODE solver).
 
-        Warning:
-            This solver has not been ported to JAX yet.
-        """
+    Warning:
+        This solver has not been ported to JAX yet.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self, dt: float):
         _ODEFixedStep.__init__(self, dt)
 
 
 class Dopri5(_DiffraxSolver, _ODEAdaptiveStep):
+    """Dormand-Prince method of order 5 (adaptive step size ODE solver).
+
+    This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
+    [`diffrax.Dopri5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Dopri5).
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+    """  # noqa: E501
+
+    # dummy init to have the signature in the documentation
     def __init__(
         self,
         rtol: float = 1e-6,
@@ -143,25 +167,27 @@ class Dopri5(_DiffraxSolver, _ODEAdaptiveStep):
         max_factor: float = 5.0,
         max_steps: int = 100_000,
     ):
-        """Dormand-Prince method of order 5 (adaptive step size ODE solver).
-
-        This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
-        [`diffrax.Dopri5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Dopri5).
-
-        Args:
-            rtol: Relative tolerance.
-            atol: Absolute tolerance.
-            safety_factor: Safety factor for adaptive step sizing.
-            min_factor: Minimum factor for adaptive step sizing.
-            max_factor: Maximum factor for adaptive step sizing.
-            max_steps: Maximum number of steps.
-        """  # noqa: E501
         _ODEAdaptiveStep.__init__(
             self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
         )
 
 
 class Dopri8(_DiffraxSolver, _ODEAdaptiveStep):
+    """Dormand-Prince method of order 8 (adaptive step size ODE solver).
+
+    This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
+    [`diffrax.Dopri8`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Dopri8).
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+    """  # noqa: E501
+
+    # dummy init to have the signature in the documentation
     def __init__(
         self,
         rtol: float = 1e-6,
@@ -171,25 +197,27 @@ class Dopri8(_DiffraxSolver, _ODEAdaptiveStep):
         max_factor: float = 5.0,
         max_steps: int = 100_000,
     ):
-        """Dormand-Prince method of order 8 (adaptive step size ODE solver).
-
-        This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
-        [`diffrax.Dopri8`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Dopri8).
-
-        Args:
-            rtol: Relative tolerance.
-            atol: Absolute tolerance.
-            safety_factor: Safety factor for adaptive step sizing.
-            min_factor: Minimum factor for adaptive step sizing.
-            max_factor: Maximum factor for adaptive step sizing.
-            max_steps: Maximum number of steps.
-        """  # noqa: E501
         _ODEAdaptiveStep.__init__(
             self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
         )
 
 
 class Tsit5(_DiffraxSolver, _ODEAdaptiveStep):
+    """Tsitouras method of order 5 (adaptive step size ODE solver).
+
+    This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
+    [`diffrax.Tsit5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Tsit5).
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+    """  # noqa: E501
+
+    # dummy init to have the signature in the documentation
     def __init__(
         self,
         rtol: float = 1e-6,
@@ -199,19 +227,6 @@ class Tsit5(_DiffraxSolver, _ODEAdaptiveStep):
         max_factor: float = 5.0,
         max_steps: int = 100_000,
     ):
-        """Tsitouras method of order 5 (adaptive step size ODE solver).
-
-        This solver is implemented by the amazing [Diffrax](https://docs.kidger.site/diffrax/) library, see
-        [`diffrax.Tsit5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Tsit5).
-
-        Args:
-            rtol: Relative tolerance.
-            atol: Absolute tolerance.
-            safety_factor: Safety factor for adaptive step sizing.
-            min_factor: Minimum factor for adaptive step sizing.
-            max_factor: Maximum factor for adaptive step sizing.
-            max_steps: Maximum number of steps.
-        """  # noqa: E501
         _ODEAdaptiveStep.__init__(
             self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
         )

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax import Array, lax
 from jax.tree_util import Partial
-from jaxtyping import ArrayLike, PyTree, Scalar
+from jaxtyping import ArrayLike, PyTree, ScalarLike
 
 from ._utils import cdtype, check_time_array, obj_type_str
 
@@ -257,7 +257,7 @@ class TimeArray(eqx.Module):
         """
 
     @abstractmethod
-    def __call__(self, t: Scalar) -> Array:
+    def __call__(self, t: ScalarLike) -> Array:
         """Returns the time-array evaluated at a given time.
 
         Args:
@@ -313,7 +313,7 @@ class ConstantTimeArray(TimeArray):
     def mT(self) -> TimeArray:
         return ConstantTimeArray(self.x.mT)
 
-    def __call__(self, t: Scalar) -> Array:  # noqa: ARG002
+    def __call__(self, t: ScalarLike) -> Array:  # noqa: ARG002
         return self.x
 
     def reshape(self, *args: int) -> TimeArray:


### PR DESCRIPTION
A bunch of small minor fixes while writing `smesolve` (coming in two PRs!). To read commit by commit.

Some of these commits despaghettify a bit the code, by removing double inheritance when unnecessary, avoiding `__init__` chains (by using properties/attributes). Things are written a bit more the equinox way.