### PR TITLE
Verify the shape of `ArrayLike` arguments in public API

### DIFF
--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -59,9 +59,8 @@ def check_shape(
 
 
 def check_times(x: Array, argname: str, allow_empty: bool = False):
-    # check that a time-array is valid (it must be a 1D array sorted in strictly
+    # check that an array of time is valid (it must be a 1D array sorted in strictly
     # ascending order and containing only positive values)
-    # check_shape(x, argname, '(n,)', subs={'n': f'n{argname}'})
 
     if x.ndim != 1:
         raise ValueError(

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -58,7 +58,7 @@ def check_shape(
     )
 
 
-def check_time_array(x: Array, argname: str, allow_empty: bool = False):
+def check_times(x: Array, argname: str, allow_empty: bool = False):
     # check that a time-array is valid (it must be a 1D array sorted in strictly
     # ascending order and containing only positive values)
     # check_shape(x, argname, '(n,)', subs={'n': f'n{argname}'})

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -6,26 +6,28 @@ from jax import Array
 _is_perfect_square = lambda n: int(n**0.5) ** 2 == n
 
 
+_cases = {
+    '(..., n, 1)': lambda x: x.ndim >= 2 and x.shape[-1] == 1,
+    '(..., 1, n)': lambda x: x.ndim >= 2 and x.shape[-2] == 1,
+    '(..., n, n)': lambda x: x.ndim >= 2 and x.shape[-2] == x.shape[-1],
+    '(N, ..., n, n)': lambda x: x.ndim >= 3 and x.shape[-2] == x.shape[-1],
+    '(..., n)': lambda x: x.ndim >= 1,
+    '(n, 1)': lambda x: x.ndim == 2 and x.shape[-1] == 1,
+    '(1, n)': lambda x: x.ndim == 2 and x.shape[-2] == 1,
+    '(n, n)': lambda x: x.ndim == 2 and x.shape[-2] == x.shape[-1],
+    '(n,)': lambda x: x.ndim == 1,
+    '(N, n, 1)': lambda x: x.ndim == 3 and x.shape[-1] == 1,
+    '(N, n, n)': lambda x: x.ndim == 3 and x.shape[-2] == x.shape[-1],
+    '(?, n, n)': lambda x: 2 <= x.ndim <= 3 and x.shape[-2] == x.shape[-1],
+    '(..., n^2, 1)': lambda x: x.ndim >= 2
+    and _is_perfect_square(x.shape[-2])
+    and x.shape[-1] == 1,
+}
+
+
 def has_shape(x: Array, shape: str) -> bool:
-    cases = {
-        '(..., n, 1)': lambda x: x.ndim >= 2 and x.shape[-1] == 1,
-        '(..., 1, n)': lambda x: x.ndim >= 2 and x.shape[-2] == 1,
-        '(..., n, n)': lambda x: x.ndim >= 2 and x.shape[-2] == x.shape[-1],
-        '(N, ..., n, n)': lambda x: x.ndim >= 3 and x.shape[-2] == x.shape[-1],
-        '(..., n)': lambda x: x.ndim >= 1,
-        '(n, 1)': lambda x: x.ndim == 2 and x.shape[-1] == 1,
-        '(1, n)': lambda x: x.ndim == 2 and x.shape[-2] == 1,
-        '(n, n)': lambda x: x.ndim == 2 and x.shape[-2] == x.shape[-1],
-        '(n,)': lambda x: x.ndim == 1,
-        '(N, n, 1)': lambda x: x.ndim == 3 and x.shape[-1] == 1,
-        '(N, n, n)': lambda x: x.ndim == 3 and x.shape[-2] == x.shape[-1],
-        '(?, n, n)': lambda x: 2 <= x.ndim <= 3 and x.shape[-2] == x.shape[-1],
-        '(..., n^2, 1)': lambda x: x.ndim >= 2
-        and _is_perfect_square(x.shape[-2])
-        and x.shape[-1] == 1,
-    }
-    if shape in cases:
-        return cases[shape](x)
+    if shape in _cases:
+        return _cases[shape](x)
     else:
         raise ValueError(f'Unknown shape specification `{shape}`.')
 

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax import Array
+
+_is_perfect_square = lambda n: int(n**0.5) ** 2 == n
+
+
+def has_shape(x: Array, shape: str) -> bool:
+    cases = {
+        '(..., n, 1)': lambda x: x.ndim >= 2 and x.shape[-1] == 1,
+        '(..., 1, n)': lambda x: x.ndim >= 2 and x.shape[-2] == 1,
+        '(..., n, n)': lambda x: x.ndim >= 2 and x.shape[-2] == x.shape[-1],
+        '(N, ..., n, n)': lambda x: x.ndim >= 3 and x.shape[-2] == x.shape[-1],
+        '(..., n)': lambda x: x.ndim >= 1,
+        '(n, 1)': lambda x: x.ndim == 2 and x.shape[-1] == 1,
+        '(1, n)': lambda x: x.ndim == 2 and x.shape[-2] == 1,
+        '(n, n)': lambda x: x.ndim == 2 and x.shape[-2] == x.shape[-1],
+        '(n,)': lambda x: x.ndim == 1,
+        '(N, n, 1)': lambda x: x.ndim == 3 and x.shape[-1] == 1,
+        '(N, n, n)': lambda x: x.ndim == 3 and x.shape[-2] == x.shape[-1],
+        '(?, n, n)': lambda x: 2 <= x.ndim <= 3 and x.shape[-2] == x.shape[-1],
+        '(..., n^2, 1)': lambda x: x.ndim >= 2
+        and _is_perfect_square(x.shape[-2])
+        and x.shape[-1] == 1,
+    }
+    if shape in cases:
+        return cases[shape](x)
+    else:
+        raise ValueError(f'Unknown shape specification `{shape}`.')
+
+
+def check_shape(
+    x: Array, argname: str, *shapes: str, subs: dict[str, str] | None = None
+):
+    for shape in shapes:
+        if has_shape(x, shape):
+            return
+
+    if len(shapes) == 1:
+        shapes_str = shapes[0]
+    else:
+        shapes_str = ', '.join(shapes[:-1]) + ' or ' + shapes[-1]
+
+    if subs is not None:
+        for k, v in subs.items():
+            shapes_str = shapes_str.replace(k, v)
+
+    raise ValueError(
+        f'Argument `{argname}` must have shape {shapes_str}, but has shape'
+        f' {argname}.shape={x.shape}.'
+    )
+
+
+def check_time_array(x: Array, argname: str, allow_empty: bool = False):
+    # check that a time-array is valid (it must be a 1D array sorted in strictly
+    # ascending order and containing only positive values)
+    # check_shape(x, argname, '(n,)', subs={'n': f'n{argname}'})
+
+    if x.ndim != 1:
+        raise ValueError(
+            f'Argument {argname} must be a 1D array, but is a {x.ndim}D array.'
+        )
+    if not allow_empty and len(x) == 0:
+        raise ValueError(f'Argument {argname} must contain at least one element.')
+    if not jnp.all(jnp.diff(x) > 0):
+        raise ValueError(
+            f'Argument {argname} must be sorted in strictly ascending order.'
+        )
+    if not jnp.all(x >= 0):
+        raise ValueError(f'Argument {argname} must contain positive values only.')

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -35,6 +35,10 @@ def has_shape(x: Array, shape: str) -> bool:
 def check_shape(
     x: Array, argname: str, *shapes: str, subs: dict[str, str] | None = None
 ):
+    # subs is used to replace symbols in the error message, this can be used to e.g.
+    # specify a shape (?, n, n) but print an error message with (nH?, n, n), by passing
+    # subs={'?': 'nH?'} to replace the '?' by 'nH?' in the shape specification
+
     for shape in shapes:
         if has_shape(x, shape):
             return

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -17,23 +17,6 @@ def obj_type_str(x: Any) -> str:
     return type_str(type(x))
 
 
-def check_time_array(x: Array, arg_name: str, allow_empty: bool = False):
-    # check that a time-array is valid (it must be a 1D array sorted in strictly
-    # ascending order and containing only positive values)
-    if x.ndim != 1:
-        raise ValueError(
-            f'Argument `{arg_name}` must be a 1D array, but is a {x.ndim}D array.'
-        )
-    if not allow_empty and len(x) == 0:
-        raise ValueError(f'Argument `{arg_name}` must contain at least one element.')
-    if not jnp.all(jnp.diff(x) > 0):
-        raise ValueError(
-            f'Argument `{arg_name}` must be sorted in strictly ascending order.'
-        )
-    if not jnp.all(x >= 0):
-        raise ValueError(f'Argument `{arg_name}` must contain positive values only.')
-
-
 def on_cpu(x: Array) -> str:
     # TODO: this is a temporary solution, it won't work when we have multiple devices
     return x.devices().pop().device_kind == 'cpu'

--- a/dynamiqs/plots/plots_fock.py
+++ b/dynamiqs/plots/plots_fock.py
@@ -6,7 +6,7 @@ from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 from matplotlib.colors import ListedColormap, LogNorm, Normalize
 
-from .._checks import check_shape, check_time_array
+from .._checks import check_shape, check_times
 from ..utils.utils import isdm, isket
 from .utils import (
     add_colorbar,
@@ -124,7 +124,7 @@ def plot_fock_evolution(
     times = jnp.asarray(times) if times is not None else None
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
     if times is not None:
-        check_time_array(times, 'times')
+        check_times(times, 'times')
 
     x = jnp.arange(len(states)) if times is None else times
     n = states[0].shape[0]

--- a/dynamiqs/plots/plots_fock.py
+++ b/dynamiqs/plots/plots_fock.py
@@ -6,6 +6,7 @@ from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 from matplotlib.colors import ListedColormap, LogNorm, Normalize
 
+from .._checks import check_shape, check_time_array
 from ..utils.utils import isdm, isket
 from .utils import (
     add_colorbar,
@@ -67,6 +68,7 @@ def plot_fock(
         ![plot_fock_coherent](/figs-code/plot_fock_coherent.png){.fig}
     """
     state = jnp.asarray(state)
+    check_shape(state, 'state', '(n, 1)', '(n, n)')
 
     n = state.shape[0]
     x = range(n)
@@ -120,6 +122,9 @@ def plot_fock_evolution(
     """
     states = jnp.asarray(states)
     times = jnp.asarray(times) if times is not None else None
+    check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
+    if times is not None:
+        check_time_array(times, 'times')
 
     x = jnp.arange(len(states)) if times is None else times
     n = states[0].shape[0]

--- a/dynamiqs/plots/plots_hinton.py
+++ b/dynamiqs/plots/plots_hinton.py
@@ -12,6 +12,7 @@ from matplotlib.axes import Axes
 from matplotlib.collections import PatchCollection
 from matplotlib.colors import Normalize
 
+from .._checks import check_shape
 from .utils import add_colorbar, bra_ticks, integer_ticks, ket_ticks, optional_ax
 
 __all__ = ['plot_hinton']
@@ -188,11 +189,7 @@ def plot_hinton(
         ![plot_hinton_large](/figs-code/plot_hinton_large.png){.fig}
     """  # noqa: E501
     x = jnp.asarray(x)
-
-    if x.ndim != 2 or x.shape[0] != x.shape[1]:
-        raise ValueError(
-            f'Argument `x` must be a 2D square array, but has shape {x.shape}.'
-        )
+    check_shape(x, 'x', '(n, n)')
 
     # set different defaults, areas and colors for real matrix, positive real matrix
     # and complex matrix

--- a/dynamiqs/plots/plots_misc.py
+++ b/dynamiqs/plots/plots_misc.py
@@ -4,7 +4,7 @@ import jax.numpy as jnp
 from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 
-from .._checks import check_time_array
+from .._checks import check_times
 from .utils import colors, optional_ax
 
 __all__ = ['plot_pwc_pulse']
@@ -37,7 +37,7 @@ def plot_pwc_pulse(
     """
     times = jnp.asarray(times)  # (n + 1)
     values = jnp.asarray(values)  # (n)
-    check_time_array(times, 'times')
+    check_times(times, 'times')
 
     # format times and values, for example:
     # times  = [0, 1, 2, 3] -> [0, 1, 1, 2, 2, 3]

--- a/dynamiqs/plots/plots_misc.py
+++ b/dynamiqs/plots/plots_misc.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from jax.typing import ArrayLike
 from matplotlib.axes import Axes
 
+from .._checks import check_time_array
 from .utils import colors, optional_ax
 
 __all__ = ['plot_pwc_pulse']
@@ -36,6 +37,7 @@ def plot_pwc_pulse(
     """
     times = jnp.asarray(times)  # (n + 1)
     values = jnp.asarray(values)  # (n)
+    check_time_array(times, 'times')
 
     # format times and values, for example:
     # times  = [0, 1, 2, 3] -> [0, 1, 1, 2, 2, 3]

--- a/dynamiqs/plots/plots_wigner.py
+++ b/dynamiqs/plots/plots_wigner.py
@@ -13,6 +13,7 @@ from matplotlib.axes import Axes
 from matplotlib.colors import Normalize
 from tqdm import tqdm
 
+from .._checks import check_shape
 from ..utils import wigner
 from .utils import add_colorbar, colors, figax, gridplot, optional_ax
 
@@ -34,6 +35,7 @@ def plot_wigner_data(
     clear: bool = False,
 ):
     w = jnp.asarray(wigner)
+    check_shape(w, 'wigner', '(n, n)')
 
     # set plot norm
     vmin = -vmax
@@ -124,6 +126,7 @@ def plot_wigner(
         ![plot_wigner_4legged](/figs-code/plot_wigner_4legged.png){.fig-half}
     """
     state = jnp.asarray(state)
+    check_shape(state, 'state', '(n, 1)', '(n, n)')
 
     ymax = xmax if ymax is None else ymax
     _, _, w = wigner(state, xmax, ymax, npixels)
@@ -195,6 +198,7 @@ def plot_wigner_mosaic(
         ![plot_wigner_mosaic_kerr](/figs-code/plot_wigner_mosaic_kerr.png){.fig}
     """
     states = jnp.asarray(states)
+    check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
 
     nstates = len(states)
     if nstates < n:
@@ -305,6 +309,7 @@ def plot_wigner_gif(
         ![plot_wigner_gif_kerr](/figs-code/wigner-kerr.gif){.fig-half}
     """
     states = jnp.asarray(states)
+    check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
 
     ymax = xmax if ymax is None else ymax
     nframes = int(gif_duration * fps)

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -11,7 +11,7 @@ from jax import Array, lax
 from jax.tree_util import Partial
 from jaxtyping import ArrayLike, PyTree, ScalarLike
 
-from ._checks import check_shape, check_time_array
+from ._checks import check_shape, check_times
 from ._utils import cdtype, obj_type_str
 
 __all__ = ['constant', 'pwc', 'modulated', 'timecallable', 'TimeArray']
@@ -68,7 +68,7 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
     """
     # times
     times = jnp.asarray(times)
-    check_time_array(times, 'times')
+    check_times(times, 'times')
 
     # values
     values = jnp.asarray(values, dtype=cdtype())

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -11,7 +11,8 @@ from jax import Array, lax
 from jax.tree_util import Partial
 from jaxtyping import ArrayLike, PyTree, ScalarLike
 
-from ._utils import cdtype, check_time_array, obj_type_str
+from ._checks import check_shape, check_time_array
+from ._utils import cdtype, obj_type_str
 
 __all__ = ['constant', 'pwc', 'modulated', 'timecallable', 'TimeArray']
 
@@ -29,6 +30,7 @@ def constant(array: ArrayLike) -> ConstantTimeArray:
         _(time-array object)_ Callable object returning $O_0$ for any time $t$.
     """
     array = jnp.asarray(array, dtype=cdtype())
+    check_shape(array, 'array', '(..., n, n)')
     return ConstantTimeArray(array)
 
 
@@ -66,7 +68,7 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
     """
     # times
     times = jnp.asarray(times)
-    check_time_array(times, arg_name='times')
+    check_time_array(times, 'times')
 
     # values
     values = jnp.asarray(values, dtype=cdtype())
@@ -78,10 +80,7 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
 
     # array
     array = jnp.asarray(array, dtype=cdtype())
-    if array.ndim != 2 or array.shape[-1] != array.shape[-2]:
-        raise TypeError(
-            f'Argument `array` must have shape `(n, n)`, but has shape {array.shape}.'
-        )
+    check_shape(array, 'array', '(n, n)')
 
     return PWCTimeArray(times, values, array)
 
@@ -118,10 +117,7 @@ def modulated(
 
     # array
     array = jnp.asarray(array, dtype=cdtype())
-    if array.ndim != 2 or array.shape[-1] != array.shape[-2]:
-        raise TypeError(
-            f'Argument `array` must have shape `(n, n)`, but has shape {array.shape}.'
-        )
+    check_shape(array, 'array', '(n, n)')
 
     # Pass `f` through `jax.tree_util.Partial`.
     # This is necessary:

--- a/dynamiqs/utils/jax_utils.py
+++ b/dynamiqs/utils/jax_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 from jax.typing import ArrayLike
 from qutip import Qobj
 
+from .._checks import check_shape
 from .utils import isbra, isket, isop
 from .utils.general import _hdim
 
@@ -18,7 +19,8 @@ def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Q
     quantum objects if it has more than two dimensions).
 
     Args:
-        x: Array-like object.
+        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,
+            density matrix or operator.
         dims _(tuple of ints or None)_: Dimensions of each subsystem in the large
             Hilbert space of the composite system, defaults to `None` (a single system
             with the same dimension as `x`).
@@ -69,6 +71,7 @@ def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Q
          [0. 0. 0. 0. 0. 1.]]
     """  # noqa: E501
     x = np.asarray(x)
+    check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 
     if x.ndim > 2:
         return [to_qutip(sub_x) for sub_x in x]

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import ArrayLike
 
+from .._checks import check_shape
 from .._utils import cdtype
 from ..utils.operators import displace
 from ..utils.states import fock
@@ -38,6 +39,8 @@ def snap_gate(phase: ArrayLike) -> Array:
         (2, 3, 3)
     """
     phase = jnp.asarray(phase, dtype=cdtype())
+    check_shape(phase, 'phase', '(..., n)')
+
     # batched construct diagonal array
     bdiag = jnp.vectorize(jnp.diag, signature='(a)->(a,a)')
     return bdiag(jnp.exp(1j * phase))

--- a/dynamiqs/utils/random.py
+++ b/dynamiqs/utils/random.py
@@ -101,7 +101,7 @@ def rand_herm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
 
     Args:
         key: A PRNG key used as the random key.
-        shape: Shape of the returned array.
+        shape _(shape of the form (..., n, n))_: Shape of the returned array.
 
     Returns:
         _(array of shape (*shape))_ Random complex Hermitian matrix.
@@ -113,7 +113,9 @@ def rand_herm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
                [ 0.473+0.446j,  0.13 +0.j   ]], dtype=complex64)
     """
     if not len(shape) >= 2 or not shape[-1] == shape[-2]:
-        raise ValueError(f'`shape` must be at least 2D and square, but got {shape}.')
+        raise ValueError(
+            f'Argument `shape` must be of the form (..., n, n), but is shape={shape}.'
+        )
     x = rand_complex(key, shape)
     return 0.5 * (x + dag(x))
 
@@ -123,7 +125,7 @@ def rand_psd(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
 
     Args:
         key: A PRNG key used as the random key.
-        shape: Shape of the returned array.
+        shape _(shape of the form (..., n, n))_: Shape of the returned array.
 
     Returns:
         _(array of shape (*shape))_ Random complex positive semi-definite matrix.
@@ -136,7 +138,9 @@ def rand_psd(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
 
     """
     if not len(shape) >= 2 or not shape[-1] == shape[-2]:
-        raise ValueError(f'`shape` must be at least 2D and square, but got {shape}.')
+        raise ValueError(
+            f'Argument `shape` must be of the form (..., n, n), but is shape={shape}.'
+        )
     x = rand_complex(key, shape)
     return x @ dag(x)
 
@@ -147,7 +151,7 @@ def rand_dm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
 
     Args:
         key: A PRNG key used as the random key.
-        shape: Shape of the returned array.
+        shape _(shape of the form (..., n, n))_: Shape of the returned array.
 
     Returns:
         _(array of shape (*shape))_ Random density matrix.
@@ -159,7 +163,9 @@ def rand_dm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
                [0.293-0.166j, 0.424+0.j   ]], dtype=complex64)
     """
     if not len(shape) >= 2 or not shape[-1] == shape[-2]:
-        raise ValueError(f'`shape` must be at least 2D and square, but got {shape}.')
+        raise ValueError(
+            f'Argument `shape` must be of the form (..., n, n), but is shape={shape}.'
+        )
     x = rand_psd(key, shape)
     return unit(x)
 
@@ -169,7 +175,7 @@ def rand_ket(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
 
     Args:
         key: A PRNG key used as the random key.
-        shape: Shape of the returned array.
+        shape _(shape of the form (..., n, 1))_: Shape of the returned array.
 
     Returns:
         _(array of shape (*shape))_ Random ket.
@@ -182,7 +188,7 @@ def rand_ket(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
     """
     if not len(shape) >= 2 or not shape[-1] == 1:
         raise ValueError(
-            f'`shape` must be at least 2D and with last dimension 1, but got {shape}.'
+            f'Argument `shape` must be of the form (..., n, 1), but is shape={shape}.'
         )
     x = rand_complex(key, shape)
     return unit(x)

--- a/dynamiqs/utils/utils/wigner.py
+++ b/dynamiqs/utils/utils/wigner.py
@@ -9,9 +9,10 @@ from jax import Array, lax
 from jax.scipy.linalg import toeplitz
 from jaxtyping import ArrayLike
 
+from ..._checks import check_shape
 from ..._utils import cdtype
 from ..operators import eye
-from .general import isdm, isket, todm
+from .general import isket, todm
 
 __all__ = ['wigner']
 
@@ -47,6 +48,7 @@ def wigner(
                 distribution at all (x, p) points.
     """
     state = jnp.asarray(state)
+    check_shape(state, 'state', '(..., n, 1)', '(..., n, n)')
 
     xvec = jnp.linspace(-xmax, xmax, npixels)
     yvec = jnp.linspace(-ymax, ymax, npixels)
@@ -57,13 +59,8 @@ def wigner(
     elif method == 'fft':
         if isket(state):
             w, yvec = _wigner_fft_psi(state, xvec, g)
-        elif isdm(state):
-            w, yvec = _wigner_fft_dm(state, xvec, g)
         else:
-            raise ValueError(
-                'Argument `state` must be a ket or density matrix, but has shape'
-                f' {state.shape}.'
-            )
+            w, yvec = _wigner_fft_dm(state, xvec, g)
     else:
         raise ValueError(
             f'Method "{method}" is not supported (supported: "clenshaw", "fft").'

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -5,6 +5,7 @@ import numpy as np
 from jax import Array
 from jaxtyping import ArrayLike
 
+from .._checks import check_shape
 from .operators import eye
 from .utils import dag
 from .utils.general import _bkron
@@ -49,6 +50,7 @@ def operator_to_vector(x: ArrayLike) -> Array:
                [4.+4.j]], dtype=complex64)
     """
     x = jnp.asarray(x)
+    check_shape(x, 'x', '(..., n, n)')
     bshape = x.shape[:-2]
     return x.mT.reshape(*bshape, -1, 1)
 
@@ -83,6 +85,7 @@ def vector_to_operator(x: ArrayLike) -> Array:
                [2.+2.j, 4.+4.j]], dtype=complex64)
     """
     x = jnp.asarray(x)
+    check_shape(x, 'x', '(..., n^2, 1)')
     bshape = x.shape[:-2]
     n = int(np.sqrt(x.shape[-2]))
     return x.reshape(*bshape, n, n).mT
@@ -108,6 +111,7 @@ def spre(x: ArrayLike) -> Array:
         (9, 9)
     """
     x = jnp.asarray(x)
+    check_shape(x, 'x', '(..., n, n)')
     n = x.shape[-1]
     Id = eye(n)
     return _bkron(Id, x)
@@ -133,6 +137,7 @@ def spost(x: ArrayLike) -> Array:
         (9, 9)
     """
     x = jnp.asarray(x)
+    check_shape(x, 'x', '(..., n, n)')
     n = x.shape[-1]
     Id = eye(n)
     return _bkron(dag(x), Id)
@@ -160,6 +165,8 @@ def sprepost(x: ArrayLike, y: ArrayLike) -> Array:
     """
     x = jnp.asarray(x)
     y = jnp.asarray(y)
+    check_shape(x, 'x', '(..., n, n)')
+    check_shape(y, 'y', '(..., n, n)')
     return _bkron(y.mT, x)
 
 
@@ -186,6 +193,7 @@ def sdissipator(L: ArrayLike) -> Array:
         _(array of shape (..., n^2, n^2))_ Dissipation superoperator.
     """
     L = jnp.asarray(L)
+    check_shape(L, 'L', '(..., n, n)')
     Ldag = dag(L)
     LdagL = Ldag @ L
     return sprepost(L, Ldag) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
@@ -224,4 +232,6 @@ def slindbladian(H: ArrayLike, jump_ops: ArrayLike) -> Array:
     """
     H = jnp.asarray(H)
     jump_ops = jnp.asarray(jump_ops)
+    check_shape(H, 'H', '(..., n, n)')
+    check_shape(jump_ops, 'jump_ops', '(N, ..., n, n)')
     return -1j * (spre(H) - spost(H)) + sdissipator(jump_ops).sum(0)


### PR DESCRIPTION
Here's a proposal for the backend to systematically verify the shape of `ArrayLike` argument in our public API. Having a shared backend allows to write once a clean exception, which always has the same format when the user mistakes a shape. For example:

```python
>>> x = jnp.array([1, 2])
>>> dq.norm(x)
ValueError: Argument `x` must have shape (..., n, 1), (..., 1, n) or (..., n, n), but has shape x.shape=(2,).
```

Implementation: it is quite rudimentary but I don't think we should make a crazy super general code, this is largely good enough to start with IMO. It has the advantage to be very versatile. This works with vectorize, vmap, and the benchmarked impact is negligible (especially, it's 100% free once the code is jitted).

What needs to be done later, and is not adressed by this PR, is to check _agreement_ between shapes, e.g. for `dq.fidelity()` check that `x` and `y` have the same `n`.

I considered using [jaxtyping](https://docs.kidger.site/jaxtyping/) for this but it has several drawbacks: uncommon function signature in the doc, can't define several shapes (e.g. `(…, n, 1)` or `(…, 1, n)` or `(…, n, n)`), need to apply a decorator to all functions of the library for runtime type checking, can't customize easily the error messages (that are a bit _énervés_). I don't think it would be a good solution for us.