### PR TITLE
Support rectangular matrices in `dq.dag()`

### DIFF
--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -11,6 +11,7 @@ _cases = {
     '(..., 1, n)': lambda x: x.ndim >= 2 and x.shape[-2] == 1,
     '(..., n, n)': lambda x: x.ndim >= 2 and x.shape[-2] == x.shape[-1],
     '(N, ..., n, n)': lambda x: x.ndim >= 3 and x.shape[-2] == x.shape[-1],
+    '(..., m, n)': lambda x: x.ndim >= 2,
     '(..., n)': lambda x: x.ndim >= 1,
     '(n, 1)': lambda x: x.ndim == 2 and x.shape[-1] == 1,
     '(1, n)': lambda x: x.ndim == 2 and x.shape[-2] == 1,

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -63,6 +63,7 @@ def dag(x: ArrayLike) -> Array:
         Array([[1.-0.j, 0.-0.j]], dtype=complex64)
     """
     x = jnp.asarray(x)
+    check_shape(x, 'x', '(..., m, n)')
     return x.mT.conj()
 
 

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -44,15 +44,13 @@ __all__ = [
 
 
 def dag(x: ArrayLike) -> Array:
-    r"""Returns the adjoint (complex conjugate transpose) of a ket, bra, density matrix
-    or operator.
+    r"""Returns the adjoint (complex conjugate transpose) of a matrix.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,
-            density matrix or operator.
+        x _(array_like of shape (..., m, n))_: Matrix.
 
     Returns:
-       _(array of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Adjoint of `x`.
+       _(array of shape (..., n, m))_ Adjoint of `x`.
 
     Notes:
         This function is equivalent to `x.mT.conj()`.

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -65,7 +65,6 @@ def dag(x: ArrayLike) -> Array:
         Array([[1.-0.j, 0.-0.j]], dtype=complex64)
     """
     x = jnp.asarray(x)
-    check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
     return x.mT.conj()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires-python = ">=3.9"
 description = "Quantum systems simulation with JAX."
 dependencies = [
     "qutip>=4.0,<5.0",
+    "scipy<=1.12",  # fix QuTiP unspecified dependency on scipy
     "numpy",
     "matplotlib",
     "tqdm",


### PR DESCRIPTION
Is is legitimate to compute the hermitian conjugate of arbitrary shaped matrices, so we should remove the check