### PR TITLE
Fix bug with save_states=False

### DIFF
--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -51,7 +51,9 @@ class BaseSolver(AbstractSolver):
     def collect_saved(self, saved: Saved, ylast: Array) -> Saved:
         # if save_states is False save only last state
         if not self.options.save_states:
-            saved = eqx.tree_at(lambda x: x.ysave, saved, ylast)
+            saved = eqx.tree_at(
+                lambda x: x.ysave, saved, ylast, is_leaf=lambda x: x is None
+            )
 
         # reorder Esave after jax.lax.scan stacking (ntsave, nE) -> (nE, ntsave)
         Esave = saved.Esave


### PR DESCRIPTION
`save_states=False` was bugged.
```python
import dynamiqs as dq
import jax.numpy as jnp

N = 16
alpha = 2.0

psi0 = dq.coherent(N, alpha)
a = dq.destroy(N)
H = dq.dag(a) @ a
tsave = jnp.linspace(0, 1.0, 11)
options = dq.Options(save_states=False)

result = dq.sesolve(H, psi0, tsave, options=options)
```