### PR TITLE
Decouple results for sesolve/mesolve

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ print(result)
 ```
 
 ```text
-==== Result ====
+==== MEResult ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
 Infos   : 7 steps (7 accepted, 0 rejected)

--- a/docs/getting_started/examples.md
+++ b/docs/getting_started/examples.md
@@ -29,7 +29,7 @@ print(result)
 ```
 
 ```text
-==== Result ====
+==== MEResult ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
 Infos   : 7 steps (7 accepted, 0 rejected)

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -52,7 +52,7 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
     options:
         table: true
 
-### Result
+### Results
 
 ::: dynamiqs.result
     options:

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -13,15 +13,15 @@ import timeit
 To simulate multiple Hamiltonians, you can pass an array of Hamiltonians for the argument `H` to [`dq.sesolve()`][dynamiqs.sesolve], [`dq.mesolve()`][dynamiqs.mesolve] or [`dq.smesolve()`][dynamiqs.smesolve]. You can also pass an array of initial states for the argument `psi0` (or `rho0` for open systems) to simulate multiple initial states. In this case, we say that the simulation is *batched*.
 
 !!! Note "Result of a batched simulation"
-    When a simulation is batched in dynamiqs, the result of the simulation is a batched array (a multi-dimensional array) that contains all the individual simulations results. The resulting `states` object has shape `(bH?, bstate?, nt, n, m)` where
+    When a simulation is batched in dynamiqs, the result of the simulation is a batched array (a multi-dimensional array) that contains all the individual simulations results. The resulting `states` object has shape `(nH?, nstate?, nt, n, m)` where
 
-    - `bH` is the number of Hamiltonians,
-    - `bstate` is the number of initial states,
+    - `nH` is the number of Hamiltonians,
+    - `nstate` is the number of initial states,
     - `nt` is the number of saved states,
     - `n` is the Hilbert space dimension,
     - `m=1` for closed systems and `m=n` for open systems.
 
-    The `?` in the shape `(bH?, bstate?, nt, n, n)` indicates that the dimension is only present if the simulation is batched over Hamiltonians or initial states.
+    The `?` in the shape `(nH?, nstate?, nt, n, n)` indicates that the dimension is only present if the simulation is batched over Hamiltonians or initial states.
 
 For instance, let's simulate the Schrödinger equation on multiple initial states:
 
@@ -41,7 +41,7 @@ print(result)
 ```
 
 ```
-==== Result ====
+==== SEResult ====
 Solver  : Tsit5
 States  : Array complex64 (4, 11, 2, 1) | 0.69 Kb
 Expects : Array complex64 (4, 1, 11) | 0.34 Kb

--- a/docs/tutorials/batching-simulations.md
+++ b/docs/tutorials/batching-simulations.md
@@ -13,15 +13,15 @@ import timeit
 To simulate multiple Hamiltonians, you can pass an array of Hamiltonians for the argument `H` to [`dq.sesolve()`][dynamiqs.sesolve], [`dq.mesolve()`][dynamiqs.mesolve] or [`dq.smesolve()`][dynamiqs.smesolve]. You can also pass an array of initial states for the argument `psi0` (or `rho0` for open systems) to simulate multiple initial states. In this case, we say that the simulation is *batched*.
 
 !!! Note "Result of a batched simulation"
-    When a simulation is batched in dynamiqs, the result of the simulation is a batched array (a multi-dimensional array) that contains all the individual simulations results. The resulting `states` object has shape `(nH?, nstate?, nt, n, m)` where
+    When a simulation is batched in dynamiqs, the result of the simulation is a batched array (a multi-dimensional array) that contains all the individual simulations results. The resulting `states` object has shape `(nH?, nstate?, ntsave, n, m)` where
 
     - `nH` is the number of Hamiltonians,
     - `nstate` is the number of initial states,
-    - `nt` is the number of saved states,
+    - `ntsave` is the number of saved states,
     - `n` is the Hilbert space dimension,
     - `m=1` for closed systems and `m=n` for open systems.
 
