### PR TITLE
Faster `sqrtm()` by leveraging broadcasting

### DIFF
--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -908,7 +908,9 @@ def _sqrtm_gpu(x: Array) -> Array:
     w, v = jnp.linalg.eigh(x)
     # we set small negative eigenvalues errors to zero to avoid `nan` propagation
     w = jnp.where(w < 0, 0, w)
-    return v @ jnp.diag(jnp.sqrt(w)) @ v.mT.conj()
+    # numerical trick to compute 'v @ jnp.diag(jnp.sqrt(w)) @ v.mT.conj()' faster with
+    # broadcasting
+    return (v * jnp.sqrt(w)[None, :]) @ v.mT.conj()
 
 
 def entropy_vn(x: ArrayLike) -> Array:


### PR DESCRIPTION
Another @gaspardbb trick, ~x2 on GPU for any size and up to ~150x faster for larger matrices (256 x 256) on CPU. This function is just used in `dq.fidelity` on GPU so this PR won't impact much users, but small performance bits by small performance bits we'll get there 😋

Benchmarking `v @ jnp.diag(jnp.sqrt(w)) @ v.mT.conj()` (first line) vs `(v * jnp.sqrt(w)[None, :]) @ v.mT.conj()` (second line):

**CPU (MacBook Air M1)**:
```
=== n=16
8.42 µs ± 2.01 µs per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
4.12 µs ± 423 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
=== n=128
1.61 ms ± 435 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
9.29 µs ± 2.6 µs per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
=== n=256
3.17 ms ± 778 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
18.1 µs ± 3.82 µs per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

**GPU (NVIDIA L40s)**:
```
=== n=16
74.3 µs ± 3.5 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
53.4 µs ± 787 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
=== n=128
81.4 µs ± 1.25 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
46.3 µs ± 1.12 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
=== n=256
75.6 µs ± 1.32 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
49.3 µs ± 671 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

**Benchmark code**
```python
import jax
import jax.numpy as jnp
import dynamiqs as dq

dq.set_matmul_precision('highest')

key = jax.random.PRNGKey(42)

for n in [16, 128, 256]:
    print(f'=== n={n}')
    x = dq.rand_psd(key, (n, n))
    w, v = jnp.linalg.eigh(x)
    w = jnp.where(w < 0, 0, w)

    @jax.jit
    def _sqrtm_old(x):
        return v @ jnp.diag(jnp.sqrt(w)) @ v.mT.conj()

    @jax.jit
    def _sqrtm_new(x):
        return (v * jnp.sqrt(w)[None, :]) @ v.mT.conj()

    x_sqrt_old = _sqrtm_old(x)
    assert jnp.allclose(x_sqrt_old @ x_sqrt_old, x, rtol=1e-3, atol=1e-3)

    x_sqrt_new = _sqrtm_new(x)
    assert jnp.allclose(x_sqrt_new @ x_sqrt_new, x, rtol=1e-3, atol=1e-3)

    %timeit _sqrtm_old(x).block_until_ready()
    %timeit _sqrtm_new(x).block_until_ready()
```

Compare to qutip to make sure the new formula is correct:
```python
import jax
import qutip as qt
import dynamiqs as dq
key = jax.random.PRNGKey(42)
keys = jax.random.split(key, 11)
for k in keys:
    k1, k2 = jax.random.split(k, 2)
    x = dq.rand_dm(k1, (8, 8))
    y = dq.rand_dm(k2, (8, 8))
    print(dq.fidelity(x, y).item(), qt.fidelity(dq.to_qutip(x), dq.to_qutip(y))**2)
```
```
0.5700632333755493 0.5700634809525873
0.5991155505180359 0.5991152497438762
0.6254615187644958 0.6254616934006589
0.5759567618370056 0.5759558751561538
0.617943525314331 0.617942834186371
0.5125143527984619 0.5125144660946622
0.44697442650794983 0.44697532256992634
0.6714707612991333 0.6714702458315892
0.6821166276931763 0.682116426488231
0.6034935116767883 0.6034933772258411
0.5847893357276917 0.5847897276250698
```