### PR TITLE
New progress bar format

### DIFF
--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -32,7 +32,7 @@ class _DiffraxTqdmProgressMeter(dx.TqdmProgressMeter):
     @staticmethod
     def _init_bar() -> tqdm.tqdm:
         bar_format = (
-            '|{bar}| {percentage:4.1f}% ◆ total {elapsed} ◆ remaining {remaining}'
+            '|{bar}| {percentage:5.1f}% ◆ total {elapsed} ◆ remaining {remaining}'
         )
         return tqdm.tqdm(total=100, unit='%', bar_format=bar_format)
 

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -2,6 +2,7 @@ from abc import abstractmethod
 
 import diffrax as dx
 import equinox as eqx
+import tqdm
 
 __all__ = [
     'AbstractProgressMeter',
@@ -27,6 +28,15 @@ class TextProgressMeter(AbstractProgressMeter):
         return dx.TextProgressMeter()
 
 
+class _DiffraxTqdmProgressMeter(dx.TqdmProgressMeter):
+    @staticmethod
+    def _init_bar() -> tqdm.tqdm:
+        bar_format = (
+            '|{bar}| {percentage:4.1f}% ◆ total {elapsed} ◆ remaining {remaining}'
+        )
+        return tqdm.tqdm(total=100, unit='%', bar_format=bar_format)
+
+
 class TqdmProgressMeter(AbstractProgressMeter):
     def to_diffrax(self) -> dx.AbstractProgressMeter:
-        return dx.TqdmProgressMeter()
+        return _DiffraxTqdmProgressMeter()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "imageio",
     "cmasher>=1.8.0",  # avoid matplotlib colormaps deprecation warning
     "ipython",
+    "tqdm",
 ]
 
 [build-system]


### PR DESCRIPTION
On top of #588.

Proposed format:
```
|█████▉    |  59.1% ◆ total 00:02 ◆ remaining 00:01
```
```
|██████████| 100.0% ◆ total 00:04 ◆ remaining 00:00
```

This is a bit of a hot-fix, @abocquet can you make a PR on top so that `TqdmProgressMeter` has a `bar_format` attribute that can be set by the user at `__init__()`, and then dynamically creates the suited `_DiffraxTqdmProgressMeter` class upon call to `to_diffrax()`? (or just inherit directly from `dx.TqdmProgressMeter`) Example usage:
```python
custom_progress_bar = dq.progress_meter.TqdmProgressMeter(bar_format='{percentage:5.1f}% ({elapsed}/{remaining})')
dq.sesolve(..., options=dq.Options(progress_bar=custom_progress_bar))
```
Ideally `dx.TqdmProgressMeter` should be fully configurable (it should pass all tqdm related settings to the tqdm instance upon creation).