### PR TITLE
Fix batching for PWC, Modulated and Summed TimeArrays

### DIFF
--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -94,8 +94,10 @@ def is_timearray_batched(tarray: TimeArray) -> TimeArray:
     elif isinstance(tarray, PWCTimeArray):
         return PWCTimeArray(False, tarray.values.ndim > 1, False)
     elif isinstance(tarray, ModulatedTimeArray):
-        return ModulatedTimeArray(False, False, (arg.ndim > 0 for arg in tarray.args))
+        return ModulatedTimeArray(
+            False, False, tuple(arg.ndim > 0 for arg in tarray.args)
+        )
     elif isinstance(tarray, CallableTimeArray):
-        return CallableTimeArray(False, (arg.ndim > 0 for arg in tarray.args))
+        return CallableTimeArray(False, tuple(arg.ndim > 0 for arg in tarray.args))
     else:
         raise TypeError(f'Unsupported TimeArray type: {type(tarray).__name__}')

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -90,7 +90,7 @@ def is_timearray_batched(tarray: TimeArray) -> TimeArray:
     if isinstance(tarray, SummedTimeArray):
         return SummedTimeArray([is_timearray_batched(arr) for arr in tarray.timearrays])
     elif isinstance(tarray, ConstantTimeArray):
-        return ConstantTimeArray(tarray.x.ndim > 2)
+        return ConstantTimeArray(tarray.array.ndim > 2)
     elif isinstance(tarray, PWCTimeArray):
         return PWCTimeArray(False, tarray.values.ndim > 1, False)
     elif isinstance(tarray, ModulatedTimeArray):

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import jax
 import jax.numpy as jnp
-from jaxtyping import ArrayLike
+from jaxtyping import ArrayLike, PyTree
 
 from .._utils import cdtype, obj_type_str
 from ..solver import Solver
@@ -47,8 +47,8 @@ def get_solver_class(
 def compute_vmap(
     f: callable,
     cartesian_batching: bool,
-    is_batched: list[bool | list[bool]],
-    out_axes: list[int | None],
+    is_batched: PyTree[bool],
+    out_axes: PyTree[int | None],
 ) -> callable:
     # This function vectorizes `f` by applying jax.vmap over batched dimensions. The
     # argument `is_batched` indicates for each argument of `f` whether it is batched.

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -83,14 +83,12 @@ def compute_vmap(
     return f
 
 
-def compute_timearray_batching(tarray: TimeArray) -> TimeArray:
+def is_timearray_batched(tarray: TimeArray) -> TimeArray:
     # This function finds all batched arrays within a given TimeArray.
     # To do so, it goes down the PyTree and identifies batched fields depending
     # on the type of TimeArray.
     if isinstance(tarray, SummedTimeArray):
-        return SummedTimeArray(
-            [compute_timearray_batching(arr) for arr in tarray.timearrays]
-        )
+        return SummedTimeArray([is_timearray_batched(arr) for arr in tarray.timearrays])
     elif isinstance(tarray, ConstantTimeArray):
         return ConstantTimeArray(tarray.x.ndim > 2)
     elif isinstance(tarray, PWCTimeArray):

--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -36,7 +36,7 @@ class PropagatorSolver(BaseSolver):
             )
 
         # extract the constant array from the `ConstantTimeArray` object
-        self.H = self.H.x
+        self.H = self.H.array
 
     def run(self) -> PyTree:
         # === solve differential equation
@@ -78,4 +78,4 @@ class MEPropagatorSolver(PropagatorSolver, MESolver):
             )
 
         # extract the constant arrays from the `ConstantTimeArray` objects
-        self.Ls = [L.x for L in self.Ls]
+        self.Ls = [L.array for L in self.Ls]

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -182,25 +182,18 @@ def _check_mesolve_args(
     tsave: Array,
     exp_ops: Array | None,
 ):
-    # === check H shape
     check_shape(H, 'H', '(?, n, n)', subs={'?': 'nH?'})
