### PR TITLE
Add `dq.smesolve()`

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,3 +4,5 @@
 *[Array-like objects]: e.g. Python lists, NumPy and JAX arrays or QuTiP Qobjs
 *[PWC]: piecewise constant
 *[SME]: stochastic master equation
+*[SMEs]: stochastic master equations
+*[PRNG]: pseudorandom number generator

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -43,6 +43,7 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
         - Rouchon1
         - Rouchon2
         - Expm
+        - Milstein
 
 ### Gradients (dq.gradient)
 

--- a/dynamiqs/integrators/apis/smesolve.py
+++ b/dynamiqs/integrators/apis/smesolve.py
@@ -2,13 +2,33 @@
 
 from __future__ import annotations
 
-from jaxtyping import ArrayLike
+import logging
+from functools import partial
 
+import jax
+import jax.numpy as jnp
+from jax import Array
+from jaxtyping import ArrayLike, PRNGKeyArray
+
+from ..._checks import check_shape, check_times
+from ..._utils import cdtype
 from ...gradient import Gradient
 from ...options import Options
-from ...result import Result
-from ...solver import Solver
-from ...time_array import TimeArray
+from ...result import SMESolveResult
+from ...solver import Euler, Milstein, Solver
+from ...time_array import Shape, TimeArray
+from ...utils.quantum_utils.general import todm
+from .._utils import (
+    _astimearray,
+    _cartesian_vectorize,
+    _flat_vectorize,
+    catch_xla_runtime_error,
+    get_integrator_class,
+)
+from ..smesolve.diffrax_integrator import (
+    SMESolveEulerIntegrator,
+    SMESolveMilsteinIntegrator,
+)
 
 
 def smesolve(
@@ -17,19 +37,20 @@ def smesolve(
     etas: ArrayLike,
     rho0: ArrayLike,
     tsave: ArrayLike,
+    keys: list[PRNGKeyArray],
     *,
     tmeas: ArrayLike | None = None,
-    ntrajs: int = 10,
     exp_ops: list[ArrayLike] | None = None,
-    solver: Solver | None = None,
+    solver: Solver = Milstein(),  # noqa: B008
     gradient: Gradient | None = None,
     options: Options = Options(),  # noqa: B008
-) -> Result:
+) -> SMESolveResult:
     r"""Solve the diffusive stochastic master equation (SME).
 
     Warning:
-        This function has not been ported to JAX yet. The following documentation is
-        a draft API, copied from the old PyTorch version of the library.
+        This function is still under test and development. Please
+        [open an issue on GitHub](https://github.com/dynamiqs/dynamiqs/issues/new) if
+        you encounter any bug.
 
     This function computes the evolution of the density matrix $\rho(t)$ at time $t$,
     starting from an initial state $\rho_0$, according to the diffusive SME in Itô
@@ -66,20 +87,20 @@ def smesolve(
         don't hesitate to
         [open an issue on GitHub](https://github.com/dynamiqs/dynamiqs/issues/new).
 
-    The measured signals $I_k=\dd y_k/\dt$ verifies (again time is implicit):
+    The measured signals $I_k=\dd Y_k/\dt$ are defined by (again time is implicit):
     $$
-        \dd y_k =\sqrt{\eta_k} \tr{(L_k + L_k^\dag) \rho} \dt + \dd W_k.
+        \dd Y_k = \sqrt{\eta_k} \tr{(L_k + L_k^\dag) \rho} \dt + \dd W_k.
     $$
 
     Note-: Signal normalisation
         Sometimes the signals are defined with a different but equivalent normalisation
-        $\dd y_k' = \dd y_k/(2\sqrt{\eta_k})$.
+        $\dd Y_k' = \dd Y_k/(2\sqrt{\eta_k})$.
 
     The signals $I_k$ are singular quantities, the solver returns the averaged signals
     $J_k$ defined for a time interval $[t_0, t_1)$ by:
     $$
         J_k([t_0, t_1)) = \frac{1}{t_1-t_0}\int_{t_0}^{t_1} I_k(t)\, \dt
-        = \frac{1}{t_1-t_0}\int_{t_0}^{t_1} \dd y_k(t).
+        = \frac{1}{t_1-t_0}\int_{t_0}^{t_1} \dd Y_k(t).
     $$
     The time intervals for integration are defined by the argument `tmeas`, which
     defines `len(tmeas) - 1` intervals. By default, `tmeas = tsave`, so the signals
@@ -94,32 +115,249 @@ def smesolve(
         tutorial for more details.
 
     Note-: Running multiple simulations concurrently
-        The Hamiltonian `H`, the jump operators `jump_ops` and the initial density
-        matrix `rho0` can be batched to solve multiple SMEs concurrently. All other
-        arguments are common to every batch. See the
+        The Hamiltonian `H` and the initial density matrix `rho0` can be batched to
+        solve multiple master equations concurrently. All other arguments are common to
+        every batch. See the
         [Batching simulations](../../documentation/basics/batching-simulations.md)
-        tutorial for
-        more details.
+        tutorial for more details.
+
+    Warning:
+            Batching on `jump_ops` and `etas` is not yet supported, if this is needed
+            don't hesitate to
+            [open an issue on GitHub](https://github.com/dynamiqs/dynamiqs/issues/new).
 
     Args:
-        H _(array-like or time-array of shape (bH?, n, n))_: Hamiltonian.
-        jump_ops _(list of array-like or time-array, of shape (nL, n, n))_: List of
+        H _(array-like or time-array of shape (...H, n, n))_: Hamiltonian.
+        jump_ops _(list of array-like or time-array, each of shape (n, n))_: List of
             jump operators.
-        etas _(array-like of shape (nL,))_: Measurement efficiencies, must be of the
-            same length as `jump_ops` with values between 0 and 1. For a purely
-            dissipative loss channel, set the corresponding efficiency to 0. No
-            measurement signal will be returned for such channels.
-        rho0 _(array-like of shape (brho?, n, 1) or (brho?, n, n))_: Initial state.
+        etas _(array-like of shape (len(jump_ops),))_: Measurement efficiency for each
+            loss channel with values between 0 (purely dissipative) and 1 (perfectly
+            monitored). No measurement signal is returned for purely dissipative
+            loss channels.
+        rho0 _(array-like of shape (...rho0, n, 1) or (...rho0, n, n))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
+        keys _(list of PRNG keys)_: PRNG keys used to sample the Wiener processes.
+            The number of elements defines the number of sampled stochastic
+            trajectories.
         tmeas _(array-like of shape (ntmeas,), optional)_: Times between which
             measurement signals are averaged and saved. Defaults to `tsave`.
-        ntrajs: Number of stochastic trajectories to solve concurrently.
-        exp_ops _(list of array-like, of shape (nE, n, n), optional)_: List of
+        exp_ops _(list of array-like, each of shape (n, n), optional)_: List of
             operators for which the expectation value is computed.
-        solver: Solver for the integration.
+        solver: Solver for the integration. Defaults to
+            [`dq.solver.Milstein`][dynamiqs.solver.Milstein] (supported:
+            [`Milstein`][dynamiqs.solver.Milstein], [`Euler`][dynamiqs.solver.Euler]).
         gradient: Algorithm used to compute the gradient.
         options: Generic options, see [`dq.Options`][dynamiqs.Options].
+
+    Returns:
+        [`dq.SMESolveResult`][dynamiqs.SMESolveResult] object holding the result of the
+            SME integration. Use the attributes `states`, `measurements` and `expects`
+            to access saved quantities, more details in
+            [`dq.SMESolveResult`][dynamiqs.SMESolveResult].
     """  # noqa: E501
