### PR TITLE
Reorganize cartesian and flat batching tests

### DIFF
--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -5,60 +5,54 @@ import pytest
 import dynamiqs as dq
 
 
-@pytest.mark.parametrize('cartesian_batching', [True, False])
+def rand_mesolve_args(n, nH, nLs, npsi0, nEs):
+    nkeys = len(nLs) + 3
+    kH, *kLs, kpsi0, kEs = jax.random.split(jax.random.PRNGKey(42), nkeys)
+    H = dq.rand_herm(kH, (*nH, n, n))
+    Ls = [dq.rand_herm(kL, (*nL, n, n)) for kL, nL in zip(kLs, nLs)]
+    psi0 = dq.rand_ket(kpsi0, (*npsi0, n, 1))
+    Es = dq.rand_complex(kEs, (nEs, n, n))
+    return H, Ls, psi0, Es
+
+
 @pytest.mark.parametrize('nH', [(), (3,), (3, 4)])
-@pytest.mark.parametrize('npsi0', [(), (5,), (5, 6)])
-@pytest.mark.parametrize('nL1', [(), (7,), (7, 8)])
+@pytest.mark.parametrize('npsi0', [(), (5,)])
+@pytest.mark.parametrize('nL1', [(), (7, 8)])
 @pytest.mark.parametrize('nL2', [(), (9,)])
-def test_batching(cartesian_batching, nH, npsi0, nL1, nL2):
-    n = 8
-    ntsave = 11
-    nL1 = nL1 if cartesian_batching else nH
-    nL2 = nL2 if cartesian_batching else nH
-    npsi0 = npsi0 if cartesian_batching else nH
-    nE = 7
-
-    options = dq.options.Options(cartesian_batching=cartesian_batching)
-
-    # create random objects
-    k1, k2, k3, k4, k5 = jax.random.split(jax.random.PRNGKey(42), 5)
-    H = dq.rand_herm(k1, (*nH, n, n))
-    Ls = [dq.rand_herm(k2, (*nL1, n, n)), dq.rand_herm(k3, (*nL2, n, n))]
-    exp_ops = dq.rand_complex(k4, (nE, n, n))
-    psi0 = dq.rand_ket(k5, (*npsi0, n, 1))
-    tsave = jnp.linspace(0, 0.01, ntsave)
-
-    result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=exp_ops, options=options)
-    if cartesian_batching:
-        assert result.states.shape == (*nH, *nL1, *nL2, *npsi0, ntsave, n, n)
-        assert result.expects.shape == (*nH, *nL1, *nL2, *npsi0, nE, ntsave)
-    else:
-        assert result.states.shape == (*nH, ntsave, n, n)
-        assert result.expects.shape == (*nH, nE, ntsave)
-
-
-@pytest.mark.parametrize(('nH'), [(), (3,), (4, 3)])
-@pytest.mark.parametrize(('npsi0'), [(), (3,), (4, 3)])
-@pytest.mark.parametrize(('nL'), [(), (3,), (4, 3)])
-def test_non_carthesian_batching_broacasting(nH, npsi0, nL):
-    n = 8
-    nE = 7
+def test_cartesian_batching(nH, npsi0, nL1, nL2):
+    n = 2
+    nLs = [nL1, nL2]
+    nEs = 10
     ntsave = 11
 
-    options = dq.options.Options(cartesian_batching=False)
-
-    # create random objects
-    k1, k2, k3 = jax.random.split(jax.random.PRNGKey(42), 3)
-    H = dq.rand_herm(k1, (*nH, n, n))
-    exp_ops = dq.rand_complex(k2, (nE, n, n))
-    psi0 = dq.rand_ket(k3, (*npsi0, n, 1))
-    Ls = [dq.rand_herm(k2, (*nL, n, n))]
+    # run mesolve
+    H, Ls, psi0, Es = rand_mesolve_args(n, nH, nLs, npsi0, nEs)
     tsave = jnp.linspace(0, 0.01, ntsave)
+    result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=Es)
 
-    broadcast_shape = jnp.broadcast_shapes(
-        psi0.shape[:-2], H.shape[:-2], *[L.shape[:-2] for L in Ls]
-    )
+    # check result shape
+    assert result.states.shape == (*nH, *nL1, *nL2, *npsi0, ntsave, n, n)
+    assert result.expects.shape == (*nH, *nL1, *nL2, *npsi0, nEs, ntsave)
 
-    result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=exp_ops, options=options)
+
+# H has fixed shape (3, 4, n, n) for the next test case, we test a broad ensemble of
+# compatible broadcastable shape
+@pytest.mark.parametrize('nL1', [(), (5, 1, 4)])
+@pytest.mark.parametrize('npsi0', [(), (1,), (4,), (3, 1), (3, 4), (5, 1, 4)])
+def test_flat_batching(nL1, npsi0):
+    n = 2
+    nH = (3, 4)
+    nLs = [nL1, ()]
+    nEs = 6
+    ntsave = 11
+
+    # run mesolve
+    H, Ls, psi0, Es = rand_mesolve_args(n, nH, nLs, npsi0, nEs)
+    tsave = jnp.linspace(0, 0.01, ntsave)
+    options = dq.Options(cartesian_batching=False)
+    result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=Es, options=options)
+
+    # check result shape
+    broadcast_shape = jnp.broadcast_shapes(nH, nL1, npsi0)
     assert result.states.shape == (*broadcast_shape, ntsave, n, n)
-    assert result.expects.shape == (*broadcast_shape, nE, ntsave)
+    assert result.expects.shape == (*broadcast_shape, nEs, ntsave)


### PR DESCRIPTION
On top of #562. Proposal for simpler nd-batching tests, based on the very nice parametrization proposed by @abocquet, mostly nits:

- Separate cartesian and flat batching tests
- Test a broad combination of broadcastable shape
- Reduce Hilbert space dimension to 2 for faster tests
- Reduce total test case number for faster tests, still having a representative ensemble
- Reorganise arguments order to be consistent with sesolve/mesolve arguments ordering
- Create helper function to create random H, Ls, psi0
- Consistently use different random keys for each random object
- Consistently use the shortcut "Es" and "nEs" for exp_ops
- Always choose nEs to be different from the batched dimensions

I recommend reading the final file rather than the diffs (which are a bit heavy):
- `tests/sesolve/test_batching.py` > [here](https://github.com/dynamiqs/dynamiqs/blob/simplify-batching-tests/tests/sesolve/test_batching.py)
- `tests/mesolve/test_batching.py` > [here](https://github.com/dynamiqs/dynamiqs/blob/simplify-batching-tests/tests/mesolve/test_batching.py)