### PR TITLE
Fix progress bar

### DIFF
--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -3,7 +3,6 @@ from importlib.metadata import version
 from . import dark
 from .options import *
 from .plots import *
-from .progress_meter import *
 from .result import *
 from .solvers import *
 from .time_array import *

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -53,7 +53,7 @@ class DiffraxSolver(BaseSolver):
                 stepsize_controller=self.stepsize_controller,
                 adjoint=adjoint,
                 max_steps=self.max_steps,
-                progress_meter=self.options.progress_bar.into_diffrax(),
+                progress_meter=self.options.progress_bar.to_diffrax(),
             )
 
         # === collect and return results

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -22,6 +22,11 @@ class Options(eqx.Module):
         cartesian_batching: If `True`, batched arguments are treated as separated
             batch dimensions, otherwise the batching is performed over a single
             shared batched dimension.
+        progress_bar: Progress bar indicating how far the solve has progressed. Defaults
+            to a [tqdm](https://github.com/tqdm/tqdm) progress bar. Pass `None` for no
+            output, see other options in [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
+            If gradients are computed, the progress bar only displays the advancement
+            for the forward pass.
         t0: Initial time. If `None`, defaults to the first time in `tsave`.
         save_extra _(function, optional)_: A function with signature
             `f(Array) -> PyTree` that takes a state as input and returns a PyTree.

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -6,7 +6,7 @@ from jax import Array
 from jaxtyping import PyTree, ScalarLike
 
 from ._utils import tree_str_inline
-from .progress_meter import AbstractProgressMeter, TqdmProgressMeter
+from .progress_meter import AbstractProgressMeter, NoProgressMeter, TqdmProgressMeter
 
 __all__ = ['Options']
 
@@ -32,7 +32,7 @@ class Options(eqx.Module):
     save_states: bool = True
     verbose: bool = True
     cartesian_batching: bool = True
-    progress_bar: AbstractProgressMeter = None
+    progress_bar: AbstractProgressMeter | None = TqdmProgressMeter()
     t0: ScalarLike | None = None
     save_extra: callable[[Array], PyTree] | None = None
 
@@ -41,12 +41,12 @@ class Options(eqx.Module):
         save_states: bool = True,
         verbose: bool = True,
         cartesian_batching: bool = True,
-        progress_bar: AbstractProgressMeter = None,
+        progress_bar: AbstractProgressMeter | None = TqdmProgressMeter(),  # noqa: B008
         t0: ScalarLike | None = None,
         save_extra: callable[[Array], PyTree] | None = None,
     ):
         if progress_bar is None:
-            progress_bar = TqdmProgressMeter()
+            progress_bar = NoProgressMeter()
 
         self.save_states = save_states
         self.verbose = verbose

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -10,20 +10,20 @@ __all__ = [
 
 
 class AbstractProgressMeter(eqx.Module):
-    def into_diffrax(self) -> dx.AbstractProgressMeter:
+    def to_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.AbstractProgressMeter()
 
 
 class NoProgressMeter(AbstractProgressMeter):
-    def into_diffrax(self) -> dx.AbstractProgressMeter:
+    def to_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.NoProgressMeter()
 
 
 class TextProgressMeter(AbstractProgressMeter):
-    def into_diffrax(self) -> dx.AbstractProgressMeter:
+    def to_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.TextProgressMeter()
 
 
 class TqdmProgressMeter(AbstractProgressMeter):
-    def into_diffrax(self) -> dx.AbstractProgressMeter:
+    def to_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.TqdmProgressMeter()

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -1,3 +1,5 @@
+from abc import abstractmethod
+
 import diffrax as dx
 import equinox as eqx
 
@@ -10,8 +12,9 @@ __all__ = [
 
 
 class AbstractProgressMeter(eqx.Module):
+    @abstractmethod
     def to_diffrax(self) -> dx.AbstractProgressMeter:
-        return dx.AbstractProgressMeter()
+        pass
 
 
 class NoProgressMeter(AbstractProgressMeter):

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -15,15 +15,15 @@ class AbstractProgressMeter(eqx.Module):
 
 
 class NoProgressMeter(AbstractProgressMeter):
-    def into_diffrax(self) -> dx.NoProgressMeter:
+    def into_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.NoProgressMeter()
 
 
 class TextProgressMeter(AbstractProgressMeter):
-    def into_diffrax(self) -> dx.TextProgressMeter:
+    def into_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.TextProgressMeter()
 
 
 class TqdmProgressMeter(AbstractProgressMeter):
-    def into_diffrax(self) -> dx.TqdmProgressMeter:
+    def into_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.TqdmProgressMeter()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "jax",
     "jaxlib",
     "jaxtyping",
-    "diffrax>=0.5.1",  # for complex support
+    "diffrax>=0.5.1",  # for complex support (0.5.0) and progress meter (0.5.1)
     "equinox",
     "imageio",
     "cmasher>=1.8.0",  # avoid matplotlib colormaps deprecation warning


### PR DESCRIPTION
Fixes on top of #428 and #587.

Left to do:
- [ ] Find a good progress bar style.
- [ ] Fix documentation output in places where we use `dq.sesolve/dq.mesolve` to include progress bar.
- [ ] Document progress bars class in public API.
- [ ] Choose either the term "progress bar" or "progress meter" for doc and API and stick to it.
- [ ] Add progress bar to non-diffrax solver > https://linear.app/dynamiqs/issue/DYN-212/add-progress-bar-to-non-diffrax-solver.