### PR TITLE
Add new batching API for time arrays and support for ND batching

### DIFF
--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -155,7 +155,7 @@ Let's define the modulated operator $H=\cos(2\pi t)\sigma_x$:
 >>> f = lambda t: jnp.cos(2.0 * jnp.pi * t)
 >>> H = dq.modulated(f, dq.sigmax())
 >>> type(H)
-<class 'dynamiqs.time_array.CallableTimeArray'>
+<class 'dynamiqs.time_array.ModulatedTimeArray'>
 >>> H.shape
 (2, 2)
 ```

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -155,7 +155,7 @@ Let's define the modulated operator $H=\cos(2\pi t)\sigma_x$:
 >>> f = lambda t: jnp.cos(2.0 * jnp.pi * t)
 >>> H = dq.modulated(f, dq.sigmax())
 >>> type(H)
-<class 'dynamiqs.time_array.ModulatedTimeArray'>
+<class 'dynamiqs.time_array.CallableTimeArray'>
 >>> H.shape
 (2, 2)
 ```
@@ -173,9 +173,9 @@ Array([[0.+0.j, 1.+0.j],
 ??? Note "Function with additional arguments"
     To define a modulated time-array with additional arguments, you can use the optional `args` parameter of [`dq.modulated()`][dynamiqs.modulated]:
     ```python
-    f = lambda t, omega: jnp.cos(omega * t)
+    f = lambda t: jnp.cos(omegas * t)
     omega = 1.0
-    H = dq.modulated(f, dq.sigmax(), args=(omega,))
+    H = dq.modulated(f, dq.sigmax())
     ```
 
 ### Arbitrary time-dependent operators
@@ -218,9 +218,9 @@ Array([[1., 0.],
 ??? Note "Function with additional arguments"
     To define a callable time-array with additional arguments, you can use the optional `args` parameter of [`dq.timecallable()`][dynamiqs.timecallable]:
     ```python
-    f = lambda t, x: x * jnp.array([[t, 0], [0, 1 - t]])
     x = 1.0
-    H = dq.timecallable(f, args=(x,))
+    f = lambda t: x * jnp.array([[t, 0], [0, 1 - t]])
+    H = dq.timecallable(f)
     ```
 
 ## Batching and differentiation with time-arrays
@@ -229,7 +229,7 @@ For modulated and arbitrary time-dependent operators, any array that is batched 
 
 For example to define a modulated Hamiltonian $H=\cos(\omega t)\sigma_x$ batched or differentiated over the parameter $\omega$:
 ```python
-f = lambda t, omega: jnp.cos(omega * t)
 omegas = jnp.linspace(0.0, 2.0, 10)
-H = dq.modulated(f, dq.sigmax(), args=(omegas,))
+f = lambda t: jnp.cos(omegas * t)
+H = dq.modulated(f, dq.sigmax())
 ```

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -9,7 +9,6 @@ from ..solver import Solver
 from ..time_array import (
     CallableTimeArray,
     ConstantTimeArray,
-    ModulatedTimeArray,
     PWCTimeArray,
     SummedTimeArray,
     TimeArray,
@@ -27,7 +26,7 @@ def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
             return ConstantTimeArray(array)
         except (TypeError, ValueError) as e:
             raise TypeError(
-                f'Argument must be an array-like or a time-array object, but has type'
+                'Argument must be an array-like or a time-array object, but has type'
                 f' {obj_type_str(x)}.'
             ) from e
 
@@ -93,10 +92,6 @@ def is_timearray_batched(tarray: TimeArray) -> TimeArray:
         return ConstantTimeArray(tarray.array.ndim > 2)
     elif isinstance(tarray, PWCTimeArray):
         return PWCTimeArray(False, tarray.values.ndim > 1, False)
-    elif isinstance(tarray, ModulatedTimeArray):
-        return ModulatedTimeArray(
-            False, False, tuple(arg.ndim > 0 for arg in tarray.args)
-        )
     elif isinstance(tarray, CallableTimeArray):
         return CallableTimeArray(False, tuple(arg.ndim > 0 for arg in tarray.args))
     else:

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -43,7 +43,7 @@ class BatchedCallable(eqx.Module):
         (*self.indices,) = jnp.indices(shape[:-2])
 
     def __call__(self, t: float) -> Array:
-        return self.f(t)[*self.indices]
+        return self.f(t)[*self.indices[:1]]
 
     @property
     def ndim(self) -> int:
@@ -63,10 +63,7 @@ def get_solver_class(
 
 
 def compute_vmap(
-    f: callable,
-    cartesian_batching: bool,
-    n_batch: [int],
-    out_axes: PyTree[int | None],
+    f: callable, cartesian_batching: bool, n_batch: [int], out_axes: PyTree[int | None]
 ) -> callable:
     # This function vectorizes `f` by applying jax.vmap over batched dimensions. The
     # argument `is_batched` indicates for each argument of `f` whether it is batched.
@@ -92,7 +89,6 @@ def compute_vmap(
                     in_axes = jtu.tree_map(lambda _: None, leaves)
                     in_axes[i] = 0
                     in_axes = jtu.tree_unflatten(treedef, in_axes)
-                    print(in_axes)
                     for _ in range(leaf):
                         f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
         else:

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -43,7 +43,7 @@ class BatchedCallable(eqx.Module):
         (*self.indices,) = jnp.indices(shape[:-2])
 
     def __call__(self, t: float) -> Array:
-        return self.f(t)[*self.indices[:1]]
+        return self.f(t)[self.indices[0]]
 
     @property
     def ndim(self) -> int:

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
-from jaxtyping import Array, ArrayLike, PyTree
+from jaxtyping import ArrayLike, PyTree
 
 from .._utils import cdtype, obj_type_str
 from ..solver import Solver
@@ -31,23 +30,6 @@ def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
                 'Argument must be an array-like or a time-array object, but has type'
                 f' {obj_type_str(x)}.'
             ) from e
-
-
-class BatchedCallable(eqx.Module):
-    f: callable[[float], Array]
-    indices: list[Array]
-
-    def __init__(self, f: callable[[float], Array]):
-        shape = jax.eval_shape(f, 0.0).shape
-        self.f = f
-        (*self.indices,) = jnp.indices(shape[:-2])
-
-    def __call__(self, t: float) -> Array:
-        return self.f(t)[self.indices[0]]
-
-    @property
-    def ndim(self) -> int:
-        return jax.eval_shape(self.f, 0.0).ndim
 
 
 def get_solver_class(

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -195,7 +195,7 @@ def _check_mesolve_args(
         )
 
     # === check rho0 shape
-    check_shape(rho0, 'rho0', '(?, n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
+    check_shape(rho0, 'rho0', '(..., n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -189,13 +189,13 @@ def _check_mesolve_args(
         check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
 
     if len(jump_ops) == 0:
-        logging.warn(
+        logging.warning(
             'Argument `jump_ops` is an empty list, consider using `dq.sesolve()` to'
             ' solve the Schrödinger equation.'
         )
 
     # === check rho0 shape
-    check_shape(rho0, 'rho0', '(..., n, 1)', '(?, n, n)', subs={'?': 'nrho0?'})
+    check_shape(rho0, 'rho0', '(..., n, 1)', '(..., n, n)', subs={'...': '...nrho0'})
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import equinox as eqx
-import jax
+import jax.tree_util as jtu
 from jax import Array
 from jaxtyping import PyTree, ScalarLike
 
@@ -47,9 +47,9 @@ class Options(eqx.Module):
         self.cartesian_batching = cartesian_batching
         self.t0 = t0
 
-        # make `save_extra` a valid Pytree with `jax.tree_util.Partial`
+        # make `save_extra` a valid Pytree with `Partial`
         if save_extra is not None:
-            save_extra = jax.tree_util.Partial(save_extra)
+            save_extra = jtu.Partial(save_extra)
         self.save_extra = save_extra
 
     def __str__(self) -> str:

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -9,12 +9,7 @@ from jaxtyping import ArrayLike
 
 from .._checks import check_shape, check_times
 from .._utils import cdtype
-from ..core._utils import (
-    _astimearray,
-    compute_vmap,
-    get_solver_class,
-    is_timearray_batched,
-)
+from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
 from ..result import SEResult
@@ -112,21 +107,22 @@ def _vmap_sesolve(
 ) -> SEResult:
     # === vectorize function
     # we vectorize over H and psi0, all other arguments are not vectorized
-    is_batched = (
-        is_timearray_batched(H),
-        psi0.ndim > 2,
-        False,
-        False,
-        False,
-        False,
-        False,
+
+    n_batch = (
+        H.ndim - 2,
+        psi0.ndim - 2,
+        0,
+        0,
+        0,
+        0,
+        0,
     )
 
     # the result is vectorized over `_saved` and `infos`
     out_axes = SEResult(None, None, None, None, 0, 0)
 
     # compute vectorized function with given batching strategy
-    f = compute_vmap(_sesolve, options.cartesian_batching, is_batched, out_axes)
+    f = compute_vmap(_sesolve, options.cartesian_batching, n_batch, out_axes)
 
     # === apply vectorized function
     return f(H, psi0, tsave, exp_ops, solver, gradient, options)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -108,15 +108,7 @@ def _vmap_sesolve(
     # === vectorize function
     # we vectorize over H and psi0, all other arguments are not vectorized
 
-    n_batch = (
-        H.ndim - 2,
-        psi0.ndim - 2,
-        0,
-        0,
-        0,
-        0,
-        0,
-    )
+    n_batch = (H.ndim - 2, psi0.ndim - 2, 0, 0, 0, 0, 0)
 
     # the result is vectorized over `_saved` and `infos`
     out_axes = SEResult(None, None, None, None, 0, 0)
@@ -165,7 +157,7 @@ def _sesolve(
 def _check_sesolve_args(H: TimeArray, psi0: Array, exp_ops: Array | None):
     # === check H shape
     check_shape(H, 'H', '(..., n, n)')
-    check_shape(psi0, 'psi0', '(?, n, 1)', subs={'?': 'npsi0?'})
+    check_shape(psi0, 'psi0', '(..., n, 1)', subs={'?': 'npsi0?'})
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -9,7 +9,7 @@ from jaxtyping import ArrayLike
 
 from .._checks import check_shape, check_times
 from .._utils import cdtype
-from ..core._utils import BatchedCallable, _astimearray, compute_vmap, get_solver_class
+from ..core._utils import _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
 from ..result import SEResult
@@ -114,7 +114,7 @@ def _vmap_sesolve(
     out_axes = SEResult(None, None, None, None, 0, 0)
 
     if H.ndim > 2:
-        H = BatchedCallable(H)
+        H = H.as_batched_callable()
     # compute vectorized function with given batching strategy
     f = compute_vmap(_sesolve, options.cartesian_batching, n_batch, out_axes)
 

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -9,7 +9,7 @@ from jaxtyping import ArrayLike
 
 from .._checks import check_shape, check_times
 from .._utils import cdtype
-from ..core._utils import _astimearray, compute_vmap, get_solver_class
+from ..core._utils import BatchedCallable, _astimearray, compute_vmap, get_solver_class
 from ..gradient import Gradient
 from ..options import Options
 from ..result import SEResult
@@ -121,6 +121,8 @@ def _vmap_sesolve(
     # the result is vectorized over `_saved` and `infos`
     out_axes = SEResult(None, None, None, None, 0, 0)
 
+    if H.ndim > 2:
+        H = BatchedCallable(H)
     # compute vectorized function with given batching strategy
     f = compute_vmap(_sesolve, options.cartesian_batching, n_batch, out_axes)
 

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -157,7 +157,7 @@ def _sesolve(
 def _check_sesolve_args(H: TimeArray, psi0: Array, exp_ops: Array | None):
     # === check H shape
     check_shape(H, 'H', '(..., n, n)')
-    check_shape(psi0, 'psi0', '(..., n, 1)', subs={'?': 'npsi0?'})
+    check_shape(psi0, 'psi0', '(..., n, 1)', subs={'...': '...npsi0?'})
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -69,20 +69,15 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
 
     # values
     values = jnp.asarray(values, dtype=cdtype())
-    if values.shape[-1] != times.shape[-1] - 1:
+    if values.shape[-1] != len(times) - 1:
         raise TypeError(
-            'Argument `values` must have shape `(..., times.shape[-1]-1)`, but '
-            f'has shape `{values.shape}.'
+            'Argument `values` must have shape `(..., len(time)-1)`, but has shape'
+            f' `{values.shape}.'
         )
 
     # array
     array = jnp.asarray(array, dtype=cdtype())
     check_shape(array, 'array', '(n, n)')
-
-    # if values.ndim > 1:
-    #     values_batching = values.shape[:-1]
-    #     times = jnp.broadcast_to(times, values_batching + times.shape)
-    #     array = jnp.broadcast_to(array, values_batching + array.shape)
 
     return PWCTimeArray(times, values, array)
 
@@ -344,7 +339,7 @@ class PWCTimeArray(TimeArray):
 
     @property
     def shape(self) -> tuple[int, ...]:
-        return *self.values.shape[:-1], *self.array.shape[-2:]
+        return *self.values.shape[:-1], *self.array.shape
 
     @property
     def mT(self) -> TimeArray:
@@ -365,10 +360,7 @@ class PWCTimeArray(TimeArray):
         return PWCTimeArray(self.times, self.values.conj(), self.array.conj())
 
     def as_batched_callable(self) -> callable:
-        times = jnp.broadcast_to(self.times, self.values.shape[:-1] + self.times.shape)
-        values = self.values
-        array = jnp.broadcast_to(self.array, values.shape[:-1] + self.array.shape)
-        return PWCTimeArray(times, values, array)
+        return self
 
     def __call__(self, t: float) -> Array:
         def _zero(_: float) -> Array:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -163,7 +163,7 @@ def _split_shape(
     # find where to split shape
     cumprod = jnp.cumprod(jnp.concatenate([jnp.array([1]), _shape]))
     idx = jnp.where(cumprod == _size_1)[0][-1]
-    return (shape[:idx], shape[idx:])
+    return shape[:idx], shape[idx:]
 
 
 class TimeArray(eqx.Module):
@@ -404,7 +404,7 @@ class ModulatedTimeArray(TimeArray):
     @property
     def shape(self) -> tuple[int, ...]:
         f_shape = jax.eval_shape(self.f, 0.0).shape
-        return (*f_shape, *self.array.shape)
+        return *f_shape, *self.array.shape
 
     @property
     def mT(self) -> TimeArray:

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -135,8 +135,8 @@ class OTDQubit(OpenSystem):
         self.params_default = self.Params(eps, omega, gamma)
 
     def H(self, params: PyTree):
-        f = lambda t, eps, omega: eps * jnp.cos(omega * t) * dq.sigmax()
-        return dq.timecallable(f, args=(params.eps, params.omega))
+        f = lambda t: params.eps * jnp.cos(params.omega * t) * dq.sigmax()
+        return dq.timecallable(f)
 
     def Ls(self, params: PyTree) -> list[ArrayLike | TimeArray]:
         return [jnp.sqrt(params.gamma) * dq.sigmax()]

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -16,7 +16,7 @@ def test_batching(cartesian_batching, nH, npsi0, nL1, nL2):
     nL1 = nL1 if cartesian_batching else nH
     nL2 = nL2 if cartesian_batching else nH
     npsi0 = npsi0 if cartesian_batching else nH
-    nEs = 7
+    nE = 7
 
     options = dq.options.Options(cartesian_batching=cartesian_batching)
 
@@ -24,14 +24,14 @@ def test_batching(cartesian_batching, nH, npsi0, nL1, nL2):
     k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(42), 5)
     H = dq.rand_herm(k1, (*nH, n, n))
     Ls = [dq.rand_herm(k2, (*nL1, n, n)), dq.rand_herm(k3, (*nL2, n, n))]
-    exp_ops = dq.rand_complex(k4, (nEs, n, n))
+    exp_ops = dq.rand_complex(k4, (nE, n, n))
     psi0 = dq.rand_ket(k5, (*npsi0, n, 1))
     tsave = jnp.linspace(0, 0.01, ntsave)
 
     result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
         assert result.states.shape == (*nH, *nL1, *nL2, *npsi0, ntsave, n, n)
-        assert result.expects.shape == (*nH, *nL1, *nL2, *npsi0, nEs, ntsave)
+        assert result.expects.shape == (*nH, *nL1, *nL2, *npsi0, nE, ntsave)
     else:
         assert result.states.shape == (*nH, ntsave, n, n)
-        assert result.expects.shape == (*nH, nEs, ntsave)
+        assert result.expects.shape == (*nH, nE, ntsave)

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -6,82 +6,32 @@ import dynamiqs as dq
 
 
 @pytest.mark.parametrize('cartesian_batching', [True, False])
-def test_batching(cartesian_batching):  # noqa: PLR0915
+@pytest.mark.parametrize('nH', [(), (3,), (3, 4)])
+@pytest.mark.parametrize('npsi0', [(), (5,), (5, 6)])
+@pytest.mark.parametrize('nL1', [(), (7,), (7, 8)])
+@pytest.mark.parametrize('nL2', [(), (9,)])
+def test_batching(cartesian_batching, nH, npsi0, nL1, nL2):
     n = 8
     ntsave = 11
-    nH = 3
-    nL1 = 4 if cartesian_batching else nH
-    nL2 = 5 if cartesian_batching else nH
-    npsi0 = 6 if cartesian_batching else nH
+    nL1 = nL1 if cartesian_batching else nH
+    nL2 = nL2 if cartesian_batching else nH
+    npsi0 = npsi0 if cartesian_batching else nH
     nEs = 7
 
     options = dq.options.Options(cartesian_batching=cartesian_batching)
 
     # create random objects
     k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(42), 5)
-    H = dq.rand_herm(k1, (nH, n, n))
-    Ls = [dq.rand_herm(k2, (nL1, n, n)), dq.rand_herm(k3, (nL2, n, n))]
-    Ls0 = [L[0] for L in Ls]  # not batched L
+    H = dq.rand_herm(k1, (*nH, n, n))
+    Ls = [dq.rand_herm(k2, (*nL1, n, n)), dq.rand_herm(k3, (*nL2, n, n))]
     exp_ops = dq.rand_complex(k4, (nEs, n, n))
-    psi0 = dq.rand_ket(k5, (npsi0, n, 1))
+    psi0 = dq.rand_ket(k5, (*npsi0, n, 1))
     tsave = jnp.linspace(0, 0.01, ntsave)
 
-    # no batching
-    result = dq.mesolve(H[0], Ls0, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (ntsave, n, n)
-    assert result.expects.shape == (nEs, ntsave)
-
-    # H batched
-    result = dq.mesolve(H, Ls0, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (nH, ntsave, n, n)
-    assert result.expects.shape == (nH, nEs, ntsave)
-
-    # Ls batched
-    result = dq.mesolve(H[0], Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    if cartesian_batching:
-        assert result.states.shape == (nL1, nL2, ntsave, n, n)
-        assert result.expects.shape == (nL1, nL2, nEs, ntsave)
-    else:
-        assert result.states.shape == (nH, ntsave, n, n)
-        assert result.expects.shape == (nH, nEs, ntsave)
-
-    # psi0 batched
-    result = dq.mesolve(H[0], Ls0, psi0, tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (npsi0, ntsave, n, n)
-    assert result.expects.shape == (npsi0, nEs, ntsave)
-
-    # H and Ls batched
-    result = dq.mesolve(H, Ls, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    if cartesian_batching:
-        assert result.states.shape == (nH, nL1, nL2, ntsave, n, n)
-        assert result.expects.shape == (nH, nL1, nL2, nEs, ntsave)
-    else:
-        assert result.states.shape == (nH, ntsave, n, n)
-        assert result.expects.shape == (nH, nEs, ntsave)
-
-    # H and psi0 batched
-    result = dq.mesolve(H, Ls0, psi0, tsave, exp_ops=exp_ops, options=options)
-    if cartesian_batching:
-        assert result.states.shape == (nH, npsi0, ntsave, n, n)
-        assert result.expects.shape == (nH, npsi0, nEs, ntsave)
-    else:
-        assert result.states.shape == (nH, ntsave, n, n)
-        assert result.expects.shape == (nH, nEs, ntsave)
-
-    # Ls and psi0 batched
-    result = dq.mesolve(H[0], Ls, psi0, tsave, exp_ops=exp_ops, options=options)
-    if cartesian_batching:
-        assert result.states.shape == (nL1, nL2, npsi0, ntsave, n, n)
-        assert result.expects.shape == (nL1, nL2, npsi0, nEs, ntsave)
-    else:
-        assert result.states.shape == (nH, ntsave, n, n)
-        assert result.expects.shape == (nH, nEs, ntsave)
-
-    # H, Ls and psi0 batched
     result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nH, nL1, nL2, npsi0, ntsave, n, n)
-        assert result.expects.shape == (nH, nL1, nL2, npsi0, nEs, ntsave)
+        assert result.states.shape == (*nH, *nL1, *nL2, *npsi0, ntsave, n, n)
+        assert result.expects.shape == (*nH, *nL1, *nL2, *npsi0, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, ntsave, n, n)
-        assert result.expects.shape == (nH, nEs, ntsave)
+        assert result.states.shape == (*nH, ntsave, n, n)
+        assert result.expects.shape == (*nH, nEs, ntsave)

--- a/tests/sesolve/closed_system.py
+++ b/tests/sesolve/closed_system.py
@@ -111,8 +111,8 @@ class TDQubit(ClosedSystem):
         self.params_default = self.Params(eps, omega)
 
     def H(self, params: PyTree) -> TimeArray:
-        f = lambda t, eps, omega: eps * jnp.cos(omega * t) * dq.sigmax()
-        return dq.timecallable(f, args=(params.eps, params.omega))
+        f = lambda t: params.eps * jnp.cos(params.omega * t) * dq.sigmax()
+        return dq.timecallable(f)
 
     def y0(self, params: PyTree) -> Array:  # noqa: ARG002
         return dq.fock(2, 0)

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -68,10 +68,8 @@ def test_timearray_batching():
 
     result = dq.sesolve(H_pwc, psi0, times)
     assert result.states.shape == (3, 11, 4, 1)
-
-    # todo: fixme
-    # result = dq.sesolve(H0 + H_pwc, psi0, times)
-    # assert result.states.shape == (3, 11, 4, 1)
+    result = dq.sesolve(H0 + H_pwc, psi0, times)
+    assert result.states.shape == (3, 11, 4, 1)
 
     # == modulated time array
     deltas = jnp.linspace(0.0, 1.0, 4)
@@ -79,10 +77,8 @@ def test_timearray_batching():
 
     result = dq.sesolve(H_mod, psi0, times)
     assert result.states.shape == (4, 11, 4, 1)
-
-    # todo: fixme
-    # result = dq.sesolve(H0 + H_mod, psi0, times)
-    # assert result.states.shape == (4, 11, 4, 1)
+    result = dq.sesolve(H0 + H_mod, psi0, times)
+    assert result.states.shape == (4, 11, 4, 1)
 
     # == callable time array
     omegas = jnp.linspace(0.0, 1.0, 5)
@@ -90,7 +86,5 @@ def test_timearray_batching():
 
     result = dq.sesolve(H_cal, psi0, times)
     assert result.states.shape == (5, 11, 4, 1)
-
-    # todo: fixme
-    # result = dq.sesolve(H0 + H_cal, psi0, times)
-    # assert result.states.shape == (5, 11, 4, 1)
+    result = dq.sesolve(H0 + H_cal, psi0, times)
+    assert result.states.shape == (5, 11, 4, 1)

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -12,24 +12,24 @@ def test_batching(cartesian_batching, nH, npsi0):
     n = 8
     ntsave = 11
     npsi0 = npsi0 if cartesian_batching else nH
-    nEs = 7
+    nE = 7
 
     options = dq.options.Options(cartesian_batching=cartesian_batching)
 
     # create random objects
     k1, k2, k3 = jax.random.split(jax.random.PRNGKey(42), 3)
     H = dq.rand_herm(k1, (*nH, n, n))
-    exp_ops = dq.rand_complex(k2, (nEs, n, n))
+    exp_ops = dq.rand_complex(k2, (nE, n, n))
     psi0 = dq.rand_ket(k3, (*npsi0, n, 1))
     tsave = jnp.linspace(0, 0.01, ntsave)
 
     result = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
         assert result.states.shape == (*nH, *npsi0, ntsave, n, 1)
-        assert result.expects.shape == (*nH, *npsi0, nEs, ntsave)
+        assert result.expects.shape == (*nH, *npsi0, nE, ntsave)
     else:
         assert result.states.shape == (*nH, ntsave, n, 1)
-        assert result.expects.shape == (*nH, nEs, ntsave)
+        assert result.expects.shape == (*nH, nE, ntsave)
 
 
 def test_timearray_batching():

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -68,25 +68,29 @@ def test_timearray_batching():
 
     result = dq.sesolve(H_pwc, psi0, times)
     assert result.states.shape == (3, 11, 4, 1)
-    result = dq.sesolve(H0 + H_pwc, psi0, times)
-    assert result.states.shape == (3, 11, 4, 1)
+
+    # todo: fixme
+    # result = dq.sesolve(H0 + H_pwc, psi0, times)
+    # assert result.states.shape == (3, 11, 4, 1)
 
     # == modulated time array
     deltas = jnp.linspace(0.0, 1.0, 4)
-    H_mod = dq.modulated(lambda t, delta: jnp.cos(t * delta), H0, args=(deltas,))
+    H_mod = dq.modulated(lambda t: jnp.cos(t * deltas), H0)
 
     result = dq.sesolve(H_mod, psi0, times)
     assert result.states.shape == (4, 11, 4, 1)
-    result = dq.sesolve(H0 + H_mod, psi0, times)
-    assert result.states.shape == (4, 11, 4, 1)
+
+    # todo: fixme
+    # result = dq.sesolve(H0 + H_mod, psi0, times)
+    # assert result.states.shape == (4, 11, 4, 1)
 
     # == callable time array
     omegas = jnp.linspace(0.0, 1.0, 5)
-    H_cal = dq.timecallable(
-        lambda t, omega: jnp.cos(t * omega[..., None, None]) * H0, args=(omegas,)
-    )
+    H_cal = dq.timecallable(lambda t: jnp.cos(t * omegas[..., None, None]) * H0)
 
     result = dq.sesolve(H_cal, psi0, times)
     assert result.states.shape == (5, 11, 4, 1)
-    result = dq.sesolve(H0 + H_cal, psi0, times)
-    assert result.states.shape == (5, 11, 4, 1)
+
+    # todo: fixme
+    # result = dq.sesolve(H0 + H_cal, psi0, times)
+    # assert result.states.shape == (5, 11, 4, 1)

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -62,8 +62,8 @@ def test_timearray_batching():
 
     result = dq.sesolve(H_mod, psi0, times)
     assert result.states.shape == (4, 11, 4, 1)
-    # result = dq.sesolve(H0 + H_mod, psi0, times)
-    # assert result.states.shape == (4, 11, 4, 1)
+    result = dq.sesolve(H0 + H_mod, psi0, times)
+    assert result.states.shape == (4, 11, 4, 1)
 
     # == callable time array
     omegas = jnp.linspace(0.0, 1.0, 5)

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -62,8 +62,8 @@ def test_timearray_batching():
 
     result = dq.sesolve(H_mod, psi0, times)
     assert result.states.shape == (4, 11, 4, 1)
-    result = dq.sesolve(H0 + H_mod, psi0, times)
-    assert result.states.shape == (4, 11, 4, 1)
+    # result = dq.sesolve(H0 + H_mod, psi0, times)
+    # assert result.states.shape == (4, 11, 4, 1)
 
     # == callable time array
     omegas = jnp.linspace(0.0, 1.0, 5)

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -6,45 +6,30 @@ import dynamiqs as dq
 
 
 @pytest.mark.parametrize('cartesian_batching', [True, False])
-def test_batching(cartesian_batching):
+@pytest.mark.parametrize('nH', [(), (3,), (3, 4)])
+@pytest.mark.parametrize('npsi0', [(), (5,), (5, 6)])
+def test_batching(cartesian_batching, nH, npsi0):
     n = 8
     ntsave = 11
-    nH = 3
-    npsi0 = 4 if cartesian_batching else nH
-    nEs = 5
+    npsi0 = npsi0 if cartesian_batching else nH
+    nEs = 7
 
     options = dq.options.Options(cartesian_batching=cartesian_batching)
 
     # create random objects
     k1, k2, k3 = jax.random.split(jax.random.PRNGKey(42), 3)
-    H = dq.rand_herm(k1, (nH, n, n))
+    H = dq.rand_herm(k1, (*nH, n, n))
     exp_ops = dq.rand_complex(k2, (nEs, n, n))
-    psi0 = dq.rand_ket(k3, (npsi0, n, 1))
+    psi0 = dq.rand_ket(k3, (*npsi0, n, 1))
     tsave = jnp.linspace(0, 0.01, ntsave)
 
-    # no batching
-    result = dq.sesolve(H[0], psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (ntsave, n, 1)
-    assert result.expects.shape == (nEs, ntsave)
-
-    # H batched
-    result = dq.sesolve(H, psi0[0], tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (nH, ntsave, n, 1)
-    assert result.expects.shape == (nH, nEs, ntsave)
-
-    # psi0 batched
-    result = dq.sesolve(H[0], psi0, tsave, exp_ops=exp_ops, options=options)
-    assert result.states.shape == (npsi0, ntsave, n, 1)
-    assert result.expects.shape == (npsi0, nEs, ntsave)
-
-    # H and psi0 batched
     result = dq.sesolve(H, psi0, tsave, exp_ops=exp_ops, options=options)
     if cartesian_batching:
-        assert result.states.shape == (nH, npsi0, ntsave, n, 1)
-        assert result.expects.shape == (nH, npsi0, nEs, ntsave)
+        assert result.states.shape == (*nH, *npsi0, ntsave, n, 1)
+        assert result.expects.shape == (*nH, *npsi0, nEs, ntsave)
     else:
-        assert result.states.shape == (nH, ntsave, n, 1)
-        assert result.expects.shape == (nH, nEs, ntsave)
+        assert result.states.shape == (*nH, ntsave, n, 1)
+        assert result.expects.shape == (*nH, nEs, ntsave)
 
 
 def test_timearray_batching():

--- a/tests/solver_tester.py
+++ b/tests/solver_tester.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 
 from dynamiqs.gradient import Gradient
 from dynamiqs.options import Options
@@ -57,11 +58,9 @@ class SolverTester:
         def assert_allclose(pytree1, pytree2):
             # assert two pytrees are equal
             f = partial(jnp.allclose, rtol=rtol, atol=atol)
-            allclose_tree = jax.tree_util.tree_map(f, pytree1, pytree2)
+            allclose_tree = jtu.tree_map(f, pytree1, pytree2)
             # reduce the tree to a single boolean value
-            all_true = jax.tree_util.tree_reduce(
-                lambda x, y: x and y, allclose_tree, True
-            )
+            all_true = jtu.tree_reduce(lambda x, y: x and y, allclose_tree, True)
             assert all_true, f'Pytrees are not close enough: \n{pytree1}\n{pytree2}'
 
         # === test gradients depending on final ysave

--- a/tests/test_time_array.py
+++ b/tests/test_time_array.py
@@ -7,7 +7,6 @@ import pytest
 from dynamiqs.time_array import (
     ConstantTimeArray,
     SummedTimeArray,
-    constant,
     modulated,
     pwc,
     timecallable,
@@ -21,7 +20,7 @@ def assert_equal(x, y):
 class TestConstantTimeArray:
     @pytest.fixture(autouse=True)
     def _setup(self):
-        self.x = constant(jnp.array([1, 2]))
+        self.x = ConstantTimeArray(jnp.array([1, 2]))
 
     @pytest.mark.skip('broken test')
     def test_jit(self):
@@ -38,7 +37,7 @@ class TestConstantTimeArray:
         assert_equal(x(0.0), [[1, 2]])
 
     def test_conj(self):
-        x = constant(jnp.array([1 + 1j, 2 + 2j]))
+        x = ConstantTimeArray(jnp.array([1 + 1j, 2 + 2j]))
         x = x.conj()
         assert_equal(x(0.0), [1 - 1j, 2 - 2j])
 

--- a/tests/test_time_array.py
+++ b/tests/test_time_array.py
@@ -7,9 +7,10 @@ import pytest
 from dynamiqs.time_array import (
     CallableTimeArray,
     ConstantTimeArray,
-    ModulatedTimeArray,
     PWCTimeArray,
     SummedTimeArray,
+    modulated,
+    timecallable,
 )
 
 
@@ -75,7 +76,7 @@ class TestCallableTimeArray:
     @pytest.fixture(autouse=True)
     def _setup(self):
         f = lambda t: t * jnp.array([1, 2])
-        self.x = CallableTimeArray(f, ())
+        self.x = timecallable(f)
 
     @pytest.mark.skip('broken test')
     def test_jit(self):
@@ -98,7 +99,7 @@ class TestCallableTimeArray:
 
     def test_conj(self):
         f = lambda t: t * jnp.array([1 + 1j, 2 + 2j])
-        x = CallableTimeArray(f, ())
+        x = CallableTimeArray(f)
         x = x.conj()
         assert_equal(x(1.0), [1 - 1j, 2 - 2j])
 
@@ -242,7 +243,7 @@ class TestModulatedTimeArray:
         eps = lambda t: (0.5 * t + 1.0j) * one
         array = jnp.array([[1, 2], [3, 4]])
 
-        self.x = ModulatedTimeArray(eps, array, ())
+        self.x = modulated(eps, array)
 
     def test_call(self):
         assert_equal(self.x(0.0), [[1.0j, 2.0j], [3.0j, 4.0j]])

--- a/tests/test_time_array.py
+++ b/tests/test_time_array.py
@@ -5,11 +5,11 @@ import jax.numpy as jnp
 import pytest
 
 from dynamiqs.time_array import (
-    CallableTimeArray,
     ConstantTimeArray,
-    PWCTimeArray,
     SummedTimeArray,
+    constant,
     modulated,
+    pwc,
     timecallable,
 )
 
@@ -21,7 +21,7 @@ def assert_equal(x, y):
 class TestConstantTimeArray:
     @pytest.fixture(autouse=True)
     def _setup(self):
-        self.x = ConstantTimeArray(jnp.array([1, 2]))
+        self.x = constant(jnp.array([1, 2]))
 
     @pytest.mark.skip('broken test')
     def test_jit(self):
@@ -38,7 +38,7 @@ class TestConstantTimeArray:
         assert_equal(x(0.0), [[1, 2]])
 
     def test_conj(self):
-        x = ConstantTimeArray(jnp.array([1 + 1j, 2 + 2j]))
+        x = constant(jnp.array([1 + 1j, 2 + 2j]))
         x = x.conj()
         assert_equal(x(0.0), [1 - 1j, 2 - 2j])
 
@@ -99,7 +99,7 @@ class TestCallableTimeArray:
 
     def test_conj(self):
         f = lambda t: t * jnp.array([1 + 1j, 2 + 2j])
-        x = CallableTimeArray(f)
+        x = timecallable(f)
         x = x.conj()
         assert_equal(x(1.0), [1 - 1j, 2 - 2j])
 
@@ -160,7 +160,7 @@ class TestPWCTimeArray:
         values = jnp.array([1, 10, 100])
         array = jnp.array([[1, 2], [3, 4]])
 
-        self.x = PWCTimeArray(times, values, array)  # shape at t: (2, 2)
+        self.x = pwc(times, values, array)  # shape at t: (2, 2)
 
     @pytest.mark.skip('broken test')
     def test_jit(self):


### PR DESCRIPTION
This PR:
i) removes the `args` from `TimeArray`s
ii) allows for vmapping on time arrays
iii) allows for vmapping on ND time arrays

Note that support for batched times in pwc time arrays is not far, but I keep it for a next PR

Closes #547.

Related to DYN-197.