### PR TITLE
Fix JIT sesolve/mesolve broken by runtime check

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -100,7 +100,8 @@ def mesolve(
     exp_ops = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
 
     # === check arguments
-    _check_mesolve_args(H, jump_ops, rho0, tsave, exp_ops)
+    _check_mesolve_args(H, jump_ops, rho0, exp_ops)
+    tsave = check_times(tsave, 'tsave')
 
     # === convert rho0 to density matrix
     rho0 = todm(rho0)
@@ -176,11 +177,7 @@ def _mesolve(
 
 
 def _check_mesolve_args(
-    H: TimeArray,
-    jump_ops: list[TimeArray],
-    rho0: Array,
-    tsave: Array,
-    exp_ops: Array | None,
+    H: TimeArray, jump_ops: list[TimeArray], rho0: Array, exp_ops: Array | None
 ):
     # === check H shape
     check_shape(H, 'H', '(?, n, n)', subs={'?': 'nH?'})
@@ -197,9 +194,6 @@ def _check_mesolve_args(
 
     # === check rho0 shape
     check_shape(rho0, 'rho0', '(?, n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
-
-    # === check tsave shape
-    check_times(tsave, 'tsave')
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/plots/plots_fock.py
+++ b/dynamiqs/plots/plots_fock.py
@@ -124,7 +124,7 @@ def plot_fock_evolution(
     times = jnp.asarray(times) if times is not None else None
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
     if times is not None:
-        check_times(times, 'times')
+        times = check_times(times, 'times')
 
     x = jnp.arange(len(states)) if times is None else times
     n = states[0].shape[0]

--- a/dynamiqs/plots/plots_misc.py
+++ b/dynamiqs/plots/plots_misc.py
@@ -37,7 +37,7 @@ def plot_pwc_pulse(
     """
     times = jnp.asarray(times)  # (n + 1)
     values = jnp.asarray(values)  # (n)
-    check_times(times, 'times')
+    times = check_times(times, 'times')
 
     # format times and values, for example:
     # times  = [0, 1, 2, 3] -> [0, 1, 1, 2, 2, 3]

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -87,7 +87,8 @@ def sesolve(
     exp_ops = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
 
     # === check arguments
-    _check_sesolve_args(H, psi0, tsave, exp_ops)
+    _check_sesolve_args(H, psi0, exp_ops)
+    tsave = check_times(tsave, 'tsave')
 
     # we implement the jitted vmap in another function to pre-convert QuTiP objects
     # (which are not JIT-compatible) to JAX arrays
@@ -147,15 +148,12 @@ def _sesolve(
     return result  # noqa: RET504
 
 
-def _check_sesolve_args(H: TimeArray, psi0: Array, tsave: Array, exp_ops: Array | None):
+def _check_sesolve_args(H: TimeArray, psi0: Array, exp_ops: Array | None):
     # === check H shape
     check_shape(H, 'H', '(?, n, n)', subs={'?': 'nH?'})
 
     # === check psi0 shape
     check_shape(psi0, 'psi0', '(?, n, 1)', subs={'?': 'npsi0?'})
-
-    # === check tsave shape
-    check_times(tsave, 'tsave')
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -68,7 +68,7 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
     """
     # times
     times = jnp.asarray(times)
-    check_times(times, 'times')
+    times = check_times(times, 'times')
 
     # values
     values = jnp.asarray(values, dtype=cdtype())


### PR DESCRIPTION
The check for `tsave` being in strictly ascending order was breaking the JIT. This PR uses [`equinox.error_if`](https://docs.kidger.site/equinox/api/errors/) to implement a JIT-compatible check.

This is exactly what's done in Diffrax too, see e.g. https://github.com/patrick-kidger/diffrax/blob/d97ba2006426836b9b57dfed8d2c24c7373567e0/diffrax/_integrate.py#L796.

MWE:
```python
import dynamiqs as dq
import jax

n = 16
a = dq.destroy(n)
ad = dq.dag(a)

H = 10 * ad @ a
psi0 = dq.coherent(n, 1.0)
tsave = [0, 1, -1]

@jax.jit
def foo():
    return dq.sesolve(H, psi0, tsave)

foo()
```
```
XlaRuntimeError: INTERNAL: Generated function failed: CpuCallback error: EqxRuntimeError: Argument tsave must be sorted in strictly ascending order.
```