### PR TITLE
Implements cos and sin for matrices

### DIFF
--- a/docs/getting_started/sharp-bits.md
+++ b/docs/getting_started/sharp-bits.md
@@ -42,10 +42,10 @@ Array([[0.+0.j, 1.+0.j],
        [1.+0.j, 0.+0.j]], dtype=complex64)
 ```
 
-Likewise, you should use `dq.mpow()` instead of `**` (element-wise power) to compute the power of a matrix:
+Likewise, you should use `dq.powm()` instead of `**` (element-wise power) to compute the power of a matrix:
 
 ```pycon
->>> dq.mpow(sx, 2)  # correct
+>>> dq.powm(sx, 2)  # correct
 Array([[1.+0.j, 0.+0.j],
        [0.+0.j, 1.+0.j]], dtype=complex64)
 >>> sx**2  # incorrect

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -6,7 +6,7 @@ This tutorial explains how to define time-dependent Hamiltonians – and more ge
     dynamiqs uses JAX arrays, which are different from QuTiP quantum objects. See [The sharp bits 🔪](../getting_started/sharp-bits.md) page for more details, briefly:
 
     - use `x + 2 * dq.eye(n)` instead of `x + 2`
-    - use `x @ y` instead of `x * y`, and `dq.mpow(x, 4)` instead of `x**4`
+    - use `x @ y` instead of `x * y`, and `dq.powm(x, 4)` instead of `x**4`
     - use `dq.dag(x)` or `x.mT.conj()` instead of `x.dag()`
 
 ```python

--- a/dynamiqs/utils/utils/__init__.py
+++ b/dynamiqs/utils/utils/__init__.py
@@ -4,8 +4,8 @@ from .wigner import *
 __all__ = [
     'dag',
     'powm',
-    'sinm',
     'cosm',
+    'sinm',
     'tracemm',
     'trace',
     'ptrace',

--- a/dynamiqs/utils/utils/__init__.py
+++ b/dynamiqs/utils/utils/__init__.py
@@ -4,6 +4,9 @@ from .wigner import *
 __all__ = [
     'dag',
     'mpow',
+    'sincosm',
+    'sinm',
+    'cosm',
     'tracemm',
     'trace',
     'ptrace',
@@ -27,7 +30,4 @@ __all__ = [
     'fidelity',
     'eigenstates',
     'wigner',
-    'sincosm',
-    'sinm',
-    'cosm',
 ]

--- a/dynamiqs/utils/utils/__init__.py
+++ b/dynamiqs/utils/utils/__init__.py
@@ -6,7 +6,6 @@ __all__ = [
     'powm',
     'sinm',
     'cosm',
-    'sincosm',
     'tracemm',
     'trace',
     'ptrace',

--- a/dynamiqs/utils/utils/__init__.py
+++ b/dynamiqs/utils/utils/__init__.py
@@ -4,9 +4,9 @@ from .wigner import *
 __all__ = [
     'dag',
     'mpow',
-    'sincosm',
     'sinm',
     'cosm',
+    'sincosm',
     'tracemm',
     'trace',
     'ptrace',

--- a/dynamiqs/utils/utils/__init__.py
+++ b/dynamiqs/utils/utils/__init__.py
@@ -27,4 +27,7 @@ __all__ = [
     'fidelity',
     'eigenstates',
     'wigner',
+    'sincosm',
+    'sinm',
+    'cosm',
 ]

--- a/dynamiqs/utils/utils/__init__.py
+++ b/dynamiqs/utils/utils/__init__.py
@@ -3,7 +3,7 @@ from .wigner import *
 
 __all__ = [
     'dag',
-    'mpow',
+    'powm',
     'sinm',
     'cosm',
     'sincosm',

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -6,6 +6,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
+from jax.scipy.linalg import expm
 from jaxtyping import ArrayLike
 
 from ..._utils import on_cpu
@@ -109,7 +110,7 @@ def sinm(x: ArrayLike) -> Array:
                [1.-0.j, 0.-0.j]], dtype=complex64)
     """
     x = jnp.asarray(x)
-    return -0.5j * (jax.scipy.linalg.expm(1j * x) - jax.scipy.linalg.expm(-1j * x))
+    return -0.5j * (expm(1j * x) - expm(-1j * x))
 
 
 def cosm(x: ArrayLike) -> Array:
@@ -134,7 +135,7 @@ def cosm(x: ArrayLike) -> Array:
                [ 0.+0.j, -1.+0.j]], dtype=complex64)
     """
     x = jnp.asarray(x)
-    return 0.5 * (jax.scipy.linalg.expm(1j * x) + jax.scipy.linalg.expm(-1j * x))
+    return 0.5 * (expm(1j * x) + expm(-1j * x))
 
 
 def tracemm(x: ArrayLike, y: ArrayLike) -> Array:

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -35,6 +35,9 @@ __all__ = [
     'overlap',
     'fidelity',
     'eigenstates',
+    'sincosm',
+    'sinm',
+    'cosm',
 ]
 
 
@@ -83,6 +86,74 @@ def mpow(x: ArrayLike, n: int) -> Array:
     """
     x = jnp.asarray(x)
     return jnp.linalg.matrix_power(x, n)
+
+
+def sincosm(x: ArrayLike) -> tuple[Array, Array]:
+    """Returns the sine and cosine of an array.
+
+    Args:
+        x _(array_like of shape (..., n, n))_: Square matrix.
+
+    Returns:
+        `sin, cos` _(arrays of shape (..., n, n))_: sine and cosine of `x`.
+
+    Notes:
+        This function uses `jax.scipy.linalg.expm`.
+
+    Examples:
+        >>> sin, cos = dq.sincosm(0.25 * jnp.pi * dq.sigmax())
+        >>> (sin + cos) * jnp.sqrt(2)
+        Array([[1.+0.j, 1.+0.j],
+               [1.+0.j, 1.+0.j]], dtype=complex64)
+    """
+    x = jnp.asarray(x)
+    exp_ip = jax.scipy.linalg.expm(1j * x)
+    exp_im = jax.scipy.linalg.expm(-1j * x)
+    sin_x = -0.5j * (exp_ip - exp_im)
+    cos_x = 0.5 * (exp_ip + exp_im)
+    return sin_x, cos_x
+
+
+def sinm(x: ArrayLike) -> Array:
+    """Returns the sine of an array.
+
+    Args:
+        x _(array_like of shape (..., n, n))_: Square matrix.
+
+    Returns:
+        _(array of shape (..., n, n))_: sine of `x`.
+
+    Notes:
+        This function uses `jax.scipy.linalg.expm`.
+
+    Examples:
+        >>> dq.sinm(0.5 * jnp.pi * dq.sigmax())
+        Array([[0.-0.j, 1.-0.j],
+               [1.-0.j, 0.-0.j]], dtype=complex64)
+    """
+    x = jnp.asarray(x)
+    return -0.5j * (jax.scipy.linalg.expm(1j * x) - jax.scipy.linalg.expm(-1j * x))
+
+
+def cosm(x: ArrayLike) -> Array:
+    """Returns the cosine of an array.
+
+    Args:
+        x _(array_like of shape (..., n, n))_: Square matrix.
+
+    Returns:
+        _(array of shape (..., n, n))_: cosine of `x`.
+
+    Notes:
+        This function uses `jax.scipy.linalg.expm`.
+
+    Examples:
+        >>> dq.cosm(jnp.pi * dq.sigmax())
+        Array([[-1.+0.j,  0.+0.j],
+               [ 0.+0.j, -1.+0.j]], dtype=complex64)
+    """
+    x = jnp.asarray(x)
+    return 0.5 * (jax.scipy.linalg.expm(1j * x) + jax.scipy.linalg.expm(-1j * x))
 
 
 def tracemm(x: ArrayLike, y: ArrayLike) -> Array:

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -126,6 +126,10 @@ def sinm(x: ArrayLike) -> Array:
     Notes:
         This function uses `jax.scipy.linalg.expm`.
 
+    Notes:
+        For better performance, consider using [`dq.sincosm()`][dynamiqs.sincosm] if you
+        wish to compute both the sine and cosine of the same array.
+
     Examples:
         >>> dq.sinm(0.5 * jnp.pi * dq.sigmax())
         Array([[0.-0.j, 1.-0.j],
@@ -146,6 +150,10 @@ def cosm(x: ArrayLike) -> Array:
 
     Notes:
         This function uses `jax.scipy.linalg.expm`.
+
+    Notes:
+        For better performance, consider using [`dq.sincosm()`][dynamiqs.sincosm] if you
+        wish to compute both the sine and cosine of the same array.
 
     Examples:
         >>> dq.cosm(jnp.pi * dq.sigmax())

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -89,7 +89,7 @@ def mpow(x: ArrayLike, n: int) -> Array:
 
 
 def sincosm(x: ArrayLike) -> tuple[Array, Array]:
-    """Returns the sine and cosine of an array.
+    r"""Returns the sine and cosine of an array.
 
     Args:
         x _(array_like of shape (..., n, n))_: Square matrix.
@@ -98,7 +98,14 @@ def sincosm(x: ArrayLike) -> tuple[Array, Array]:
         _(tuple with two arrays of shape (..., n, n))_ Sine and cosine of `x`.
 
     Notes:
-        This function uses `jax.scipy.linalg.expm`.
+        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
+        to compute the sine and cosine of a matrix $A$:
+        $$
+            \begin{aligned}
+                \sin(A) &= \frac{e^{iA} - e^{-iA}}{2i} \\\\
+                \cos(A) &= \frac{e^{iA} + e^{-iA}}{2}
+            \end{aligned}
+        $$
 
     Examples:
         >>> sin, cos = dq.sincosm(0.25 * jnp.pi * dq.sigmax())
@@ -115,7 +122,7 @@ def sincosm(x: ArrayLike) -> tuple[Array, Array]:
 
 
 def sinm(x: ArrayLike) -> Array:
-    """Returns the sine of an array.
+    r"""Returns the sine of an array.
 
     Args:
         x _(array_like of shape (..., n, n))_: Square matrix.
@@ -124,7 +131,11 @@ def sinm(x: ArrayLike) -> Array:
         _(array of shape (..., n, n))_ Sine of `x`.
 
     Notes:
-        This function uses `jax.scipy.linalg.expm`.
+        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
+        to compute the sine of a matrix $A$:
+        $$
+            \sin(A) = \frac{e^{iA} - e^{-iA}}{2i}
+        $$
 
     Notes:
         For better performance, consider using [`dq.sincosm()`][dynamiqs.sincosm] if you
@@ -140,7 +151,7 @@ def sinm(x: ArrayLike) -> Array:
 
 
 def cosm(x: ArrayLike) -> Array:
-    """Returns the cosine of an array.
+    r"""Returns the cosine of an array.
 
     Args:
         x _(array_like of shape (..., n, n))_: Square matrix.
@@ -149,7 +160,11 @@ def cosm(x: ArrayLike) -> Array:
         _(array of shape (..., n, n))_ Cosine of `x`.
 
     Notes:
-        This function uses `jax.scipy.linalg.expm`.
+        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
+        to compute the cosine of a matrix $A$:
+        $$
+            \cos(A) = \frac{e^{iA} + e^{-iA}}{2}
+        $$
 
     Notes:
         For better performance, consider using [`dq.sincosm()`][dynamiqs.sincosm] if you

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -12,7 +12,7 @@ from ..._utils import on_cpu
 
 __all__ = [
     'dag',
-    'mpow',
+    'powm',
     'sinm',
     'cosm',
     'sincosm',
@@ -66,7 +66,7 @@ def dag(x: ArrayLike) -> Array:
     return x.mT.conj()
 
 
-def mpow(x: ArrayLike, n: int) -> Array:
+def powm(x: ArrayLike, n: int) -> Array:
     """Returns the $n$-th matrix power of an array.
 
     Args:
@@ -80,7 +80,7 @@ def mpow(x: ArrayLike, n: int) -> Array:
         This function is equivalent to `jnp.linalg.matrix_power(x, n)`.
 
     Examples:
-        >>> dq.mpow(dq.sigmax(), 2)
+        >>> dq.powm(dq.sigmax(), 2)
         Array([[1.+0.j, 0.+0.j],
                [0.+0.j, 1.+0.j]], dtype=complex64)
     """

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -15,7 +15,6 @@ __all__ = [
     'powm',
     'sinm',
     'cosm',
-    'sincosm',
     'tracemm',
     'trace',
     'ptrace',
@@ -104,10 +103,6 @@ def sinm(x: ArrayLike) -> Array:
             \sin(A) = \frac{e^{iA} - e^{-iA}}{2i}
         $$
 
-    Notes:
-        For better performance, consider using [`dq.sincosm()`][dynamiqs.sincosm] if you
-        wish to compute both the sine and cosine of the same array.
-
     Examples:
         >>> dq.sinm(0.5 * jnp.pi * dq.sigmax())
         Array([[0.-0.j, 1.-0.j],
@@ -133,10 +128,6 @@ def cosm(x: ArrayLike) -> Array:
             \cos(A) = \frac{e^{iA} + e^{-iA}}{2}
         $$
 
-    Notes:
-        For better performance, consider using [`dq.sincosm()`][dynamiqs.sincosm] if you
-        wish to compute both the sine and cosine of the same array.
-
     Examples:
         >>> dq.cosm(jnp.pi * dq.sigmax())
         Array([[-1.+0.j,  0.+0.j],
@@ -144,39 +135,6 @@ def cosm(x: ArrayLike) -> Array:
     """
     x = jnp.asarray(x)
     return 0.5 * (jax.scipy.linalg.expm(1j * x) + jax.scipy.linalg.expm(-1j * x))
-
-
-def sincosm(x: ArrayLike) -> tuple[Array, Array]:
-    r"""Returns the sine and cosine of an array.
-
-    Args:
-        x _(array_like of shape (..., n, n))_: Square matrix.
-
-    Returns:
-        _(tuple with two arrays of shape (..., n, n))_ Sine and cosine of `x`.
-
-    Notes:
-        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
-        to compute the sine and cosine of a matrix $A$:
-        $$
-            \begin{aligned}
-                \sin(A) &= \frac{e^{iA} - e^{-iA}}{2i} \\\\
-                \cos(A) &= \frac{e^{iA} + e^{-iA}}{2}
-            \end{aligned}
-        $$
-
-    Examples:
-        >>> sin, cos = dq.sincosm(0.25 * jnp.pi * dq.sigmax())
-        >>> (sin + cos) * jnp.sqrt(2)
-        Array([[1.+0.j, 1.+0.j],
-               [1.+0.j, 1.+0.j]], dtype=complex64)
-    """
-    x = jnp.asarray(x)
-    exp_ip = jax.scipy.linalg.expm(1j * x)
-    exp_im = jax.scipy.linalg.expm(-1j * x)
-    sin_x = -0.5j * (exp_ip - exp_im)
-    cos_x = 0.5 * (exp_ip + exp_im)
-    return sin_x, cos_x
 
 
 def tracemm(x: ArrayLike, y: ArrayLike) -> Array:

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -14,8 +14,8 @@ from ..._utils import on_cpu
 __all__ = [
     'dag',
     'powm',
-    'sinm',
     'cosm',
+    'sinm',
     'tracemm',
     'trace',
     'ptrace',
@@ -88,31 +88,6 @@ def powm(x: ArrayLike, n: int) -> Array:
     return jnp.linalg.matrix_power(x, n)
 
 
-def sinm(x: ArrayLike) -> Array:
-    r"""Returns the sine of an array.
-
-    Args:
-        x _(array_like of shape (..., n, n))_: Square matrix.
-
-    Returns:
-        _(array of shape (..., n, n))_ Sine of `x`.
-
-    Notes:
-        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
-        to compute the sine of a matrix $A$:
-        $$
-            \sin(A) = \frac{e^{iA} - e^{-iA}}{2i}
-        $$
-
-    Examples:
-        >>> dq.sinm(0.5 * jnp.pi * dq.sigmax())
-        Array([[0.-0.j, 1.-0.j],
-               [1.-0.j, 0.-0.j]], dtype=complex64)
-    """
-    x = jnp.asarray(x)
-    return -0.5j * (expm(1j * x) - expm(-1j * x))
-
-
 def cosm(x: ArrayLike) -> Array:
     r"""Returns the cosine of an array.
 
@@ -136,6 +111,31 @@ def cosm(x: ArrayLike) -> Array:
     """
     x = jnp.asarray(x)
     return 0.5 * (expm(1j * x) + expm(-1j * x))
+
+
+def sinm(x: ArrayLike) -> Array:
+    r"""Returns the sine of an array.
+
+    Args:
+        x _(array_like of shape (..., n, n))_: Square matrix.
+
+    Returns:
+        _(array of shape (..., n, n))_ Sine of `x`.
+
+    Notes:
+        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
+        to compute the sine of a matrix $A$:
+        $$
+            \sin(A) = \frac{e^{iA} - e^{-iA}}{2i}
+        $$
+
+    Examples:
+        >>> dq.sinm(0.5 * jnp.pi * dq.sigmax())
+        Array([[0.-0.j, 1.-0.j],
+               [1.-0.j, 0.-0.j]], dtype=complex64)
+    """
+    x = jnp.asarray(x)
+    return -0.5j * (expm(1j * x) - expm(-1j * x))
 
 
 def tracemm(x: ArrayLike, y: ArrayLike) -> Array:

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -13,9 +13,9 @@ from ..._utils import on_cpu
 __all__ = [
     'dag',
     'mpow',
-    'sincosm',
     'sinm',
     'cosm',
+    'sincosm',
     'tracemm',
     'trace',
     'ptrace',
@@ -88,39 +88,6 @@ def mpow(x: ArrayLike, n: int) -> Array:
     return jnp.linalg.matrix_power(x, n)
 
 
-def sincosm(x: ArrayLike) -> tuple[Array, Array]:
-    r"""Returns the sine and cosine of an array.
-
-    Args:
-        x _(array_like of shape (..., n, n))_: Square matrix.
-
-    Returns:
-        _(tuple with two arrays of shape (..., n, n))_ Sine and cosine of `x`.
-
-    Notes:
-        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
-        to compute the sine and cosine of a matrix $A$:
-        $$
-            \begin{aligned}
-                \sin(A) &= \frac{e^{iA} - e^{-iA}}{2i} \\\\
-                \cos(A) &= \frac{e^{iA} + e^{-iA}}{2}
-            \end{aligned}
-        $$
-
-    Examples:
-        >>> sin, cos = dq.sincosm(0.25 * jnp.pi * dq.sigmax())
-        >>> (sin + cos) * jnp.sqrt(2)
-        Array([[1.+0.j, 1.+0.j],
-               [1.+0.j, 1.+0.j]], dtype=complex64)
-    """
-    x = jnp.asarray(x)
-    exp_ip = jax.scipy.linalg.expm(1j * x)
-    exp_im = jax.scipy.linalg.expm(-1j * x)
-    sin_x = -0.5j * (exp_ip - exp_im)
-    cos_x = 0.5 * (exp_ip + exp_im)
-    return sin_x, cos_x
-
-
 def sinm(x: ArrayLike) -> Array:
     r"""Returns the sine of an array.
 
@@ -177,6 +144,39 @@ def cosm(x: ArrayLike) -> Array:
     """
     x = jnp.asarray(x)
     return 0.5 * (jax.scipy.linalg.expm(1j * x) + jax.scipy.linalg.expm(-1j * x))
+
+
+def sincosm(x: ArrayLike) -> tuple[Array, Array]:
+    r"""Returns the sine and cosine of an array.
+
+    Args:
+        x _(array_like of shape (..., n, n))_: Square matrix.
+
+    Returns:
+        _(tuple with two arrays of shape (..., n, n))_ Sine and cosine of `x`.
+
+    Notes:
+        This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
+        to compute the sine and cosine of a matrix $A$:
+        $$
+            \begin{aligned}
+                \sin(A) &= \frac{e^{iA} - e^{-iA}}{2i} \\\\
+                \cos(A) &= \frac{e^{iA} + e^{-iA}}{2}
+            \end{aligned}
+        $$
+
+    Examples:
+        >>> sin, cos = dq.sincosm(0.25 * jnp.pi * dq.sigmax())
+        >>> (sin + cos) * jnp.sqrt(2)
+        Array([[1.+0.j, 1.+0.j],
+               [1.+0.j, 1.+0.j]], dtype=complex64)
+    """
+    x = jnp.asarray(x)
+    exp_ip = jax.scipy.linalg.expm(1j * x)
+    exp_im = jax.scipy.linalg.expm(-1j * x)
+    sin_x = -0.5j * (exp_ip - exp_im)
+    cos_x = 0.5 * (exp_ip + exp_im)
+    return sin_x, cos_x
 
 
 def tracemm(x: ArrayLike, y: ArrayLike) -> Array:

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -95,7 +95,7 @@ def sincosm(x: ArrayLike) -> tuple[Array, Array]:
         x _(array_like of shape (..., n, n))_: Square matrix.
 
     Returns:
-        `sin, cos` _(arrays of shape (..., n, n))_: sine and cosine of `x`.
+        _(tuple with two arrays of shape (..., n, n))_ Sine and cosine of `x`.
 
     Notes:
         This function uses `jax.scipy.linalg.expm`.
@@ -121,7 +121,7 @@ def sinm(x: ArrayLike) -> Array:
         x _(array_like of shape (..., n, n))_: Square matrix.
 
     Returns:
-        _(array of shape (..., n, n))_: sine of `x`.
+        _(array of shape (..., n, n))_ Sine of `x`.
 
     Notes:
         This function uses `jax.scipy.linalg.expm`.
@@ -142,7 +142,7 @@ def cosm(x: ArrayLike) -> Array:
         x _(array_like of shape (..., n, n))_: Square matrix.
 
     Returns:
-        _(array of shape (..., n, n))_: cosine of `x`.
+        _(array of shape (..., n, n))_ Cosine of `x`.
 
     Notes:
         This function uses `jax.scipy.linalg.expm`.

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -13,6 +13,9 @@ from ..._utils import on_cpu
 __all__ = [
     'dag',
     'mpow',
+    'sincosm',
+    'sinm',
+    'cosm',
     'tracemm',
     'trace',
     'ptrace',
@@ -35,9 +38,6 @@ __all__ = [
     'overlap',
     'fidelity',
     'eigenstates',
-    'sincosm',
-    'sinm',
-    'cosm',
 ]
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,6 +187,9 @@ nav:
           - Quantum utilities:
               - dag: python_api/utils/utils/dag.md
               - mpow: python_api/utils/utils/mpow.md
+              - sinm: python_api/utils/utils/sinm.md
+              - cosm: python_api/utils/utils/cosm.md
+              - sincosm: python_api/utils/utils/sincosm.md
               - tracemm: python_api/utils/utils/tracemm.md
               - trace: python_api/utils/utils/trace.md
               - ptrace: python_api/utils/utils/ptrace.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -189,7 +189,6 @@ nav:
               - powm: python_api/utils/utils/powm.md
               - sinm: python_api/utils/utils/sinm.md
               - cosm: python_api/utils/utils/cosm.md
-              - sincosm: python_api/utils/utils/sincosm.md
               - tracemm: python_api/utils/utils/tracemm.md
               - trace: python_api/utils/utils/trace.md
               - ptrace: python_api/utils/utils/ptrace.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,7 +186,7 @@ nav:
               - coherent_dm: python_api/utils/states/coherent_dm.md
           - Quantum utilities:
               - dag: python_api/utils/utils/dag.md
-              - mpow: python_api/utils/utils/mpow.md
+              - powm: python_api/utils/utils/powm.md
               - sinm: python_api/utils/utils/sinm.md
               - cosm: python_api/utils/utils/cosm.md
               - sincosm: python_api/utils/utils/sincosm.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -187,8 +187,8 @@ nav:
           - Quantum utilities:
               - dag: python_api/utils/utils/dag.md
               - powm: python_api/utils/utils/powm.md
-              - sinm: python_api/utils/utils/sinm.md
               - cosm: python_api/utils/utils/cosm.md
+              - sinm: python_api/utils/utils/sinm.md
               - tracemm: python_api/utils/utils/tracemm.md
               - trace: python_api/utils/utils/trace.md
               - ptrace: python_api/utils/utils/ptrace.md


### PR DESCRIPTION
Resolves DYN-10. 
Uses `jax.scipy.linalg.expm`. That's how [Julia does](https://github.com/JuliaLang/julia/blob/09400e4f5c3e31ba528c2dbcf8e1ccef2a66ce3d/stdlib/LinearAlgebra/src/dense.jl#L1100).
Added `sincosm`, which is useful when we need both sine and cosine and avoid twice the computation. 