-    return NotImplementedError
+    # === convert arguments
+    H = _astimearray(H)
+    jump_ops = [_astimearray(L) for L in jump_ops]
+    etas = jnp.asarray(etas)
+    rho0 = jnp.asarray(rho0, dtype=cdtype())
+    tsave = jnp.asarray(tsave)
+    keys = jnp.asarray(keys)
+    tmeas = jnp.asarray(tmeas) if tmeas is not None else tsave
+    exp_ops = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
+
+    # === check arguments
+    _check_smesolve_args(H, jump_ops, etas, rho0, exp_ops)
+    tsave = check_times(tsave, 'tsave')
+    tmeas = check_times(tmeas, 'tmeas')
+
+    # === convert rho0 to density matrix
+    rho0 = todm(rho0)
+
+    # === split jump operators
+    # split between purely dissipative (eta = 0) and monitored (eta != 0)
+    dissipative_ops = [L for L, eta in zip(jump_ops, etas) if eta == 0]
+    measured_ops = [L for L, eta in zip(jump_ops, etas) if eta != 0]
+    etas = etas[etas != 0]
+
+    # we implement the jitted vectorization in another function to pre-convert QuTiP
+    # objects (which are not JIT-compatible) to JAX arrays
+    return _vectorized_smesolve(
+        H,
+        dissipative_ops,
+        measured_ops,
+        etas,
+        rho0,
+        tsave,
+        keys,
+        tmeas,
+        exp_ops,
+        solver,
+        gradient,
+        options,
+    )
+
+
+@catch_xla_runtime_error
+@partial(jax.jit, static_argnames=('solver', 'gradient', 'options'))
+def _vectorized_smesolve(
+    H: TimeArray,
+    dissipative_ops: list[TimeArray],
+    measured_ops: list[TimeArray],
+    etas: Array,
+    rho0: Array,
+    tsave: Array,
+    keys: PRNGKeyArray,
+    tmeas: Array,
+    exp_ops: Array | None,
+    solver: Solver,
+    gradient: Gradient | None,
+    options: Options,
+) -> SMESolveResult:
+    # === vectorize function
+    # we vectorize over H and rho0, all other arguments are not vectorized
+    # `n_batch` is a pytree. Each leaf of this pytree gives the number of times
+    # this leaf should be vmapped on.
+
+    # the result is vectorized over `_saved` and `infos`
+    out_axes = SMESolveResult(False, False, False, False, 0, 0, False, 0)
+
+    if not options.cartesian_batching:
+        broadcast_shape = jnp.broadcast_shapes(H.shape[:-2], rho0.shape[:-2])
+
+        def broadcast(x: TimeArray) -> TimeArray:
+            return x.broadcast_to(*(broadcast_shape + x.shape[-2:]))
+
+        H = broadcast(H)
+        rho0 = jnp.broadcast_to(rho0, broadcast_shape + rho0.shape[-2:])
+
+    n_batch = (
+        H.in_axes,
+        Shape(),
+        Shape(),
+        Shape(),
+        Shape(rho0.shape[:-2]),
+        Shape(),
+        Shape([len(keys)]),
+        Shape(),
+        Shape(),
+        Shape(),
+        Shape(),
+        Shape(),
+    )
+
+    # compute vectorized function with given batching strategy
+    if options.cartesian_batching:
+        f = _cartesian_vectorize(_smesolve_single_trajectory, n_batch, out_axes)
+    else:
+        f = _flat_vectorize(_smesolve_single_trajectory, n_batch, out_axes)
+
+    # === apply vectorized function
+    return f(
+        H,
+        dissipative_ops,
+        measured_ops,
+        etas,
+        rho0,
+        tsave,
+        keys,
+        tmeas,
+        exp_ops,
+        solver,
+        gradient,
+        options,
+    )
+
+
+def _smesolve_single_trajectory(
+    H: TimeArray,
+    dissipative_ops: list[TimeArray],
+    measured_ops: list[TimeArray],
+    etas: Array,
+    rho0: Array,
+    tsave: Array,
+    key: PRNGKeyArray,
+    tmeas: Array,
+    exp_ops: Array | None,
+    solver: Solver,
+    gradient: Gradient | None,
+    options: Options,
+) -> SMESolveResult:
+    # === select integrator class
+    integrators = {Euler: SMESolveEulerIntegrator, Milstein: SMESolveMilsteinIntegrator}
+    integrator_class = get_integrator_class(integrators, solver)
+
+    # === check gradient is supported
+    solver.assert_supports_gradient(gradient)
+
+    # === init solver
+    integrator = integrator_class(
+        tsave,
+        rho0,
+        H,
+        solver,
+        gradient,
+        options,
+        tmeas,
+        key,
+        dissipative_ops,
+        measured_ops,
+        etas,
+        exp_ops,
+    )
+
+    # === run solver
+    result = integrator.run()
+
+    # === return result
+    return result  # noqa: RET504
+
+
+def _check_smesolve_args(
+    H: TimeArray,
+    jump_ops: list[TimeArray],
+    etas: Array,
+    rho0: Array,
+    exp_ops: Array | None,
+):
+    # === check H shape
+    check_shape(H, 'H', '(..., n, n)', subs={'...': '...H'})
+
+    # === check jump_ops
+    for i, L in enumerate(jump_ops):
+        check_shape(L, f'jump_ops[{i}]', '(n, n)')
+
+    if len(jump_ops) == 0:
+        logging.warn(
+            'Argument `jump_ops` is an empty list, consider using `dq.sesolve()` to'
+            ' solve the Schrödinger equation.'
+        )
+
+    # === check etas
+    check_shape(etas, 'etas', '(n,)', subs={'n': 'len(jump_ops)'})
+
+    if not len(etas) == len(jump_ops):
+        raise ValueError(
+            'Argument `etas` should be of the same length as argument `jump_ops`, but'
+            f' len(etas)={len(etas)} and len(jump_ops)={len(jump_ops)}.'
+        )
+
+    if jnp.all(etas == 0):
+        raise ValueError(
+            'Argument `etas` contains only null values, consider using `dq.mesolve()`'
+            ' to solve the Lindblad master equation.'
+        )
+
+    if not (jnp.all(etas >= 0) and jnp.all(etas <= 1)):
+        raise ValueError(
+            'Argument `etas` should only contain values between 0 and 1, but'
+            f' is {etas}.'
+        )
+
+    # === check rho0 shape
+    check_shape(rho0, 'rho0', '(..., n, 1)', '(..., n, n)', subs={'...': '...rho0'})
+
+    # === check exp_ops shape
+    if exp_ops is not None:
+        check_shape(exp_ops, 'exp_ops', '(N, n, n)', subs={'N': 'len(exp_ops)'})

