### PR TITLE
Fix `dq.spost()` formula to use transpose instead of adjoint

### DIFF
--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -140,7 +140,7 @@ def spost(x: ArrayLike) -> Array:
     check_shape(x, 'x', '(..., n, n)')
     n = x.shape[-1]
     Id = eye(n)
-    return _bkron(dag(x), Id)
+    return _bkron(x.mT, Id)
 
 
 def sprepost(x: ArrayLike, y: ArrayLike) -> Array:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 requires-python = ">=3.9"
 description = "Quantum systems simulation with JAX."
 dependencies = [
-    "qutip",
+    "qutip>=4.0,<5.0",
     "numpy",
     "matplotlib",
     "tqdm",


### PR DESCRIPTION
On top of #531.

This was introduced by mistake when transitioning to JAX (see https://github.com/dynamiqs/dynamiqs/commit/3ad11d1dcd1fbec94e9f4bdf76f7635b7b007d5b). I had fixed half of the mistakes in `vectorization.py` in https://github.com/dynamiqs/dynamiqs/pull/447/commits/9936919fbdfb9e06a6b76af6f3b0deab4fd38a2e.