-    The `?` in the shape `(nH?, nstate?, nt, n, n)` indicates that the dimension is only present if the simulation is batched over Hamiltonians or initial states.
+    The `?` in the shape `(nH?, nstate?, ntsave, n, n)` indicates that the dimension is only present if the simulation is batched over Hamiltonians or initial states.
 
 For instance, let's simulate the Schrödinger equation on multiple initial states:
 
@@ -71,7 +71,7 @@ Similarly, `expects` has shape `(4, 1, 11)` where `4` is the number of initial s
 <!-- remove until smesolve is written again
 ## Batching over stochastic trajectories (SME)
 
-For the diffusive stochastic master equation solver, many stochastic trajectories must often be solved to obtain faithful statistics of the evolved density matrix. In this case, dynamiqs also provides batching over trajectories to run them simultaneously. This is performed automatically by setting the value of the `ntrajs` argument in [`dq.smesolve()`][dynamiqs.smesolve]. The resulting `states` object has shape `(bH?, brho?, ntrajs, nt, n, n)`.
+For the diffusive stochastic master equation solver, many stochastic trajectories must often be solved to obtain faithful statistics of the evolved density matrix. In this case, dynamiqs also provides batching over trajectories to run them simultaneously. This is performed automatically by setting the value of the `ntrajs` argument in [`dq.smesolve()`][dynamiqs.smesolve]. The resulting `states` object has shape `(bH?, brho?, ntrajs, ntsave, n, n)`.
 
 -->
 

--- a/docs/tutorials/workflow.md
+++ b/docs/tutorials/workflow.md
@@ -62,7 +62,7 @@ solver = dq.solver.Dopri5(rtol=1e-6, atol=1e-8)
 
 ## 3. Run the simulation
 
