### PR TITLE
Fix imageio duration argument for wigner gif (re-fix)

### DIFF
--- a/dynamiqs/plots/plots_wigner.py
+++ b/dynamiqs/plots/plots_wigner.py
@@ -340,7 +340,10 @@ def plot_wigner_gif(
             frames.append(frame)
 
         # loop=0: loop the GIF forever
-        iio.v3.imwrite(filename, frames, format='GIF', duration=gif_duration, loop=0)
+        frame_duration_ms = 1000 * 1 / fps
+        iio.v3.imwrite(
+            filename, frames, format='GIF', duration=frame_duration_ms, loop=0
+        )
         if display:
             ipy.display(ipy.Image(filename))
     finally:


### PR DESCRIPTION
Following #520 and #525. See https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html.