### PR TITLE
Batch dq.fock and dq.coherent over argument number/alpha

### DIFF
--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -15,28 +15,29 @@ __all__ = ['fock', 'fock_dm', 'basis', 'basis_dm', 'coherent', 'coherent_dm']
 
 
 def fock(dim: int, number: ArrayLike) -> Array:
-    r"""Returns the ket of a Fock state or the ket of a tensor product of Fock states.
+    r"""Returns the ket of a Fock state.
 
     Args:
-        dim _(int or tuple of ints)_: Dimension of the Hilbert space of each mode.
-        number _(int or tuple of ints)_: Fock state number of each mode.
+        dim: Dimension of the Hilbert space.
+        number _(array-like of integers of shape (...))_: Fock state number.
 
     Returns:
-        _(array of shape (n, 1))_ Ket of the Fock state or tensor product of Fock
-            states.
+        _(array of shape (..., dim, 1))_ Ket of the Fock state, or array of kets of
+            Fock states if batched.
 
     Examples:
         >>> dq.fock(3, 1)
         Array([[0.+0.j],
                [1.+0.j],
                [0.+0.j]], dtype=complex64)
-        >>> dq.fock((3, 2), (1, 0))
-        Array([[0.+0.j],
-               [0.+0.j],
-               [1.+0.j],
-               [0.+0.j],
-               [0.+0.j],
-               [0.+0.j]], dtype=complex64)
+        >>> dq.fock(3, (1, 0))
+        Array([[[0.+0.j],
+                [1.+0.j],
+                [0.+0.j]],
+        <BLANKLINE>
+               [[1.+0.j],
+                [0.+0.j],
+                [0.+0.j]]], dtype=complex64)
     """
     # check `dim` is an integer
     dim = jnp.asarray(dim)


### PR DESCRIPTION
This PR proposes to change the behavior of `dq.fock` and `dq.coherent` to accept batching over the `number` and `alpha` parameters, respectively. 

Before, we would accept tuple inputs to create multi-mode fock and coherent states. This is no longer the case, in favor of single-mode batching. Contrary to what I was advocating before, I believe this is actually way more useful on a day-to-day basis, and also more natural and compliant with the rest of the library. At least this is what I am seeing from my personal usage of the library.

If you agree with the behavior, I suggest reviewing commit by commit.

Examples:
```python
import dynamiqs as dq
import jax.numpy as jnp

print(dq.fock(3, 1))
# [[0.+0.j]
#  [1.+0.j]
#  [0.+0.j]]

print(dq.fock(3, (1, 0)))
# [[[0.+0.j]
#   [1.+0.j]
#   [0.+0.j]]
# 
#  [[1.+0.j]
#   [0.+0.j]
#   [0.+0.j]]]

alphas = jnp.linspace(0.0, 3.0, 5)
print(dq.coherent(4, alphas).shape)
# (5, 4, 1)

```
