### PR TITLE
Remove `dq.eigenstates()` (for now)

### DIFF
--- a/dynamiqs/utils/utils/__init__.py
+++ b/dynamiqs/utils/utils/__init__.py
@@ -28,6 +28,5 @@ __all__ = [
     'overlap',
     'fidelity',
     'entropy_vn',
-    'eigenstates',
     'wigner',
 ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -211,7 +211,6 @@ nav:
               - overlap: python_api/utils/utils/overlap.md
               - fidelity: python_api/utils/utils/fidelity.md
               - entropy_vn: python_api/utils/utils/entropy_vn.md
-              - eigenstates: python_api/utils/utils/eigenstates.md
               - wigner: python_api/utils/utils/wigner.md
           - JAX-related utilities:
               - to_qutip: python_api/utils/jax_utils/to_qutip.md


### PR DESCRIPTION
As discussed with @gautierronan and @RemiRousseau this functions has a bunch of issues for now, we'll work on a better version

- Somewhat ill-defined for super-operators (only returns right eigenvectors)
- Documentation is too loose
- Not GPU-compatible
- Bug in the current implementation (due to mismatch btw `jnp.linalg.eig()` and `np.linalg.eig()`)