+    check_shape(rho0, 'rho0', '(?, n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
+    check_times(tsave, 'tsave')
 
-    # === check jump_ops shape
+    if exp_ops is not None:
+        check_shape(exp_ops, 'exp_ops', '(N, n, n)', subs={'N': 'nE'})
+
+    for i, L in enumerate(jump_ops):
+        check_shape(L, f'jump_ops[{i}]', '(?, n, n)', subs={'?': 'nL?'})
+
     if len(jump_ops) == 0:
         logging.warn(
             'Argument `jump_ops` is an empty list, consider using `dq.sesolve()` to'
             ' solve the Schrödinger equation.'
         )
-
-    for i, L in enumerate(jump_ops):
-        check_shape(L, f'jump_ops[{i}]', '(?, n, n)', subs={'?': 'nL?'})
-
-    # === check rho0 shape
-    check_shape(rho0, 'rho0', '(?, n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
-
-    # === check tsave shape
-    check_times(tsave, 'tsave')
-
-    # === check exp_ops shape
-    if exp_ops is not None:
-        check_shape(exp_ops, 'exp_ops', '(N, n, n)', subs={'N': 'nE'})

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -190,11 +190,6 @@ def _check_mesolve_args(
     exp_ops: Array | None,
 ):
     check_shape(H, 'H', '(?, n, n)', subs={'?': 'nH?'})
-    check_shape(rho0, 'rho0', '(?, n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
-    check_times(tsave, 'tsave')
-
-    if exp_ops is not None:
-        check_shape(exp_ops, 'exp_ops', '(N, n, n)', subs={'N': 'nE'})
 
     for i, L in enumerate(jump_ops):
         check_shape(L, f'jump_ops[{i}]', '(?, n, n)', subs={'?': 'nL?'})
@@ -204,3 +199,9 @@ def _check_mesolve_args(
             'Argument `jump_ops` is an empty list, consider using `dq.sesolve()` to'
             ' solve the Schrödinger equation.'
         )
+
+    check_shape(rho0, 'rho0', '(?, n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
+    check_times(tsave, 'tsave')
+
+    if exp_ops is not None:
+        check_shape(exp_ops, 'exp_ops', '(N, n, n)', subs={'N': 'nE'})

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -139,7 +139,7 @@ def _vmap_mesolve(
         False,
     )
 
-    # the result is vectorized over `saved`
+    # the result is vectorized over `_saved` and `infos`
     out_axes = MEResult(None, None, None, None, 0, 0)
 
     # compute vectorized function with given batching strategy

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -148,15 +148,9 @@ def _sesolve(
 
 
 def _check_sesolve_args(H: TimeArray, psi0: Array, tsave: Array, exp_ops: Array | None):
-    # === check H shape
     check_shape(H, 'H', '(?, n, n)', subs={'?': 'nH?'})
-
-    # === check psi0 shape
     check_shape(psi0, 'psi0', '(?, n, 1)', subs={'?': 'npsi0?'})
-
-    # === check tsave shape
     check_times(tsave, 'tsave')
 
-    # === check exp_ops shape
     if exp_ops is not None:
         check_shape(exp_ops, 'exp_ops', '(N, n, n)', subs={'N': 'nE'})

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -11,9 +11,9 @@ from .._checks import check_shape, check_times
 from .._utils import cdtype
 from ..core._utils import (
     _astimearray,
-    compute_timearray_batching,
     compute_vmap,
     get_solver_class,
+    is_timearray_batched,
 )
 from ..gradient import Gradient
 from ..options import Options
@@ -111,8 +111,15 @@ def _vmap_sesolve(
 ) -> SEResult:
     # === vectorize function
     # we vectorize over H and psi0, all other arguments are not vectorized
-    is_batched_H = compute_timearray_batching(H)
-    is_batched = (is_batched_H, psi0.ndim > 2, False, False, False, False, False)
+    is_batched = (
+        is_timearray_batched(H),
+        psi0.ndim > 2,
+        False,
+        False,
+        False,
+        False,
+        False,
+    )
 
     # the result is vectorized over `saved`
     out_axes = SEResult(None, None, None, None, 0, 0)

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -45,9 +45,6 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
     window function defined by $\Omega_{[t_a, t_b[}(t) = 1$ if $t \in [t_a, t_b[$ and
     $\Omega_{[t_a, t_b[}(t) = 0$ otherwise, and $O_0$ is a constant array.
 
-    Warning:
-        Batching is not yet supported for PWC time-arrays, this will be fixed soon.
-
     Notes:
         The argument `times` argument must be sorted in ascending order, but does not
         need to be evenly spaced.
@@ -94,10 +91,6 @@ def modulated(
     time-dependent scalar. The function $f$ is defined by passing a Python function
     with signature `f(t: float, *args: PyTree) -> Array` that returns an array of shape
     _(...)_ for any time $t$.
-
-    Warning:
-        Batching is not yet supported for modulated time-arrays, this will be fixed
-        soon.
 
     Args:
         f _(function returning array of shape (...))_: Function with signature

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -295,40 +295,40 @@ class TimeArray(eqx.Module):
 
 
 class ConstantTimeArray(TimeArray):
-    x: Array
+    array: Array
 
     @property
     def dtype(self) -> np.dtype:
-        return self.x.dtype
+        return self.array.dtype
 
     @property
     def shape(self) -> tuple[int, ...]:
-        return self.x.shape
+        return self.array.shape
 
     @property
     def mT(self) -> TimeArray:
-        return ConstantTimeArray(self.x.mT)
+        return ConstantTimeArray(self.array.mT)
 
     def __call__(self, t: ScalarLike) -> Array:  # noqa: ARG002
-        return self.x
+        return self.array
 
     def reshape(self, *args: int) -> TimeArray:
-        return ConstantTimeArray(self.x.reshape(*args))
+        return ConstantTimeArray(self.array.reshape(*args))
 
     def conj(self) -> TimeArray:
-        return ConstantTimeArray(self.x.conj())
+        return ConstantTimeArray(self.array.conj())
 
     def __neg__(self) -> TimeArray:
-        return ConstantTimeArray(-self.x)
+        return ConstantTimeArray(-self.array)
 
     def __mul__(self, y: ArrayLike) -> TimeArray:
-        return ConstantTimeArray(self.x * y)
+        return ConstantTimeArray(self.array * y)
 
     def __add__(self, other: ArrayLike | TimeArray) -> TimeArray:
         if isinstance(other, get_args(ArrayLike)):
-            return ConstantTimeArray(jnp.asarray(other, dtype=cdtype()) + self.x)
+            return ConstantTimeArray(jnp.asarray(other, dtype=cdtype()) + self.array)
         elif isinstance(other, ConstantTimeArray):
-            return ConstantTimeArray(self.x + other.x)
+            return ConstantTimeArray(self.array + other.x)
         elif isinstance(other, TimeArray):
             return SummedTimeArray([self, other])
         else:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -328,7 +328,7 @@ class ConstantTimeArray(TimeArray):
         if isinstance(other, get_args(ArrayLike)):
             return ConstantTimeArray(jnp.asarray(other, dtype=cdtype()) + self.array)
         elif isinstance(other, ConstantTimeArray):
-            return ConstantTimeArray(self.array + other.x)
+            return ConstantTimeArray(self.array + other.array)
         elif isinstance(other, TimeArray):
             return SummedTimeArray([self, other])
         else:

--- a/tests/test_time_array.py
+++ b/tests/test_time_array.py
@@ -4,16 +4,12 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from dynamiqs import basis, dag, destroy, sesolve
 from dynamiqs.time_array import (
     CallableTimeArray,
     ConstantTimeArray,
     ModulatedTimeArray,
     PWCTimeArray,
     SummedTimeArray,
-    modulated,
-    pwc,
-    timecallable,
 )
 
 
@@ -73,23 +69,6 @@ class TestConstantTimeArray:
         x = 1 + self.x
         assert isinstance(x, ConstantTimeArray)
         assert_equal(x(0.0), [2, 3])
-
-    def test_batching(self):
-        # generic arrays
-        a = destroy(4)
-        H0 = a + dag(a)
-        psi0 = basis(4, 0)
-        times = jnp.linspace(0.0, 1.0, 11)
-
-        # constant time array
-        H_cte = jnp.stack([H0, 2 * H0])
-
-        # test sesolve output shape
-        result = sesolve(H_cte, psi0, times)
-        assert result.states.shape == (2, 11, 4, 1)
-
-        result = sesolve(H0 + H_cte, psi0, times)
-        assert result.states.shape == (2, 11, 4, 1)
 
 
 class TestCallableTimeArray:
@@ -171,26 +150,6 @@ class TestCallableTimeArray:
         assert isinstance(x, SummedTimeArray)
         assert_equal(x(0.0), [0, 1])
         assert_equal(x(1.0), [1, 3])
-
-    def test_batching(self):
-        # generic arrays
-        a = destroy(4)
-        H0 = a + dag(a)
-        psi0 = basis(4, 0)
-        times = jnp.linspace(0.0, 1.0, 11)
-
-        # callable time array
-        omegas = jnp.linspace(0.0, 1.0, 5)
-        H_cal = timecallable(
-            lambda t, omega: jnp.cos(t * omega[..., None, None]) * H0, args=(omegas,)
-        )
-
-        # test sesolve output shape
-        result = sesolve(H_cal, psi0, times)
-        assert result.states.shape == (5, 11, 4, 1)
-
-        result = sesolve(H0 + H_cal, psi0, times)
-        assert result.states.shape == (5, 11, 4, 1)
 
 
 class TestPWCTimeArray:
@@ -275,24 +234,6 @@ class TestPWCTimeArray:
         assert_equal(x(-0.1), [[1, 1], [1, 1]])
         assert_equal(x(0.0), [[2, 3], [4, 5]])
 
-    def test_batching(self):
-        # generic arrays
-        a = destroy(4)
-        H0 = a + dag(a)
-        psi0 = basis(4, 0)
-        times = jnp.linspace(0.0, 1.0, 11)
-
-        # pwc time array
-        values = jnp.arange(3 * 10).reshape(3, 10)
-        H_pwc = pwc(times, values, H0)
-
-        # test sesolve output shape
-        result = sesolve(H_pwc, psi0, times)
-        assert result.states.shape == (3, 11, 4, 1)
-
-        result = sesolve(H0 + H_pwc, psi0, times)
-        assert result.states.shape == (3, 11, 4, 1)
-
 
 class TestModulatedTimeArray:
     @pytest.fixture(autouse=True)
@@ -358,21 +299,3 @@ class TestModulatedTimeArray:
         assert isinstance(x, SummedTimeArray)
         assert_equal(x(-0.1), [[1, 1], [1, 1]])
         assert_equal(x(0.0), [[2, 3], [4, 5]])
-
-    def test_batching(self):
-        # generic arrays
-        a = destroy(4)
-        H0 = a + dag(a)
-        psi0 = basis(4, 0)
-        times = jnp.linspace(0.0, 1.0, 11)
-
-        # modulated time array
-        deltas = jnp.linspace(0.0, 1.0, 4)
-        H_mod = modulated(lambda t, delta: jnp.cos(t * delta), H0, args=(deltas,))
-
-        # test sesolve output shape
-        result = sesolve(H_mod, psi0, times)
-        assert result.states.shape == (4, 11, 4, 1)
-
-        result = sesolve(H0 + H_mod, psi0, times)
-        assert result.states.shape == (4, 11, 4, 1)


### PR DESCRIPTION
This PR fixes batching for TimeArrays all around. We still cannot handle weird batchings (e.g. multiple batching within the same TimeArray) but it shouldn't be very hard to add: it's rather a question of whether we want it.

I needed it so I decided to implement it without waiting for the `args` refactorization of TimeArrays. I hope it's fine, and a similar structure might be needed anyway. 

Nits but can remove:
 - 72fe473c5778fe67792bc4d7aa2677eeced8b7b8 removes comments in args checks (thought it was self-explanatory already)
 - da7f2e6db1468aef0c89bb20ad7f1e6951886b17 renames `self.x` to `self.array` in `ConstantTimeArray`. I think it's more aligned with other notations inside TimeArrays this way.

Closes DYN-192.