### PR TITLE
Catch `XLARuntimeError` to raise a more friendly exception

### DIFF
--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -12,6 +12,7 @@ from .._checks import check_shape, check_times
 from .._utils import cdtype
 from ..core._utils import (
     _astimearray,
+    catch_xla_runtime_error,
     compute_vmap,
     get_solver_class,
     is_timearray_batched,
@@ -116,6 +117,7 @@ def mesolve(
     return _vmap_mesolve(H, jump_ops, rho0, tsave, exp_ops, solver, gradient, options)
 
 
+@catch_xla_runtime_error
 @partial(jax.jit, static_argnames=('solver', 'gradient', 'options'))
 def _vmap_mesolve(
     H: TimeArray,

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -11,6 +11,7 @@ from .._checks import check_shape, check_times
 from .._utils import cdtype
 from ..core._utils import (
     _astimearray,
+    catch_xla_runtime_error,
     compute_vmap,
     get_solver_class,
     is_timearray_batched,
@@ -100,6 +101,7 @@ def sesolve(
     return _vmap_sesolve(H, psi0, tsave, exp_ops, solver, gradient, options)
 
 
+@catch_xla_runtime_error
 @partial(jax.jit, static_argnames=('solver', 'gradient', 'options'))
 def _vmap_sesolve(
     H: TimeArray,


### PR DESCRIPTION
This only works in non-jitted code, but I think it's a nice to have (especially for beginners) in our wrapping `sesolve/mesolve` functions.

Closes DYN-168.

- Catch `XLARuntimeError` and ask user to submit a ticket -> these are "unexpected" errors.
- Specify where the `max_steps` option can be set.

For `max_steps`:
```diff
- XlaRuntimeError: INTERNAL: Generated function failed: CpuCallback error: EqxRuntimeError: The maximum number of solver steps was reached. Try increasing `max_steps`.
+ RuntimeError: The maximum number of solver steps has been reached (the default value is `max_steps=100_000`). Try increasing `max_steps` with the `solver` argument, e.g. `solver=dq.solver.Tsit5(max_steps=1_000_000)`.
```

And for any other `XlaRuntimeError`:
```
RuntimeError: An internal JAX error interrupted the execution, please report this to the dynamiqs developers by opening an issue on GitHub or sending a message on dynamiqs Slack (links available at https://www.dynamiqs.org/getting_started/lets-talk.html).
```

Note also that this avoids the barbaric `XLARuntimeError` that covers the screen with a long traceback. If scrolling up the user finds back the original exception, which will be nice for us to debug the new ones we may discover.

**Before**
![Screenshot 2024-05-04 at 13 16 42](https://github.com/dynamiqs/dynamiqs/assets/38159029/1fe77663-6234-40e0-8a9c-dd27a8d2c4f3)

**After**
![Screenshot 2024-05-04 at 13 17 42](https://github.com/dynamiqs/dynamiqs/assets/38159029/8c5b976b-fe5d-49c6-a16c-56f10e1ade40)