--- a/dynamiqs/integrators/smesolve/diffrax_integrator.py
+++ b/dynamiqs/integrators/smesolve/diffrax_integrator.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from ..core.abstract_integrator import SMESolveIntegrator
+from ..core.diffrax_integrator import (
+    EulerIntegrator,
+    MilsteinIntegrator,
+    SMEDiffraxIntegrator,
+)
+
+
+class SMESolveDiffraxIntegrator(SMEDiffraxIntegrator, SMESolveIntegrator):
+    pass
+
+
+class SMESolveEulerIntegrator(SMESolveDiffraxIntegrator, EulerIntegrator):
+    pass
+
+
+class SMESolveMilsteinIntegrator(SMESolveDiffraxIntegrator, MilsteinIntegrator):
+    pass

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -17,6 +17,7 @@ __all__ = [
     'Tsit5',
     'Kvaerno3',
     'Kvaerno5',
+    'Milstein',
 ]
 
 
@@ -112,7 +113,7 @@ class _ODEAdaptiveStep(_ODESolver):
 
 # === public solvers options
 class Euler(_ODEFixedStep):
-    """Euler method (fixed step size ODE solver).
+    """Euler method (fixed step size ODE/SDE solver).
 
     This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
     library, see [`diffrax.Euler`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Euler).
