### PR TITLE
Remove broadcasting before ND-batching

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
-from jaxtyping import Array, ArrayLike, PyTree
+from jaxtyping import Array, PyTree
 
 
 def type_str(type: Any) -> str:  # noqa: A002
@@ -43,21 +43,3 @@ def cdtype() -> jnp.complex64 | jnp.complex128:
 def tree_str_inline(x: PyTree) -> str:
     # return an inline formatting of a pytree as a string
     return eqx.tree_pformat(x, indent=0).replace('\n', '').replace(',', ', ')
-
-
-def expand_as_broadcastable(arrays: tuple[ArrayLike, ...]) -> tuple[ArrayLike, ...]:
-    arrays = tuple([jnp.asarray(arr) for arr in arrays])
-    expanded_arrays = []
-
-    # number of dimensions of the expanded arrays
-    num_dims = sum([arr.ndim for arr in arrays])
-
-    # loop over the arrays and expand them
-    k = 0
-    for arr in arrays:
-        new_shape = [-1 if i in range(k, k + arr.ndim) else 1 for i in range(num_dims)]
-        new_arr = arr.reshape(new_shape)
-        expanded_arrays.append(new_arr)
-        k += arr.ndim
-
-    return tuple(expanded_arrays)

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -132,11 +132,3 @@ def _cartesian_vectorize(
     # Hamilonian. This prevents performing the Cartesian product
     # on all terms for the sum Hamiltonian.
     return _flat_vectorize(f, n_batch[:1] + (None,) * len(n_batch[1:]), out_axes)
-
-
-def squeeze_ones(x: TimeArray) -> TimeArray:
-    shape = x.shape
-    for i, s in reversed(list(enumerate(shape))):
-        if s == 1:
-            x = x.squeeze(i)
-    return x

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -16,7 +16,6 @@ from ..core._utils import (
     _flat_vectorize,
     catch_xla_runtime_error,
     get_solver_class,
-    squeeze_ones,
 )
 from ..gradient import Gradient
 from ..options import Options
@@ -162,8 +161,8 @@ def _vectorized_mesolve(
         f = _cartesian_vectorize(_mesolve, n_batch, out_axes)
     else:
         f = _flat_vectorize(_mesolve, n_batch, out_axes)
-        H = squeeze_ones(H)
-        jump_ops = list(map(squeeze_ones, jump_ops))
+        H = H.squeeze()
+        jump_ops = [x.squeeze() for x in jump_ops]
 
     # === apply vectorized function
     return f(H, jump_ops, rho0, tsave, exp_ops, solver, gradient, options)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -114,12 +114,9 @@ def _vectorized_sesolve(
 ) -> SEResult:
     # === vectorize function
     # we vectorize over H and psi0, all other arguments are not vectorized
-
     if not options.cartesian_batching:
         broadcast_shape = jnp.broadcast_shapes(H.shape[:-2], psi0.shape[:-2])
-        H = H.broadcast_to(*(broadcast_shape + H.shape[-2:]))
         psi0 = jnp.broadcast_to(psi0, broadcast_shape + psi0.shape[-2:])
-
     # `n_batch` is a pytree. Each leaf of this pytree gives the number of times
     # this leaf should be vmapped on.
     n_batch = (

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -222,6 +222,21 @@ class TimeArray(eqx.Module):
             New time-array object with the given shape.
         """
 
+    def squeeze(self, axis: int) -> TimeArray:
+        """Squeeze a time-array.
+
+        Args:
+            axis: Axis to squeeze.
+
+        Returns:
+        New time-array object with squeezed_shape
+        """
+        if axis >= self.ndim:
+            raise ValueError(
+                f'Cannot squeeze axis {axis} from a time-array with {self.ndim} axes.'
+            )
+        return self.reshape(*self.shape[:axis], *self.shape[axis + 1 :])
+
     @abstractmethod
     def broadcast_to(self, *new_shape: int) -> TimeArray:
         """Broadcasts a time-array to a new shape.

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -222,15 +222,23 @@ class TimeArray(eqx.Module):
             New time-array object with the given shape.
         """
 
-    def squeeze(self, axis: int) -> TimeArray:
+    def squeeze(self, axis: int | None = None) -> TimeArray:
         """Squeeze a time-array.
 
         Args:
-            axis: Axis to squeeze.
+            axis: Axis to squeeze. If `none`, all axes with dimension 1 are squeezed.
 
         Returns:
-        New time-array object with squeezed_shape
+            New time-array object with squeezed_shape
         """
+        if axis is None:
+            shape = self.shape
+            x = self
+            for i, s in reversed(list(enumerate(shape))):
+                if s == 1:
+                    x = x.squeeze(i)
+            return x
+
         if axis >= self.ndim:
             raise ValueError(
                 f'Cannot squeeze axis {axis} from a time-array with {self.ndim} axes.'


### PR DESCRIPTION
Who needs broadcasting anyway ? Remove broadcasting before ND-batching.
Also removes `expand_as_broadcastable`, that isn't used anymore.

Follows https://github.com/dynamiqs/dynamiqs/pull/562

Related to DYN-197.