### PR TITLE
Fix imageio "fps" deprecation warning.

### DIFF
--- a/dynamiqs/plots/plots_wigner.py
+++ b/dynamiqs/plots/plots_wigner.py
@@ -340,7 +340,8 @@ def plot_wigner_gif(
             frames.append(frame)
 
         # loop=0: loop the GIF forever
-        iio.v3.imwrite(filename, frames, format='GIF', fps=fps, loop=0)
+        duration = gif_duration * 1e3  # in ms
+        iio.v3.imwrite(filename, frames, format='GIF', duration=duration, loop=0)
         if display:
             ipy.display(ipy.Image(filename))
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "jaxtyping",
     "diffrax>=0.5.0",  # for complex support
     "equinox",
-    "imageio",
+    "imageio>=2.32.0", # for gif support
     "cmasher",
     "ipython",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "jaxtyping",
     "diffrax>=0.5.0",  # for complex support
     "equinox",
-    "imageio>=2.32.0", # for gif support
+    "imageio",
     "cmasher",
     "ipython",
 ]


### PR DESCRIPTION
In older versions, the `fps` keyword is deprecated, which raises a bug when running `dq.plot_wigner_gif`.

Closes https://linear.app/dynamiqs/issue/DYN-175/fix-fps-warning-when-running-tests.