-We can now run the simulation. This is done by calling the [`dq.sesolve()`][dynamiqs.sesolve] function, which returns an instance of the [`Result`][dynamiqs.Result] class. This object contains the computed states, the observables, and various information about the solver.
+We can now run the simulation. This is done by calling the [`dq.sesolve()`][dynamiqs.sesolve] function, which returns an instance of the [`SEResult`][dynamiqs.SEResult] class. This object contains the computed states, the observables, and various information about the solver.
 
 ```python
 # run simulation
@@ -76,11 +76,11 @@ print(result)
 ```
 
 ```text
-`result` is of type <class 'dynamiqs.result.Result'>.
+`result` is of type <class 'dynamiqs.result.SEResult'>.
 `result` has the following attributes:
 ['Esave', '_abc_impl', 'expects', 'gradient', 'options', 'solver', 'states', 'to_numpy', 'to_qutip', 'tsave', 'ysave']
 
-==== Result ====
+==== SEResult ====
 Solver  : Dopri5
 States  : Array complex64 (101, 2, 1) | 1.58 Kb
 Expects : Array complex64 (1, 101) | 0.79 Kb

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -53,7 +53,7 @@ class BaseSolver(AbstractSolver):
         if not self.options.save_states:
             saved = eqx.tree_at(lambda x: x.ysave, saved, ylast)
 
-        # reorder Esave after jax.lax.scan stacking (nt, nE) -> (nE, nt)
+        # reorder Esave after jax.lax.scan stacking (ntsave, nE) -> (nE, ntsave)
         Esave = saved.Esave
         if Esave is not None:
             Esave = Esave.swapaxes(-1, -2)

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -57,9 +57,8 @@ class DiffraxSolver(BaseSolver):
 
         # === collect and return results
         save_a, save_b = solution.ys
-        saved = save_a
-        ylast = save_b[0]  # (n, m)
-        return self.result(saved, ylast, infos=self.infos(solution.stats))
+        saved = self.collect_saved(save_a, save_b[0])
+        return self.result(saved, infos=self.infos(solution.stats))
 
     @abstractmethod
     def infos(self, stats: dict[str, Array]) -> PyTree:

--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -9,7 +9,7 @@ from jax import Array
 from jaxtyping import PyTree, Scalar
 
 from ..time_array import ConstantTimeArray
-from .abstract_solver import BaseSolver, MESolver
+from .abstract_solver import BaseSolver, MESolver, SESolver
 
 
 class PropagatorSolver(BaseSolver):
@@ -55,14 +55,16 @@ class PropagatorSolver(BaseSolver):
 
         # === collect and return results
         nsteps = (delta_ts != 0).sum()
-        return self.result(saved, ylast, infos=self.Infos(nsteps))
+        saved = self.collect_saved(saved, ylast)
+        return self.result(saved, infos=self.Infos(nsteps))
 
     @abstractmethod
     def forward(self, delta_t: Scalar, y: Array) -> Array:
         pass
 
 
-SEPropagatorSolver = PropagatorSolver
+class SEPropagatorSolver(PropagatorSolver, SESolver):
+    pass
 
 
 class MEPropagatorSolver(PropagatorSolver, MESolver):

--- a/dynamiqs/mesolve/mepropagator.py
+++ b/dynamiqs/mesolve/mepropagator.py
@@ -3,6 +3,7 @@ from jax import Array
 from jaxtyping import Scalar
 
 from ..core.propagator_solver import MEPropagatorSolver
+from ..result import Saved
 from ..utils.vectorization import operator_to_vector, slindbladian, vector_to_operator
 
 
@@ -20,7 +21,7 @@ class MEPropagator(MEPropagatorSolver):
         propagator = jax.scipy.linalg.expm(delta_t * self.lindbladian)
         return propagator @ y
 
-    def save(self, y: Array) -> dict[str, Array]:
+    def save(self, y: Array) -> Saved:
         # TODO: implement bexpect for vectorized operators and convert at the end
         #       instead ofat each step
         y = vector_to_operator(y)

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -11,7 +11,7 @@ from .._utils import cdtype
 from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
-from ..result import Result
+from ..result import MEResult
 from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import TimeArray
 from ..utils.utils import todm
@@ -31,7 +31,7 @@ def mesolve(
     solver: Solver = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
     options: Options = Options(),  # noqa: B008
-) -> Result:
+) -> MEResult:
     r"""Solve the Lindblad master equation.
 
     This function computes the evolution of the density matrix $\rho(t)$ at time $t$,
@@ -64,10 +64,10 @@ def mesolve(
         more details.
 
     Args:
-        H _(array-like or time-array of shape (bH?, n, n))_: Hamiltonian.
+        H _(array-like or time-array of shape (nH?, n, n))_: Hamiltonian.
         jump_ops _(list of array-like or time-array, of shape (nL, n, n))_: List of
             jump operators.
-        rho0 _(array-like of shape (brho?, n, 1) or (brho?, n, n))_: Initial state.
+        rho0 _(array-like of shape (nrho0?, n, 1) or (nrho0?, n, n))_: Initial state.
         tsave _(array-like of shape (nt,))_: Times at which the states and expectation
             values are saved. The equation is solved from `tsave[0]` to `tsave[-1]`, or
             from `t0` to `tsave[-1]` if `t0` is specified in `options`.
@@ -79,21 +79,10 @@ def mesolve(
         options: Generic options, see [`dq.Options`][dynamiqs.Options].
 
     Returns:
-        [`dq.Result`][dynamiqs.Result] object holding the result of the Lindblad master
-            equation integration. It has the following attributes:
-
-            - **states** _(array of shape (bH?, brho?, nt, n, n))_ -- Saved states.
-            - **expects** _(array of shape (bH?, brho?, nE, nt), optional)_ -- Saved
-                expectation values.
-            - **extra** _(PyTree, optional)_ -- Extra data saved with `save_extra()` if
-                specified in `options`.
-            - **infos** _(PyTree, optional)_ -- Solver-dependent information on the
-                resolution.
-            - **tsave** _(array of shape (nt,))_ -- Times for which states and
-                expectation values were saved.
-            - **solver** _(Solver)_ -- Solver used.
-            - **gradient** _(Gradient)_ -- Gradient used.
-            - **options** _(Options)_ -- Options used.
+        [`dq.MEResult`][dynamiqs.MEResult] object holding the result of the Lindblad
+            master  equation integration. Use the attributes `states` and `expects`
+            to access saved quantities, more details in
+            [`dq.MEResult`][dynamiqs.MEResult].
     """
     # === convert arguments
     H = _astimearray(H)
@@ -118,7 +107,7 @@ def _vmap_mesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> Result:
+) -> MEResult:
     # === vectorize function
     # we vectorize over H, jump_ops and rho0, all other arguments are not vectorized
     is_batched = (
@@ -132,7 +121,7 @@ def _vmap_mesolve(
         False,
     )
     # the result is vectorized over `saved`
-    out_axes = Result(None, None, None, None, 0, 0)
+    out_axes = MEResult(None, None, None, None, 0, 0)
 
     f = compute_vmap(_mesolve, options.cartesian_batching, is_batched, out_axes)
 
@@ -149,7 +138,7 @@ def _mesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> Result:
+) -> MEResult:
     # === select solver class
     solvers = {
         Euler: MEEuler,

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -68,9 +68,9 @@ def mesolve(
         jump_ops _(list of array-like or time-array, of shape (nL, n, n))_: List of
             jump operators.
         rho0 _(array-like of shape (nrho0?, n, 1) or (nrho0?, n, n))_: Initial state.
-        tsave _(array-like of shape (nt,))_: Times at which the states and expectation
-            values are saved. The equation is solved from `tsave[0]` to `tsave[-1]`, or
-            from `t0` to `tsave[-1]` if `t0` is specified in `options`.
+        tsave _(array-like of shape (ntsave,))_: Times at which the states and
+            expectation values are saved. The equation is solved from `tsave[0]` to
+            `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
         exp_ops _(list of array-like, of shape (nE, n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration. Defaults to

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import NamedTuple
-
 import equinox as eqx
 from jax import Array
 from jaxtyping import PyTree
@@ -32,7 +30,7 @@ def array_str(x: Array | None) -> str | None:
 
 
 # the Saved object holds quantities saved during the equation integration
-class Saved(NamedTuple):
+class Saved(eqx.Module):
     ysave: Array
     Esave: Array | None
     extra: PyTree | None

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -92,13 +92,13 @@ class SEResult(Result):
     """Result of the Schrödinger equation integration.
 
     Attributes:
-        states _(array of shape (nH?, npsi0?, nt, n, 1))_: Saved states.
-        expects _(array of shape (nH?, npsi0?, nE, nt) or None)_: Saved expectation
+        states _(array of shape (nH?, npsi0?, ntsave, n, 1))_: Saved states.
+        expects _(array of shape (nH?, npsi0?, nE, ntsave) or None)_: Saved expectation
             values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options`.
         infos _(PyTree or None)_: Solver-dependent information on the resolution.
-        tsave _(array of shape (nt,))_: Times for which results were saved.
+        tsave _(array of shape (ntsave,))_: Times for which results were saved.
         solver _(Solver)_: Solver used.
         gradient _(Gradient)_: Gradient used.
         options _(Options)_: Options used.
@@ -109,13 +109,13 @@ class MEResult(Result):
     """Result of the Lindblad master equation integration.
 
     Attributes:
-        states _(array of shape (nH?, nrho0?, nt, n, n))_: Saved states.
-        expects _(array of shape (nH?, nrho0?, nE, nt) or None)_: Saved expectation
+        states _(array of shape (nH?, nrho0?, ntsave, n, n))_: Saved states.
+        expects _(array of shape (nH?, nrho0?, nE, ntsave) or None)_: Saved expectation
             values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options`.
         infos _(PyTree or None)_: Solver-dependent information on the resolution.
-        tsave _(array of shape (nt,))_: Times for which results were saved.
+        tsave _(array of shape (ntsave,))_: Times for which results were saved.
         solver _(Solver)_: Solver used.
         gradient _(Gradient)_: Gradient used.
         options _(Options)_: Options used.

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -11,7 +11,7 @@ from .._utils import cdtype
 from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
-from ..result import Result
+from ..result import SEResult
 from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import TimeArray
 from .sediffrax import SEDopri5, SEDopri8, SEEuler, SETsit5
@@ -29,7 +29,7 @@ def sesolve(
     solver: Solver = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
     options: Options = Options(),  # noqa: B008
-) -> Result:
+) -> SEResult:
     r"""Solve the Schrödinger equation.
 
     This function computes the evolution of the state vector $\ket{\psi(t)}$ at time
@@ -56,8 +56,8 @@ def sesolve(
         more details.
 
     Args:
-        H _(array-like or time-array of shape (bH?, n, n))_: Hamiltonian.
-        psi0 _(array-like of shape (bpsi?, n, 1))_: Initial state.
+        H _(array-like or time-array of shape (nH?, n, n))_: Hamiltonian.
+        psi0 _(array-like of shape (npsi0?, n, 1))_: Initial state.
         tsave _(array-like of shape (nt,))_: Times at which the states and expectation
             values are saved. The equation is solved from `tsave[0]` to `tsave[-1]`, or
             from `t0` to `tsave[-1]` if `t0` is specified in `options`.
@@ -69,20 +69,10 @@ def sesolve(
         options: Generic options, see [`dq.Options`][dynamiqs.Options].
 
     Returns:
-        [`dq.Result`][dynamiqs.Result] object holding the result of the
-            Schrödinger equation integration. It has the following attributes:
-
-            - **states** _(array of shape (bH?, bpsi?, nt, n, 1))_ -- Saved states.
-            - **expects** _(array of shape (bH?, bpsi?, nE, nt), optional)_ -- Saved
-                expectation values.
-            - **extra** _(PyTree, optional)_ -- Extra data saved with `save_extra()` if
-                specified in `options`.
-            - **infos** _(PyTree, optional)_ -- Solver-dependent information on the
-                resolution.
-            - **tsave** _(array of shape (nt,))_ -- Times for which results were saved.
-            - **solver** _(Solver)_ -- Solver used.
-            - **gradient** _(Gradient)_ -- Gradient used.
-            - **options** _(Options)_ -- Options used.
+        [`dq.SEResult`][dynamiqs.SEResult] object holding the result of the
+            Schrödinger equation integration. Use the attributes `states` and `expects`
+            to access saved quantities, more details in
+            [`dq.SEResult`][dynamiqs.SEResult].
     """
     # === convert arguments
     H = _astimearray(H)
@@ -104,12 +94,12 @@ def _vmap_sesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> Result:
+) -> SEResult:
     # === vectorize function
     # we vectorize over H and psi0, all other arguments are not vectorized
     is_batched = (H.ndim > 2, psi0.ndim > 2, False, False, False, False, False)
     # the result is vectorized over `saved`
-    out_axes = Result(None, None, None, None, 0, 0)
+    out_axes = SEResult(None, None, None, None, 0, 0)
     f = compute_vmap(_sesolve, options.cartesian_batching, is_batched, out_axes)
 
     # === apply vectorized function
@@ -124,7 +114,7 @@ def _sesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> Result:
+) -> SEResult:
     # === select solver class
     solvers = {
         Euler: SEEuler,

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -58,9 +58,9 @@ def sesolve(
     Args:
         H _(array-like or time-array of shape (nH?, n, n))_: Hamiltonian.
         psi0 _(array-like of shape (npsi0?, n, 1))_: Initial state.
-        tsave _(array-like of shape (nt,))_: Times at which the states and expectation
-            values are saved. The equation is solved from `tsave[0]` to `tsave[-1]`, or
-            from `t0` to `tsave[-1]` if `t0` is specified in `options`.
+        tsave _(array-like of shape (ntsave,))_: Times at which the states and
+            expectation values are saved. The equation is solved from `tsave[0]` to
+            `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
         exp_ops _(list of array-like, of shape (nE, n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration. Defaults to

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -106,9 +106,9 @@ def smesolve(
             dissipative loss channel, set the corresponding efficiency to 0. No
             measurement signal will be returned for such channels.
         rho0 _(array-like of shape (brho?, n, 1) or (brho?, n, n))_: Initial state.
-        tsave _(array-like of shape (nt,))_: Times at which the states and expectation
-            values are saved. The equation is solved from `tsave[0]` to `tsave[-1]`, or
-            from `t0` to `tsave[-1]` if `t0` is specified in `options`.
+        tsave _(array-like of shape (ntsave,))_: Times at which the states and
+            expectation values are saved. The equation is solved from `tsave[0]` to
+            `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
         tmeas _(array-like of shape (ntmeas,), optional)_: Times between which
             measurement signals are averaged and saved. Defaults to `tsave`.
         ntrajs: Number of stochastic trajectories to solve concurrently.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -155,7 +155,9 @@ nav:
               - Autograd: python_api/gradient/Autograd.md
               - CheckpointAutograd: python_api/gradient/CheckpointAutograd.md
           - Options: python_api/options/Options.md
-          - Result: python_api/result/Result.md
+          - Results:
+              - SEResult: python_api/result/SEResult.md
+              - MEResult: python_api/result/MEResult.md
       - Utilities:
           - Operators:
               - eye: python_api/utils/operators/eye.md

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -8,7 +8,7 @@ import dynamiqs as dq
 @pytest.mark.parametrize('cartesian_batching', [True, False])
 def test_batching(cartesian_batching):  # noqa: PLR0915
     n = 8
-    nt = 11
+    ntsave = 11
     nH = 3
     nL1 = 4 if cartesian_batching else nH
     nL2 = 5 if cartesian_batching else nH
@@ -24,64 +24,64 @@ def test_batching(cartesian_batching):  # noqa: PLR0915
     Ls0 = [L[0] for L in Ls]  # not batched L
     exp_ops = dq.rand_complex(k4, (nEs, n, n))
     psi0 = dq.rand_ket(k5, (npsi0, n, 1))
-    tsave = jnp.linspace(0, 0.01, nt)
+    tsave = jnp.linspace(0, 0.01, ntsave)
 
     # no batching
     result = dq.mesolve(H[0], Ls0, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (nt, n, n)
-    assert result.expects.shape == (nEs, nt)
+    assert result.states.shape == (ntsave, n, n)
+    assert result.expects.shape == (nEs, ntsave)
 
     # H batched
     result = dq.mesolve(H, Ls0, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (nH, nt, n, n)
-    assert result.expects.shape == (nH, nEs, nt)
+    assert result.states.shape == (nH, ntsave, n, n)
+    assert result.expects.shape == (nH, nEs, ntsave)
 
     # Ls batched
     result = dq.mesolve(H[0], Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nL1, nL2, nt, n, n)
-        assert result.expects.shape == (nL1, nL2, nEs, nt)
+        assert result.states.shape == (nL1, nL2, ntsave, n, n)
+        assert result.expects.shape == (nL1, nL2, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, nt, n, n)
-        assert result.expects.shape == (nH, nEs, nt)
+        assert result.states.shape == (nH, ntsave, n, n)
+        assert result.expects.shape == (nH, nEs, ntsave)
 
     # psi0 batched
     result = dq.mesolve(H[0], Ls0, psi0, tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (npsi0, nt, n, n)
-    assert result.expects.shape == (npsi0, nEs, nt)
+    assert result.states.shape == (npsi0, ntsave, n, n)
+    assert result.expects.shape == (npsi0, nEs, ntsave)
 
     # H and Ls batched
     result = dq.mesolve(H, Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nH, nL1, nL2, nt, n, n)
-        assert result.expects.shape == (nH, nL1, nL2, nEs, nt)
+        assert result.states.shape == (nH, nL1, nL2, ntsave, n, n)
+        assert result.expects.shape == (nH, nL1, nL2, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, nt, n, n)
-        assert result.expects.shape == (nH, nEs, nt)
+        assert result.states.shape == (nH, ntsave, n, n)
+        assert result.expects.shape == (nH, nEs, ntsave)
 
     # H and psi0 batched
     result = dq.mesolve(H, Ls0, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nH, npsi0, nt, n, n)
-        assert result.expects.shape == (nH, npsi0, nEs, nt)
+        assert result.states.shape == (nH, npsi0, ntsave, n, n)
+        assert result.expects.shape == (nH, npsi0, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, nt, n, n)
-        assert result.expects.shape == (nH, nEs, nt)
+        assert result.states.shape == (nH, ntsave, n, n)
+        assert result.expects.shape == (nH, nEs, ntsave)
 
     # Ls and psi0 batched
     result = dq.mesolve(H[0], Ls, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nL1, nL2, npsi0, nt, n, n)
-        assert result.expects.shape == (nL1, nL2, npsi0, nEs, nt)
+        assert result.states.shape == (nL1, nL2, npsi0, ntsave, n, n)
+        assert result.expects.shape == (nL1, nL2, npsi0, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, nt, n, n)
-        assert result.expects.shape == (nH, nEs, nt)
+        assert result.states.shape == (nH, ntsave, n, n)
+        assert result.expects.shape == (nH, nEs, ntsave)
 
     # H, Ls and psi0 batched
     result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nH, nL1, nL2, npsi0, nt, n, n)
-        assert result.expects.shape == (nH, nL1, nL2, npsi0, nEs, nt)
+        assert result.states.shape == (nH, nL1, nL2, npsi0, ntsave, n, n)
+        assert result.expects.shape == (nH, nL1, nL2, npsi0, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, nt, n, n)
-        assert result.expects.shape == (nH, nEs, nt)
+        assert result.states.shape == (nH, ntsave, n, n)
+        assert result.expects.shape == (nH, nEs, ntsave)

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -8,7 +8,7 @@ import dynamiqs as dq
 @pytest.mark.parametrize('cartesian_batching', [True, False])
 def test_batching(cartesian_batching):
     n = 8
-    nt = 11
+    ntsave = 11
     nH = 3
     npsi0 = 4 if cartesian_batching else nH
     nEs = 5
@@ -20,28 +20,28 @@ def test_batching(cartesian_batching):
     H = dq.rand_herm(k1, (nH, n, n))
     exp_ops = dq.rand_complex(k2, (nEs, n, n))
     psi0 = dq.rand_ket(k3, (npsi0, n, 1))
-    tsave = jnp.linspace(0, 0.01, nt)
+    tsave = jnp.linspace(0, 0.01, ntsave)
 
     # no batching
     result = dq.sesolve(H[0], psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (nt, n, 1)
-    assert result.expects.shape == (nEs, nt)
+    assert result.states.shape == (ntsave, n, 1)
+    assert result.expects.shape == (nEs, ntsave)
 
     # H batched
     result = dq.sesolve(H, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (nH, nt, n, 1)
-    assert result.expects.shape == (nH, nEs, nt)
+    assert result.states.shape == (nH, ntsave, n, 1)
+    assert result.expects.shape == (nH, nEs, ntsave)
 
     # psi0 batched
     result = dq.sesolve(H[0], psi0, tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (npsi0, nt, n, 1)
-    assert result.expects.shape == (npsi0, nEs, nt)
+    assert result.states.shape == (npsi0, ntsave, n, 1)
+    assert result.expects.shape == (npsi0, nEs, ntsave)
 
     # H and psi0 batched
     result = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nH, npsi0, nt, n, 1)
-        assert result.expects.shape == (nH, npsi0, nEs, nt)
+        assert result.states.shape == (nH, npsi0, ntsave, n, 1)
+        assert result.expects.shape == (nH, npsi0, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, nt, n, 1)
-        assert result.expects.shape == (nH, nEs, nt)
+        assert result.states.shape == (nH, ntsave, n, 1)
+        assert result.expects.shape == (nH, nEs, ntsave)


### PR DESCRIPTION
On top of #512.

Preparing the ground for `smesolve`. Also allows to specify documentation (e.g. shapes) independently.