@@ -356,6 +357,41 @@ class Kvaerno5(_ODEAdaptiveStep):
         consider switching to double-precision with
         [`dq.set_precision('double')`][dynamiqs.set_precision]. See more details in
         [The sharp bits 🔪](../../documentation/getting_started/sharp-bits.md) tutorial.
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+
+    Note-: Supported gradients
+        This solver supports differentiation with
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd].
+    """
+
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+
+    # dummy init to have the signature in the documentation
+    def __init__(
+        self,
+        rtol: float = 1e-6,
+        atol: float = 1e-6,
+        safety_factor: float = 0.9,
+        min_factor: float = 0.2,
+        max_factor: float = 5.0,
+        max_steps: int = 100_000,
+    ):
+        super().__init__(rtol, atol, safety_factor, min_factor, max_factor, max_steps)
+
+
+class Milstein(_ODEAdaptiveStep):
+    """Milstein method (adaptive step size SDE solver).
+
+    This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
+    library, see [`diffrax.ItoMilstein`](https://docs.kidger.site/diffrax/api/solvers/sde_solvers/#diffrax.ItoMilstein).
 
     Args:
         rtol: Relative tolerance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -161,6 +161,7 @@ nav:
               - Rouchon1: python_api/solver/Rouchon1.md
               - Rouchon2: python_api/solver/Rouchon2.md
               - Expm: python_api/solver/Expm.md
+              - Milstein: python_api/solver/Milstein.md
           - Gradients (dq.gradient):
               - Autograd: python_api/gradient/Autograd.md
               - CheckpointAutograd: python_api/gradient/CheckpointAutograd.md
@@ -168,6 +169,7 @@ nav:
           - Results:
               - SESolveResult: python_api/result/SESolveResult.md
               - MESolveResult: python_api/result/MESolveResult.md
+              - SMESolveResult: python_api/result/SMESolveResult.md
               - SEPropagatorResult: python_api/result/SEPropagatorResult.md
               - MEPropagatorResult: python_api/result/MEPropagatorResult.md
       - Utilities:


### PR DESCRIPTION
Closes DYN-164.

First version April 11, 2024, updated September 2, 2024. Changed target branch to `dev-smesolve`.

This is quite a big one, I advise reading commit by commit. I did my best to split the logic between saving, solver logic and API. This solver has not reached it's final version, consider this is a first working POC on which we can iterate.

<img width="612" alt="Screenshot 2024-04-11 at 22 59 48" src="https://github.com/dynamiqs/dynamiqs/assets/38159029/adf7bf37-8367-4c03-89d1-66b1ac606e42">

## Example API usage
```python
H = dq.zero(2)
psi0 = dq.unit(dq.basis(2, 0) + dq.basis(2, 1))
jump_ops = [1.0 * dq.sigmaz()]
etas = [1.0]
tsave = np.linspace(0, 1.0, 101)
key = jax.random.PRNGKey(42)
ntrajs = 6
keys = jax.random.split(key, ntrajs)

result = dq.smesolve(H, jump_ops, etas, psi0, tsave, keys)

print(result.states.shape)  # (ntrajs, ntsave, n, n)
print(result.measurements.shape)  # (ntrajs, nLm, ntsave-1)
```

## Example 1: monitored qubit
First example to convince the SME-practionner that the solver is correct. Qubit starting from $\ket+$ with $H=0$ and monitored $L=\sigma_z$ (we expect diffusive projection onto one of $\sigma_z$ eigenvalues).

![qubit-trajectories](https://github.com/dynamiqs/dynamiqs/assets/38159029/166e7f57-1a8b-4838-ac9d-516203b2a8a4)

<details>
  <summary>Code</summary>

  ```python
  # imports
  import jax
  import jax.numpy as jnp
  import numpy as np
  
  import dynamiqs as dq
  from dynamiqs.plots.utils import mplstyle
  
  mplstyle()
  
  # simulation
  H = dq.zero(2)
  psi0 = dq.unit(dq.basis(2, 0) + dq.basis(2, 1))
  jump_ops = [1.0 * dq.sigmaz()]
  etas = [1.0]
  tsave = np.linspace(0, 1.0, 101)
  key = jax.random.PRNGKey(42)
  ntrajs = 6
  keys = jax.random.split(key, ntrajs)
  
  result = dq.smesolve(H, jump_ops, etas, psi0, tsave, keys)
  
  print(result.states.shape)  # (ntrajs, ntsave, n, n)
  print(result.measurements.shape)  # (ntrajs, nLm, ntsave-1)
  
  # plot
  fig, axs = dq.gridplot(3, 3, w=6, h=3, sharex=True)
  ax0, ax1, ax2 = list(axs)
  
  for states in result.states:
      ax0.plot(tsave, dq.expect(dq.sigmaz(), states).real, lw=1.5)
      ax0.axhline(-1, ls='--', lw=1.0, color='gray')
      ax0.axhline(1, ls='--', lw=1.0, color='gray')
      ax0.set(
          title=r'Time evolution of $\sigma_z$ expectation value',
          xlabel=r'$t$',
          ylabel=r'$\mathrm{Tr}[\sigma_z\rho_t]$',
          ylim=(-1.1, 1.1),
      )
  
  for It in result.measurements[:, 0]:
      integrated_signal = jnp.cumsum(It)
      ax1.axhline(0, ls='--', lw=1.0, color='gray')
      ax1.plot(tsave[1:], integrated_signal, lw=1.5)
      ax1.set(
          title=r'Time integrated signal',
          xlabel=r'$t$',
          ylabel=r'$\int_0^t \mathrm{d}Y_u$',
          ylim=(-4.5, 4.5),
      )
  
      ax2.plot(tsave[:-1], It, lw=1.5)
      delta_t = tsave[1] - tsave[0]
      ax2.set(
          title=rf'Instantaneous signal (binned on $\Delta t={delta_t}$)',
          xlabel=r'$t$',
          ylabel=r'$I_t$',
          ylim=(-0.4, 0.4),
      )
  
  fig.savefig('qubit-sme.png', dpi=300, bbox_inches='tight')
  ```

</details>

## Example 2: monitored cavity

Cavity starting from $\ket\alpha$ with $H=\Delta a^\dagger a$ and monitored $L_X = \sqrt\kappa a$ and $L_P = \sqrt\kappa (-ia)$ (we expect no measurement backaction and average signal trajectories following the state expectation values)
![cavity-sme](https://github.com/dynamiqs/dynamiqs/assets/38159029/ae60789f-e72a-44fd-bb8c-b249ab70d3ca)

<details>
  <summary>Code</summary>

```python
# imports
import jax
import jax.numpy as jnp
import numpy as np

import dynamiqs as dq
from dynamiqs.plots.utils import mplstyle

mplstyle()

# simulation
n = 16
a = dq.destroy(n)
H = 10 * dq.dag(a) @ a
psi0 = dq.coherent(n, 2.0)
jump_ops = [a, -1j * a]
etas = [1.0, 1.0]
tsave = np.linspace(0, 1.0, 101)
key = jax.random.PRNGKey(42)
ntrajs = 100
keys = jax.random.split(key, ntrajs)

result = dq.smesolve(H, jump_ops, etas, psi0, tsave, keys)

# plot
fig, axs = dq.gridplot(6, 3, w=6, h=3, sharex=True)
ax0, ax1, ax2, ax3, ax4, ax5 = list(axs)
delta_t = tsave[1] - tsave[0]

for states in result.states:
    ax0.plot(tsave, dq.expect(dq.position(n), states).real, lw=1.5)
    ax0.set(
        title=r'Time evolution of $X$ expectation value',
        xlabel=r'$t$',
        ylabel=r'$\mathrm{Tr}[X\rho_t]$',
        ylim=(-2.5, 2.5),
    )

    ax1.plot(tsave, dq.expect(dq.momentum(n), states).real, lw=1.5)
    ax1.set(
        title=r'Time evolution of $P$ expectation value',
        xlabel=r'$t$',
        ylabel=r'$\mathrm{Tr}[P\rho_t]$',
        ylim=(-2.5, 2.5),
    )

ItXs = result.measurements[:, 0] / delta_t / 2
ax2.plot(tsave[1:], jnp.mean(ItXs, axis=0))
ax2.set(
    title=r'$X$ quadrature signal averaged over all trajectories',
    xlabel=r'$t$',
    ylabel=r'$\mathbb{E}[I_t^X]$',
    ylim=(-2.5, 2.5),
)

ItPs = result.measurements[:, 1] / delta_t / 2
ax3.plot(tsave[1:], jnp.mean(ItPs, axis=0))
ax3.set(
    title=r'$P$ quadrature signal averaged over all trajectories',
    xlabel=r'$t$',
    ylabel=r'$\mathbb{E}[I_t^P]$',
    ylim=(-2.5, 2.5),
)

for It in ItXs[:3]:
    ax4.plot(tsave[:-1], It, lw=1.5)
    ax4.set(
        title=rf'Instantaneous $X$ quadrature signal for 3 trajectories (binned on $\Delta t={delta_t}$)',
        xlabel=r'$t$',
        ylabel=r'$I_t^X$',
        ylim=(-15, 15),
    )

for It in ItPs[:3]:
    ax5.plot(tsave[:-1], It, lw=1.5)
    ax5.set(
        title=rf'Instantaneous $P$ quadrature signal for 3 trajectories (binned on $\Delta t={delta_t}$)',
        xlabel=r'$t$',
        ylabel=r'$I_t^P$',
        ylim=(-15, 15),
    )

fig.savefig('cavity-sme.png', dpi=300, bbox_inches='tight')
```
</details>

## Miscellaneous
I manually tested `H` and `rho0` batching, that `exp_ops` keep working, and that `tmeas` does its job.

What's missing:
- (easy to solve) the same key is used by each batch instance
- (easy to solve) result.wiener is not correctly batched
- (tedious but easy) write tests
- (meeeh) the outer smesolve function is not JIT-compatible due to the split between measured and dissipative operators
- (meeeeh) performance is not very good