### PR TITLE
Fix N-D batching for TimeArrays

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
-from jaxtyping import Array, PyTree
+from jaxtyping import Array, ArrayLike, PyTree
 
 
 def type_str(type: Any) -> str:  # noqa: A002
@@ -43,3 +43,21 @@ def cdtype() -> jnp.complex64 | jnp.complex128:
 def tree_str_inline(x: PyTree) -> str:
     # return an inline formatting of a pytree as a string
     return eqx.tree_pformat(x, indent=0).replace('\n', '').replace(',', ', ')
+
+
+def expand_as_broadcastable(arrays: tuple[ArrayLike, ...]) -> tuple[ArrayLike, ...]:
+    arrays = tuple([jnp.asarray(arr) for arr in arrays])
+    expanded_arrays = []
+
+    # number of dimensions of the expanded arrays
+    num_dims = sum([arr.ndim for arr in arrays])
+
+    # loop over the arrays and expand them
+    k = 0
+    for arr in arrays:
+        new_shape = [-1 if i in range(k, k + arr.ndim) else 1 for i in range(num_dims)]
+        new_arr = arr.reshape(new_shape)
+        expanded_arrays.append(new_arr)
+        k += arr.ndim
+
+    return tuple(expanded_arrays)

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -186,10 +186,10 @@ def _mesolve(
 def _check_mesolve_args(
     H: TimeArray, jump_ops: list[TimeArray], rho0: Array, exp_ops: Array | None
 ):
-    check_shape(H, 'H', '(?, n, n)', subs={'?': 'nH?'})
+    check_shape(H, 'H', '(..., n, n)')
 
     for i, L in enumerate(jump_ops):
-        check_shape(L, f'jump_ops[{i}]', '(?, n, n)', subs={'?': 'nL?'})
+        check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
 
     if len(jump_ops) == 0:
         logging.warn(

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -166,7 +166,7 @@ def _sesolve(
 
 def _check_sesolve_args(H: TimeArray, psi0: Array, exp_ops: Array | None):
     # === check H shape
-    check_shape(H, 'H', '(?, n, n)', subs={'?': 'nH?'})
+    check_shape(H, 'H', '(..., n, n)')
     check_shape(psi0, 'psi0', '(?, n, 1)', subs={'?': 'npsi0?'})
 
     # === check exp_ops shape


### PR DESCRIPTION
Temporary fix for N-D batching with TimeArrays, until we figure out the new TimeArray API.

See the example below to see how it works. In short, we force broadcasting when >1D batching is required.

```python
import jax.numpy as jnp

import dynamiqs as dq

# arrays to 2D batch over
omegas = jnp.linspace(-1.0, 1.0, 2)
phases = jnp.linspace(0.0, 2.0 * jnp.pi, 3)

# common arrays
a = dq.destroy(4)
psi0 = dq.basis(4, 0)
tsave = jnp.linspace(0, 1.0, 11)

# make Hamiltonian
def coeff(t, omega, phase):
    return jnp.cos(omega * t + phase)

# == check solver shapes
# 0D batch
H = dq.modulated(coeff, a + dq.dag(a), args=(0.0, 1.0))
assert H(0.0).shape == (4, 4)
assert dq.sesolve(H, psi0, tsave).states.shape == (11, 4, 1)

# 1D batch over omegas
H = dq.modulated(coeff, a + dq.dag(a), args=(omegas, 1.0))
assert H(0.0).shape == (2, 4, 4)
assert dq.sesolve(H, psi0, tsave).states.shape == (2, 11, 4, 1)

# 1D batch over phases
H = dq.modulated(coeff, a + dq.dag(a), args=(0.0, phases))
assert H(0.0).shape == (3, 4, 4)
assert dq.sesolve(H, psi0, tsave).states.shape == (3, 11, 4, 1)

# 2D batch
H = dq.modulated(coeff, a + dq.dag(a), args=(omegas, phases))
assert H(0.0).shape == (2, 3, 4, 4)
assert dq.sesolve(H, psi0, tsave).states.shape == (2, 3, 11, 4, 1)
```