### PR TITLE
Add Bosh3 solver from diffrax

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -35,6 +35,7 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
         - Tsit5
         - Dopri5
         - Dopri8
+        - Bosh3
         - Euler
         - Rouchon1
         - Rouchon2

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -142,3 +142,7 @@ class Dopri8Solver(AdaptiveSolver):
 
 class Tsit5Solver(AdaptiveSolver):
     diffrax_solver = dx.Tsit5()
+
+
+class Bosh3Solver(AdaptiveSolver):
+    diffrax_solver = dx.Bosh3()

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 
 from ..core.abstract_solver import MESolver
 from ..core.diffrax_solver import (
+    Bosh3Solver,
     DiffraxSolver,
     Dopri5Solver,
     Dopri8Solver,
@@ -59,4 +60,8 @@ class MEDopri8(MEDiffraxSolver, Dopri8Solver):
 
 
 class METsit5(MEDiffraxSolver, Tsit5Solver):
+    pass
+
+
+class MEBosh3(MEDiffraxSolver, Bosh3Solver):
     pass

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -19,10 +19,10 @@ from ..core._utils import (
 from ..gradient import Gradient
 from ..options import Options
 from ..result import MEResult
-from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
+from ..solver import Bosh3, Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import TimeArray
 from ..utils.utils import todm
-from .mediffrax import MEDopri5, MEDopri8, MEEuler, METsit5
+from .mediffrax import MEBosh3, MEDopri5, MEDopri8, MEEuler, METsit5
 from .mepropagator import MEPropagator
 
 __all__ = ['mesolve']
@@ -83,7 +83,7 @@ def mesolve(
         solver: Solver for the integration. Defaults to
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:
             [`Tsit5`][dynamiqs.solver.Tsit5], [`Dopri5`][dynamiqs.solver.Dopri5],
-            [`Dopri8`][dynamiqs.solver.Dopri8],
+            [`Dopri8`][dynamiqs.solver.Dopri8], [`Bosh3`][dynamiqs.solver.Bosh3],
             [`Euler`][dynamiqs.solver.Euler],
             [`Rouchon1`][dynamiqs.solver.Rouchon1],
             [`Rouchon2`][dynamiqs.solver.Rouchon2],
@@ -166,6 +166,7 @@ def _mesolve(
         Dopri5: MEDopri5,
         Dopri8: MEDopri8,
         Tsit5: METsit5,
+        Bosh3: MEBosh3,
         Propagator: MEPropagator,
     }
     solver_class = get_solver_class(solvers, solver)

--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -4,6 +4,7 @@ import diffrax as dx
 
 from ..core.abstract_solver import SESolver
 from ..core.diffrax_solver import (
+    Bosh3Solver,
     DiffraxSolver,
     Dopri5Solver,
     Dopri8Solver,
@@ -33,4 +34,8 @@ class SEDopri8(SEDiffraxSolver, Dopri8Solver):
 
 
 class SETsit5(SEDiffraxSolver, Tsit5Solver):
+    pass
+
+
+class SEBosh3(SEDiffraxSolver, Bosh3Solver):
     pass

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -18,9 +18,9 @@ from ..core._utils import (
 from ..gradient import Gradient
 from ..options import Options
 from ..result import SEResult
-from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
+from ..solver import Bosh3, Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import TimeArray
-from .sediffrax import SEDopri5, SEDopri8, SEEuler, SETsit5
+from .sediffrax import SEBosh3, SEDopri5, SEDopri8, SEEuler, SETsit5
 from .sepropagator import SEPropagator
 
 __all__ = ['sesolve']
@@ -72,7 +72,7 @@ def sesolve(
         solver: Solver for the integration. Defaults to
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:
             [`Tsit5`][dynamiqs.solver.Tsit5], [`Dopri5`][dynamiqs.solver.Dopri5],
-            [`Dopri8`][dynamiqs.solver.Dopri8],
+            [`Dopri8`][dynamiqs.solver.Dopri8], [`Bosh3`][dynamiqs.solver.Bosh3],
             [`Euler`][dynamiqs.solver.Euler],
             [`Propagator`][dynamiqs.solver.Propagator]).
 
@@ -147,6 +147,7 @@ def _sesolve(
         Dopri5: SEDopri5,
         Dopri8: SEDopri8,
         Tsit5: SETsit5,
+        Bosh3: SEBosh3,
         Propagator: SEPropagator,
     }
     solver_class = get_solver_class(solvers, solver)

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -7,7 +7,16 @@ import equinox as eqx
 from ._utils import tree_str_inline
 from .gradient import Autograd, CheckpointAutograd, Gradient
 
-__all__ = ['Propagator', 'Euler', 'Rouchon1', 'Rouchon2', 'Dopri5', 'Dopri8', 'Tsit5']
+__all__ = [
+    'Propagator',
+    'Euler',
+    'Rouchon1',
+    'Rouchon2',
+    'Dopri5',
+    'Dopri8',
+    'Tsit5',
+    'Bosh3',
+]
 
 
 _TupleGradient = tuple[type[Gradient], ...]
@@ -23,7 +32,10 @@ class Solver(eqx.Module):
         return isinstance(gradient, cls.SUPPORTED_GRADIENT)
 
     @classmethod
-    def assert_supports_gradient(cls, gradient: Gradient | None) -> None:  # noqa: ANN102
+    def assert_supports_gradient(
+        cls,  # noqa: ANN102
+        gradient: Gradient | None,
+    ) -> None:
         if gradient is not None and not cls.supports_gradient(gradient):
             support_str = ', '.join(f'`{x.__name__}`' for x in cls.SUPPORTED_GRADIENT)
             raise ValueError(
@@ -245,6 +257,41 @@ class Tsit5(_ODEAdaptiveStep):
 
     This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
     library, see [`diffrax.Tsit5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Tsit5).
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+
+    Notes: Supported gradients
+        This solver supports differentiation with
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd].
+    """
+
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+
+    # dummy init to have the signature in the documentation
+    def __init__(
+        self,
+        rtol: float = 1e-6,
+        atol: float = 1e-6,
+        safety_factor: float = 0.9,
+        min_factor: float = 0.2,
+        max_factor: float = 5.0,
+        max_steps: int = 100_000,
+    ):
+        super().__init__(rtol, atol, safety_factor, min_factor, max_factor, max_steps)
+
+
+class Bosh3(_ODEAdaptiveStep):
+    """Dormand-Prince method of order 5 (adaptive step size ODE solver).
+
+    This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
+    library, see [`diffrax.Bosh3`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Bosh3).
 
     Args:
         rtol: Relative tolerance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
               - Tsit5: python_api/solver/Tsit5.md
               - Dopri5: python_api/solver/Dopri5.md
               - Dopri8: python_api/solver/Dopri8.md
+              - Bosh3: python_api/solver/Bosh3.md
               - Euler: python_api/solver/Euler.md
               - Rouchon1: python_api/solver/Rouchon1.md
               - Rouchon2: python_api/solver/Rouchon2.md


### PR DESCRIPTION
Just adding a low-order Runge Kutta solver (`Bosh3`) from diffrax to dynamiqs. Wanted to try it out on a specific problem (no RWA, fast dynamics) to see if it would improve the solving. We can merge already, but can also wait to see if tests are concluant.