### PR TITLE
Remove matplotlib DeprecationWarning

### DIFF
--- a/dynamiqs/plots/plots_hinton.py
+++ b/dynamiqs/plots/plots_hinton.py
@@ -105,7 +105,7 @@ def _plot_hinton(
     # squares areas
     areas = areas.T.flatten()
     # squares colors
-    cmap = mpl.colormaps.get_cmap(cmap)
+    cmap = mpl.colormaps[cmap]
     colors = cmap(colors.T).reshape(-1, 4)
     _plot_squares(ax, areas, colors, offsets, ecolor=ecolor, ewidth=ewidth)
 

--- a/dynamiqs/plots/utils.py
+++ b/dynamiqs/plots/utils.py
@@ -209,7 +209,7 @@ def bra_ticks(axis: Axis):
 
 
 def sample_cmap(name: str, n: int, alpha: float = 1.0) -> np.ndarray:
-    sampled_cmap = matplotlib.colormaps.get_cmap(name)(np.linspace(0, 1, n))
+    sampled_cmap = matplotlib.colormaps[name](np.linspace(0, 1, n))
     sampled_cmap[:, -1] = alpha
     return sampled_cmap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "diffrax>=0.5.0",  # for complex support
     "equinox",
     "imageio",
-    "cmasher",
+    "cmasher>=1.8.0",  # avoid matplotlib colormaps deprecation warning
     "ipython",
 ]
 


### PR DESCRIPTION
Fixes this warning:
```
(base) ➜  dynamiqs git:(fix-matplotlib-warning) ✗ pytest dynamiqs/plots/plots_wigner.py

Test session starts (platform: darwin, Python 3.11.4, pytest 7.4.2, pytest-sugar 0.9.7)
rootdir: /Users/rgautier/Code/dynamiqs
configfile: pytest.ini
plugins: jaxtyping-0.2.25, typeguard-2.13.3, xdist-3.3.1, sugar-0.9.7
collected 47 items                                                                                                   

 dynamiqs/plots/plots_wigner.py ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓                        100% ██████████
================================================== warnings summary ==================================================
../../miniconda3/lib/python3.11/site-packages/cmasher/utils.py:859: 110 warnings
  /Users/rgautier/miniconda3/lib/python3.11/site-packages/cmasher/utils.py:859: MatplotlibDeprecationWarning: The get_cmap function was deprecated in Matplotlib 3.7 and will be removed two minor releases later. Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = mplcm.get_cmap(cmap)
```