### PR TITLE
Document new ND batching feature and new time-array API

### DIFF
--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -213,7 +213,6 @@ Array([[1., 0.],
 ```
 
 !!! Warning "The function `f` must return a JAX array (not an array-like object!)"
-    An error is raised if the function `f` does not return a JAX array. This error includes other array-like objects. This is enforced to avoid costly conversions at every time step of the numerical integration.
 
 ??? Note "Function with additional arguments"
     To define a callable time-array with additional arguments, you can use the optional `args` parameter of [`dq.timecallable()`][dynamiqs.timecallable]:
@@ -221,6 +220,7 @@ Array([[1., 0.],
     x = 1.0
     f = lambda t: x * jnp.array([[t, 0], [0, 1 - t]])
     H = dq.timecallable(f)
+    An error is raised if the function `f` does not return a JAX array. This error concerns any other array-like objects. This is enforced to avoid costly conversions at every time step of the numerical integration.
     ```
 
 ## Batching and differentiation with time-arrays

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -145,7 +145,7 @@ where $f(t)$ is an time-dependent scalar.
 
 In dynamiqs, modulated operators are defined by:
 
-- `f`: a Python function with signature `f(t: float, *args: PyTree) -> Array` that returns the modulating factor $f(t)$ for any time $t$, as an array of shape _(...)_,
+- `f`: a Python function with signature `f(t: float) -> Array` that returns the modulating factor $f(t)$ for any time $t$, as an array of shape _(...)_,
 - `array`: the array defining the constant operator $O_0$, of shape _(n, n)_.
 
 To construct a modulated operator, pass these two arguments to the [`dq.modulated()`][dynamiqs.modulated] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object. This object then returns an array with shape _(..., n, n)_ when called at any time $t$.
@@ -188,7 +188,7 @@ where $f(t)$ is a time-dependent operator.
 
 In dynamiqs, arbitrary time-dependent operators are defined by:
 
-- `f`: a Python function with signature `f(t: float, *args: PyTree) -> Array` that returns the operator $f(t)$ for any time $t$, as an array of shape _(..., n, n)_.
+- `f`: a Python function with signature `f(t: float) -> Array` that returns the operator $f(t)$ for any time $t$, as an array of shape _(..., n, n)_.
 
 To construct an arbitrary time-dependent operator, pass this argument to the [`dq.timecallable()`][dynamiqs.timecallable] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object. This object then returns an array with shape _(..., n, n)_ when called at any time $t$.
 

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -96,7 +96,7 @@ In dynamiqs, PWC operators are defined by three array-like objects:
 - `values`: the constant values $(c_0, \ldots, c_{N-1})$ for each time interval, of shape _(..., N)_,
 - `array`: the array defining the constant operator $O_0$, of shape _(n, n)_.
 
-To construct a PWC operator, pass these three arguments to the [`dq.pwc()`][dynamiqs.pwc] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object.
+To construct a PWC operator, pass these three arguments to the [`dq.pwc()`][dynamiqs.pwc] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object. This object then returns an array with shape _(..., n, n)_ when called at any time $t$.
 
 !!! Notes
     The argument `times` must be sorted in ascending order, but does not need to be evenly spaced. When calling the resulting time-array object at time $t$, the returned array is the operator $c_k\ O_0$ corresponding to the interval $[t_k, t_{k+1}[$ in which the time $t$ falls. If $t$ does not belong to any time intervals, the returned array is null.
@@ -148,7 +148,7 @@ In dynamiqs, modulated operators are defined by:
 - `f`: a Python function with signature `f(t: float, *args: PyTree) -> Array` that returns the modulating factor $f(t)$ for any time $t$, as an array of shape _(...)_,
 - `array`: the array defining the constant operator $O_0$, of shape _(n, n)_.
 
-To construct a modulated operator, pass these two arguments to the [`dq.modulated()`][dynamiqs.modulated] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object.
+To construct a modulated operator, pass these two arguments to the [`dq.modulated()`][dynamiqs.modulated] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object. This object then returns an array with shape _(..., n, n)_ when called at any time $t$.
 
 Let's define the modulated operator $H=\cos(2\pi t)\sigma_x$:
 ```python
@@ -190,7 +190,7 @@ In dynamiqs, arbitrary time-dependent operators are defined by:
 
 - `f`: a Python function with signature `f(t: float, *args: PyTree) -> Array` that returns the operator $f(t)$ for any time $t$, as an array of shape _(..., n, n)_.
 
-To construct an arbitrary time-dependent operator, pass this argument to the [`dq.timecallable()`][dynamiqs.timecallable] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object.
+To construct an arbitrary time-dependent operator, pass this argument to the [`dq.timecallable()`][dynamiqs.timecallable] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object. This object then returns an array with shape _(..., n, n)_ when called at any time $t$.
 
 Let's define the arbitrary time-dependent operator $H=\begin{pmatrix}t & 0\\0 & 1 - t\end{pmatrix}$:
 ```pycon

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -199,7 +199,7 @@ Array([[0.+0.j, 1.+0.j],
     >>> def pulse(t, omega, amplitude=1.0):
     ...     return amplitude * jnp.cos(omega * t)
     >>> # create function with correct signature (t: float) -> Array
-    >>> f = functools.partial(pulse, 1.0, amplitude=5.0)
+    >>> f = functools.partial(pulse, omega=1.0, amplitude=5.0)
     >>> H = dq.modulated(f, dq.sigmax())
     ```
 
@@ -257,6 +257,6 @@ Array([[1., 0.],
     >>> def func(t, a, amplitude=1.0):
     ...     return amplitude * jnp.array([[t, a], [a, 1 - t]])
     >>> # create function with correct signature (t: float) -> Array
-    >>> f = functools.partial(func, 1.0, amplitude=5.0)
+    >>> f = functools.partial(func, a=1.0, amplitude=5.0)
     >>> H = dq.timecallable(f)
     ```

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -135,6 +135,18 @@ Array([[ 0.+0.j,  0.+0.j],
        [ 0.+0.j, -0.+0.j]], dtype=complex64)
 ```
 
+??? Notes "Batching"
+    The batching of the returned time-array is specified by `values`. For example, to define a PWC operator batched over a parameter $\theta$:
+    ```pycon
+    >>> thetas = jnp.linspace(0, 1.0, 11)  # (11,)
+    >>> times = jnp.array([0.0, 1.0, 2.0])
+    >>> values = thetas[:, None] * jnp.array([3.0, -2.0])  # (11, 2)
+    >>> array = dq.sigmaz()
+    >>> H = dq.pwc(times, values, array)
+    >>> H.shape
+    (11, 2, 2)
+    ```
+
 ### Modulated operators
 
 A modulated operator is defined by
@@ -170,12 +182,14 @@ Array([[0.+0.j, 1.+0.j],
        [1.+0.j, 0.+0.j]], dtype=complex64)
 ```
 
-??? Note "Function with additional arguments"
-    To define a modulated time-array with additional arguments, you can use the optional `args` parameter of [`dq.modulated()`][dynamiqs.modulated]:
-    ```python
-    f = lambda t: jnp.cos(omegas * t)
-    omega = 1.0
-    H = dq.modulated(f, dq.sigmax())
+??? Notes "Batching"
+    The batching of the returned time-array is specified by the array returned by `f`. For example, to define a modulated Hamiltonian $H=\cos(\omega t)\sigma_x$ batched over the parameter $\omega$:
+    ```pycon
+    >>> omegas = jnp.linspace(0.0, 1.0, 11)  # (11,)
+    >>> f = lambda t: jnp.cos(omegas * t)
+    >>> H = dq.modulated(f, dq.sigmax())
+    >>> H.shape
+    (11, 2, 2)
     ```
 
 ### Arbitrary time-dependent operators
@@ -213,23 +227,14 @@ Array([[1., 0.],
 ```
 
 !!! Warning "The function `f` must return a JAX array (not an array-like object!)"
-
-??? Note "Function with additional arguments"
-    To define a callable time-array with additional arguments, you can use the optional `args` parameter of [`dq.timecallable()`][dynamiqs.timecallable]:
-    ```python
-    x = 1.0
-    f = lambda t: x * jnp.array([[t, 0], [0, 1 - t]])
-    H = dq.timecallable(f)
     An error is raised if the function `f` does not return a JAX array. This error concerns any other array-like objects. This is enforced to avoid costly conversions at every time step of the numerical integration.
+
+??? Notes "Batching"
+    The batching of the returned time-array is specified by the array returned by `f`. For example, to define am arbitrary time-dependent operator batched over a parameter $\theta$:
+    ```pycon
+    >>> thetas = jnp.linspace(0, 1.0, 11)  # (11,)
+    >>> f = lambda t: thetas[:, None, None] * jnp.array([[t, 0], [0, 1 - t]])
+    >>> H = dq.timecallable(f)
+    >>> H.shape
+    (11, 2, 2)
     ```
-
-## Batching and differentiation with time-arrays
-
-For modulated and arbitrary time-dependent operators, any array that is batched or differentiated over should be passed as an additional `*args` argument to [`dq.modulated()`][dynamiqs.modulated] and [`dq.timecallable()`][dynamiqs.timecallable].
-
-For example to define a modulated Hamiltonian $H=\cos(\omega t)\sigma_x$ batched or differentiated over the parameter $\omega$:
-```python
-omegas = jnp.linspace(0.0, 2.0, 10)
-f = lambda t: jnp.cos(omegas * t)
-H = dq.modulated(f, dq.sigmax())
-```

--- a/docs/tutorials/time-dependent-operators.md
+++ b/docs/tutorials/time-dependent-operators.md
@@ -192,6 +192,17 @@ Array([[0.+0.j, 1.+0.j],
     (11, 2, 2)
     ```
 
+??? Notes "Function with additional arguments"
+    To define a modulated operator with a function that takes arguments other than time (extra `*args` and `**kwargs`), you can use [`functools.partial()`](https://docs.python.org/3/library/functools.html#functools.partial). For example:
+    ```pycon
+    >>> import functools
+    >>> def pulse(t, omega, amplitude=1.0):
+    ...     return amplitude * jnp.cos(omega * t)
+    >>> # create function with correct signature (t: float) -> Array
+    >>> f = functools.partial(pulse, 1.0, amplitude=5.0)
+    >>> H = dq.modulated(f, dq.sigmax())
+    ```
+
 ### Arbitrary time-dependent operators
 
 An arbitrary time-dependent operator is defined by
@@ -230,11 +241,22 @@ Array([[1., 0.],
     An error is raised if the function `f` does not return a JAX array. This error concerns any other array-like objects. This is enforced to avoid costly conversions at every time step of the numerical integration.
 
 ??? Notes "Batching"
-    The batching of the returned time-array is specified by the array returned by `f`. For example, to define am arbitrary time-dependent operator batched over a parameter $\theta$:
+    The batching of the returned time-array is specified by the array returned by `f`. For example, to define an arbitrary time-dependent operator batched over a parameter $\theta$:
     ```pycon
     >>> thetas = jnp.linspace(0, 1.0, 11)  # (11,)
     >>> f = lambda t: thetas[:, None, None] * jnp.array([[t, 0], [0, 1 - t]])
     >>> H = dq.timecallable(f)
     >>> H.shape
     (11, 2, 2)
+    ```
+
+??? Notes "Function with additional arguments"
+    To define an arbitrary time-dependent operator with a function that takes arguments other than time (extra `*args` and `**kwargs`), you can use [`functools.partial()`](https://docs.python.org/3/library/functools.html#functools.partial). For example:
+    ```pycon
+    >>> import functools
+    >>> def func(t, a, amplitude=1.0):
+    ...     return amplitude * jnp.array([[t, a], [a, 1 - t]])
+    >>> # create function with correct signature (t: float) -> Array
+    >>> f = functools.partial(func, 1.0, amplitude=5.0)
+    >>> H = dq.timecallable(f)
     ```

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -66,14 +66,14 @@ def mesolve(
         more details.
 
     Args:
-        H _(array-like or time-array of shape (nH?, n, n))_: Hamiltonian.
-        jump_ops _(list of array-like or time-array, of shape (nL, n, n))_: List of
-            jump operators.
-        rho0 _(array-like of shape (nrho0?, n, 1) or (nrho0?, n, n))_: Initial state.
+        H _(array-like or time-array of shape (...H, n, n))_: Hamiltonian.
+        jump_ops _(list of nL array-like or time-array, each of shape (...Lk, n, n))_:
+            List of jump operators.
+        rho0 _(array-like of shape (...rho0, n, 1) or (...rho0, n, n))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
-        exp_ops _(list of array-like, of shape (nE, n, n), optional)_: List of
+        exp_ops _(list of nE array-like, each of shape (n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration. Defaults to
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:
@@ -182,11 +182,11 @@ def _check_mesolve_args(
     H: TimeArray, jump_ops: list[TimeArray], rho0: Array, exp_ops: Array | None
 ):
     # === check H shape
-    check_shape(H, 'H', '(..., n, n)')
+    check_shape(H, 'H', '(..., n, n)', subs={'...': '...H'})
 
-    # === check jump_ops
+    # === check jump_ops shape
     for i, L in enumerate(jump_ops):
-        check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
+        check_shape(L, f'jump_ops[{i}]', '(..., n, n)', subs={'...': f'...L{i}'})
 
     if len(jump_ops) == 0:
         logging.warning(
@@ -195,7 +195,7 @@ def _check_mesolve_args(
         )
 
     # === check rho0 shape
-    check_shape(rho0, 'rho0', '(..., n, 1)', '(..., n, n)', subs={'...': '...nrho0'})
+    check_shape(rho0, 'rho0', '(..., n, 1)', '(..., n, n)', subs={'...': '...rho0'})
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -67,13 +67,13 @@ def mesolve(
 
     Args:
         H _(array-like or time-array of shape (...H, n, n))_: Hamiltonian.
-        jump_ops _(list of nL array-like or time-array, each of shape (...Lk, n, n))_:
+        jump_ops _(list of array-like or time-array, each of shape (...Lk, n, n))_:
             List of jump operators.
         rho0 _(array-like of shape (...rho0, n, 1) or (...rho0, n, n))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
-        exp_ops _(list of nE array-like, each of shape (n, n), optional)_: List of
+        exp_ops _(list of array-like, each of shape (n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration. Defaults to
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -93,8 +93,8 @@ class SEResult(Result):
 
     Attributes:
         states _(array of shape (..., ntsave, n, 1))_: Saved states.
-        expects _(array of shape (..., nE, ntsave) or None)_: Saved expectation values,
-            if specified by `exp_ops`.
+        expects _(array of shape (..., len(exp_ops), ntsave) or None)_: Saved
+            expectation values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options`.
         infos _(PyTree or None)_: Solver-dependent information on the resolution.
@@ -140,8 +140,8 @@ class MEResult(Result):
 
     Attributes:
         states _(array of shape (..., ntsave, n, n))_: Saved states.
-        expects _(array of shape (..., nE, ntsave) or None)_: Saved expectation values,
-            if specified by `exp_ops`.
+        expects _(array of shape (..., len(exp_ops), ntsave) or None)_: Saved
+            expectation values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options`.
         infos _(PyTree or None)_: Solver-dependent information on the resolution.

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -89,12 +89,12 @@ class Result(eqx.Module):
 
 
 class SEResult(Result):
-    """Result of the Schrödinger equation integration.
+    r"""Result of the Schrödinger equation integration.
 
     Attributes:
-        states _(array of shape (nH?, npsi0?, ntsave, n, 1))_: Saved states.
-        expects _(array of shape (nH?, npsi0?, nE, ntsave) or None)_: Saved expectation
-            values, if specified by `exp_ops`.
+        states _(array of shape (..., ntsave, n, 1))_: Saved states.
+        expects _(array of shape (..., nE, ntsave) or None)_: Saved expectation values,
+            if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options`.
         infos _(PyTree or None)_: Solver-dependent information on the resolution.
@@ -102,6 +102,36 @@ class SEResult(Result):
         solver _(Solver)_: Solver used.
         gradient _(Gradient)_: Gradient used.
         options _(Options)_: Options used.
+
+    Notes-: Result of running multiple simulations concurrently
+        The resulting states and expectation values are batched according to the
+        leading dimensions of the Hamiltonian `H` and initial state `psi0` :
+
+        - If the option `cartesian_batching = True` (default value), the results
+          leading dimensions are
+          ```
+          ... = ...H, ...psi0
+          ```
+          For example if:
+
+            - `H` has shape _(2, 3, n, n)_,
+            - `psi0` has shape _(4, n, 1)_,
+
+            then `states` has shape _(2, 3, 4, ntsave, n, 1)_.
+
+        - If the option `cartesian_batching = False`, the results leading dimensions are
+          ```
+          ... = ...H = ...psi0  # (once broadcasted)
+          ```
+          For example if:
+
+            - `H` has shape _(2, 3, n, n)_,
+            - `psi0` has shape _(3, n, 1)_,
+
+            then `states` has shape _(2, 3, ntsave, n, 1)_.
+
+        See the [Batching simulations](../../tutorials/batching-simulations.md)
+        tutorial for more details.
     """
 
 
@@ -109,9 +139,9 @@ class MEResult(Result):
     """Result of the Lindblad master equation integration.
 
     Attributes:
-        states _(array of shape (nH?, nrho0?, ntsave, n, n))_: Saved states.
-        expects _(array of shape (nH?, nrho0?, nE, ntsave) or None)_: Saved expectation
-            values, if specified by `exp_ops`.
+        states _(array of shape (..., ntsave, n, n))_: Saved states.
+        expects _(array of shape (..., nE, ntsave) or None)_: Saved expectation values,
+            if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options`.
         infos _(PyTree or None)_: Solver-dependent information on the resolution.
@@ -119,4 +149,37 @@ class MEResult(Result):
         solver _(Solver)_: Solver used.
         gradient _(Gradient)_: Gradient used.
         options _(Options)_: Options used.
+
+    Notes-: Result of running multiple simulations concurrently
+        The resulting states and expectation values are batched according to the
+        leading dimensions of the Hamiltonian `H`, jump operators `jump_ops` and initial
+        state `rho0`:
+
+        - If the option `cartesian_batching = True` (default value), the results leading
+          dimensions are
+          ```
+          ... = ...H, ...L0, ...L1, (...), ...rho0
+          ```
+          For example if:
+
+            - `H` has shape _(2, 3, n, n)_,
+            - `jump_ops = [L0, L1]` has shape _[(4, 5, n, n), (6, n, n)]_,
+            - `rho0` has shape _(7, n, n)_,
+
+            then `states` has shape _(2, 3, 4, 5, 6, 7, ntsave, n, n)_.
+
+        - If the option `cartesian_batching = False`, the results leading dimensions are
+          ```
+          ... = ...H = ...L0 = ...L1 = (...) = ...rho0  # (once broadcasted)
+          ```
+          For example if:
+
+            - `H` has shape _(2, 3, n, n)_,
+            - `jump_ops = [L0, L1]` has shape _[(3, n, n), (2, 1, n, n)]_,
+            - `rho0` has shape _(3, n, n)_,
+
+            then `states` has shape _(2, 3, ntsave, n, n)_.
+
+        See the [Batching simulations](../../tutorials/batching-simulations.md)
+        tutorial for more details.
     """

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -57,12 +57,12 @@ def sesolve(
         more details.
 
     Args:
-        H _(array-like or time-array of shape (nH?, n, n))_: Hamiltonian.
-        psi0 _(array-like of shape (npsi0?, n, 1))_: Initial state.
+        H _(array-like or time-array of shape (...H, n, n))_: Hamiltonian.
+        psi0 _(array-like of shape (...psi0, n, 1))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
-        exp_ops _(list of array-like, of shape (nE, n, n), optional)_: List of
+        exp_ops _(list of nE array-like, each of shape (n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration. Defaults to
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:
@@ -156,8 +156,10 @@ def _sesolve(
 
 def _check_sesolve_args(H: TimeArray, psi0: Array, exp_ops: Array | None):
     # === check H shape
-    check_shape(H, 'H', '(..., n, n)')
-    check_shape(psi0, 'psi0', '(..., n, 1)', subs={'...': '...npsi0?'})
+    check_shape(H, 'H', '(..., n, n)', subs={'...': '...H'})
+
+    # === check psi0 shape
+    check_shape(psi0, 'psi0', '(..., n, 1)', subs={'...': '...psi0'})
 
     # === check exp_ops shape
     if exp_ops is not None:

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -62,7 +62,7 @@ def sesolve(
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
-        exp_ops _(list of nE array-like, each of shape (n, n), optional)_: List of
+        exp_ops _(list of array-like, each of shape (n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration. Defaults to
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -133,6 +133,11 @@ def timecallable(f: callable[[float], Array]) -> CallableTimeArray:
     with signature `f(t: float) -> Array` that returns an array of shape
     _(..., n, n)_ for any time $t$.
 
+    Warning: The function `f` must return a JAX array (not an array-like object!)
+        An error is raised if the function `f` does not return a JAX array. This error
+        concerns any other array-like objects. This is enforced to avoid costly
+        conversions at every time step of the numerical integration.
+
     Args:
         f _(function returning array of shape (..., n, n))_: Function with signature
             `(t: float) -> Array` that returns the array $f(t)$.

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -28,7 +28,8 @@ def constant(array: ArrayLike) -> ConstantTimeArray:
         array _(array_like of shape (..., n, n))_: Constant array $O_0$.
 
     Returns:
-        _(time-array object)_ Callable object returning $O_0$ for any time $t$.
+        _(time-array object of shape (..., n, n) when called)_ Callable object
+            returning $O_0$ for any time $t$.
     """
     array = jnp.asarray(array, dtype=cdtype())
     check_shape(array, 'array', '(..., n, n)')
@@ -62,7 +63,8 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
         array _(array_like of shape (n, n))_: Constant array $O_0$.
 
     Returns:
-        _(time-array object)_ Callable object returning $O(t)$ for any time $t$.
+        _(time-array object of shape (..., n, n) when called)_ Callable object
+            returning $O(t)$ for any time $t$.
     """
     # times
     times = jnp.asarray(times)
@@ -103,7 +105,8 @@ def modulated(f: callable[[float], Array], array: ArrayLike) -> CallableTimeArra
         array _(array_like of shape (n, n))_: Constant array $O_0$.
 
     Returns:
-        _(time-array object)_ Callable object returning $O(t)$ for any time $t$.
+        _(time-array object of shape (..., n, n) when called)_ Callable object
+            returning $O(t)$ for any time $t$.
     """
     # check f is callable
     if not callable(f):
@@ -135,7 +138,8 @@ def timecallable(f: callable[[float], Array]) -> CallableTimeArray:
             `(t: float) -> Array` that returns the array $f(t)$.
 
     Returns:
-        _(time-array object)_ Callable object returning $O(t)$ for any time $t$.
+        _(time-array object of shape (..., n, n) when called)_ Callable object
+            returning $O(t)$ for any time $t$.
     """
     # check f is callable
     if not callable(f):


### PR DESCRIPTION
Closes DYN-73 and DYN-197.

On top of #552. I recommend reading commit by commit.

Here are a few screenshots of the main bits for convenience:

**MEResult documentation**

The note is folded by default.
![Screenshot 2024-04-24 at 14 46 08](https://github.com/dynamiqs/dynamiqs/assets/38159029/48fc7885-5ded-472d-afe1-714461dd174f)

**Time-dependent operators documentation**
The note is folded by default.
![Screenshot 2024-04-24 at 14 47 07](https://github.com/dynamiqs/dynamiqs/assets/38159029/ebc652a4-d452-4703-8ddb-92dad664f7b3)

I propose to revamp the "Batching simulations" tutorial in another PR (there's a bit of work, we need to explain cartesian vs non-cartesian batching, nd batching and broadcasting) > https://linear.app/dynamiqs/issue/DYN-206/rework-batching-simulations-tutorial.