### PR TITLE
Implement caching for ConstantTimeArrays

### DIFF
--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -16,7 +16,8 @@ class SEDiffraxSolver(DiffraxSolver, SESolver):
     @property
     def terms(self) -> dx.AbstractTerm:
         # define Schrödinger term d|psi>/dt = - i H |psi>
-        vector_field = lambda t, y, _: -1j * self.H(t) @ y
+        Hnh = -1j * self.H
+        vector_field = lambda t, y, _: Hnh(t) @ y
         return dx.ODETerm(vector_field)
 
 


### PR DESCRIPTION
Add straightforward caching by separating static and time-dependent parts in `vector_field`.

However, I ran benchmarks on which I was expecting speedup, and I'm not seeing any (no speedup nor slowdown). Do you think this optimization is already taken care of by the compiler? If yes, should we keep part of this PR still?


<details>
  <summary>Benchmarking code</summary>

 ```python
from __future__ import annotations

from math import ceil
from timeit import Timer
from typing import Literal

import jax
import jax.numpy as jnp
import numpy as np
import qutip as qt

import dynamiqs as dq


def _auto_timeit(fn: callable, max_repeat: int = 7, tmin: float = 0.5, min_repeat: int=7) -> float:
    """Automatically determine the number of iterations and repetitions for timeit."""
    timer = Timer(fn)

    # determiner number of repetitions per run
    n = 1
    t = timer.timeit(number=n)
    while t < tmin:
        n *= 10
        t = timer.timeit(number=n)

    # determine number of runs with some heuristic that makes sure the
    # benchmark is neither too short or too long
    repeat = max(min_repeat, min(max_repeat, ceil(2 * max_repeat * tmin / t)))

    # repeat the benchmark and return the average runtime
    for _ in range(repeat - 1):
        t += timer.timeit(number=n)

    return t / n / repeat



class CatCNOT:

    def __init__(self, *args, **kwargs):
        self.init_qutip(*args, **kwargs)
        with jax.default_matmul_precision('float32'):
            # use float32 instead of tensorfloat32 for initialisation precision on GPU
            self.init_dynamiqs(*args, **kwargs)

    def init_qutip(
        self,
        kappa_2: float = 1.0,
        g_cnot: float = 0.3,
        nbar: float = 4.0,
        num_tsave: int = 100,
        N: int = 16,
    ):
        # time evolution
        alpha = np.sqrt(nbar)
        gate_time = np.pi / (4 * alpha * g_cnot)
        tlist = np.linspace(0.0, gate_time, num_tsave)

        # operators
        ac = qt.tensor(qt.destroy(N), qt.qeye(N))
        nt = qt.tensor(qt.qeye(N), qt.num(N))

        # Hamiltonian
        H = g_cnot * (ac + ac.dag()) * (nt - nbar)

        # collapse operators
        c_ops = [np.sqrt(kappa_2) * (ac**2 - nbar)]

        # initial state
        plus = (qt.coherent(N, alpha) + qt.coherent(N, -alpha)).unit()
        psi0 = qt.tensor(plus, plus)

        self.kwargs_qutip = {'H': H, 'rho0': psi0, 'tlist': tlist, 'c_ops': c_ops}
        self.fn_qutip = qt.mesolve

    def init_dynamiqs(
        self,
        kappa_2: float = 1.0,
        g_cnot: float = 0.3,
        nbar: float = 4.0,
        num_tsave: int = 100,
        N: int = 16,
    ):
        # time evolution
        alpha = jnp.sqrt(nbar)
        gate_time = jnp.pi / (4 * alpha * g_cnot)
        tsave = jnp.linspace(0.0, gate_time, num_tsave)

        # operators
        ac = dq.tensor(dq.destroy(N), dq.eye(N))
        nt = dq.tensor(dq.eye(N), dq.number(N))
        I = dq.tensor(dq.eye(N), dq.eye(N))

        # Hamiltonian
        H = g_cnot * (ac + dq.dag(ac)) @ (nt - nbar * I)

        # jump operator
        jump_ops = [jnp.sqrt(kappa_2) * (ac @ ac - nbar * I)]

        # initial state
        plus = dq.unit(dq.coherent(N, alpha) + dq.coherent(N, -alpha))
        psi0 = dq.tensor(plus, plus)

        self.kwargs_dynamiqs = {
            'H': H,
            'jump_ops': jump_ops,
            'rho0': psi0,
            'tsave': tsave,
        }
        self.fn_dynamiqs = dq.mesolve

    def benchmark(
        self,
        library: Literal['dynamiqs', 'qutip'],
        backend: Literal['cpu', 'gpu'],
        max_repeat: int = 13,
        tmin: float = 0.05,
    ) -> float:
        """Benchmark the model and returns the runtime in seconds."""
        if (library, backend) == ('dynamiqs', 'cpu'):
            dq.set_device('cpu')
            fn = lambda: self.fn_dynamiqs(**self.kwargs_dynamiqs)
        elif (library, backend) == ('dynamiqs', 'gpu'):
            dq.set_device('gpu')
            fn = lambda: self.fn_dynamiqs(**self.kwargs_dynamiqs)
        elif (library, backend) == ('qutip', 'cpu'):
            fn = lambda: self.fn_qutip(**self.kwargs_qutip)
        else:
            raise ValueError(
                f'Invalid combination of library and backend: {library}, {backend}'
            )

        # run once for jit
        if library == 'dynamiqs':
            fn()

        return _auto_timeit(fn, max_repeat=max_repeat, tmin=tmin)


catcnot = CatCNOT(N=12)
timer_qutip_cpu = catcnot.benchmark('qutip', 'cpu')
print(f'Qutip CPU: {timer_qutip_cpu*1e3:.2f} ms')
timer_dynamiqs_cpu = catcnot.benchmark('dynamiqs', 'cpu')
print(f'Dynamiqs CPU: {timer_dynamiqs_cpu*1e3:.2f} ms')
print(f'Speedup: {timer_qutip_cpu / timer_dynamiqs_cpu:.3f}x')
 ```
</details>

Closes DYN-199