### PR TITLE
Add implicit solvers to dynamiqs

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -35,6 +35,8 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
         - Tsit5
         - Dopri5
         - Dopri8
+        - Kvaerno3
+        - Kvaerno5
         - Euler
         - Rouchon1
         - Rouchon2

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -143,3 +143,11 @@ class Dopri8Solver(AdaptiveSolver):
 
 class Tsit5Solver(AdaptiveSolver):
     diffrax_solver = dx.Tsit5()
+
+
+class Kvaerno3Solver(AdaptiveSolver):
+    diffrax_solver = dx.Kvaerno3()
+
+
+class Kvaerno5Solver(AdaptiveSolver):
+    diffrax_solver = dx.Kvaerno5()

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -9,6 +9,8 @@ from ..core.diffrax_solver import (
     Dopri5Solver,
     Dopri8Solver,
     EulerSolver,
+    Kvaerno3Solver,
+    Kvaerno5Solver,
     Tsit5Solver,
 )
 from ..utils.utils import dag
@@ -59,4 +61,12 @@ class MEDopri8(MEDiffraxSolver, Dopri8Solver):
 
 
 class METsit5(MEDiffraxSolver, Tsit5Solver):
+    pass
+
+
+class MEKvaerno3(MEDiffraxSolver, Kvaerno3Solver):
+    pass
+
+
+class MEKvaerno5(MEDiffraxSolver, Kvaerno5Solver):
     pass

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -20,10 +20,19 @@ from ..core._utils import (
 from ..gradient import Gradient
 from ..options import Options
 from ..result import MEResult
-from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
+from ..solver import (
+    Dopri5,
+    Dopri8,
+    Euler,
+    Kvaerno3,
+    Kvaerno5,
+    Propagator,
+    Solver,
+    Tsit5,
+)
 from ..time_array import Shape, TimeArray
 from ..utils.utils import todm
-from .mediffrax import MEDopri5, MEDopri8, MEEuler, METsit5
+from .mediffrax import MEDopri5, MEDopri8, MEEuler, MEKvaerno3, MEKvaerno5, METsit5
 from .mepropagator import MEPropagator
 
 __all__ = ['mesolve']
@@ -85,6 +94,8 @@ def mesolve(
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:
             [`Tsit5`][dynamiqs.solver.Tsit5], [`Dopri5`][dynamiqs.solver.Dopri5],
             [`Dopri8`][dynamiqs.solver.Dopri8],
+            [`Kvaerno3`][dynamiqs.solver.Kvaerno3],
+            [`Kvaerno5`][dynamiqs.solver.Kvaerno5],
             [`Euler`][dynamiqs.solver.Euler],
             [`Rouchon1`][dynamiqs.solver.Rouchon1],
             [`Rouchon2`][dynamiqs.solver.Rouchon2],
@@ -188,6 +199,8 @@ def _mesolve(
         Dopri5: MEDopri5,
         Dopri8: MEDopri8,
         Tsit5: METsit5,
+        Kvaerno3: MEKvaerno3,
+        Kvaerno5: MEKvaerno5,
         Propagator: MEPropagator,
     }
     solver_class = get_solver_class(solvers, solver)

--- a/dynamiqs/sesolve/sediffrax.py
+++ b/dynamiqs/sesolve/sediffrax.py
@@ -8,6 +8,8 @@ from ..core.diffrax_solver import (
     Dopri5Solver,
     Dopri8Solver,
     EulerSolver,
+    Kvaerno3Solver,
+    Kvaerno5Solver,
     Tsit5Solver,
 )
 
@@ -33,4 +35,12 @@ class SEDopri8(SEDiffraxSolver, Dopri8Solver):
 
 
 class SETsit5(SEDiffraxSolver, Tsit5Solver):
+    pass
+
+
+class SEKvaerno3(SEDiffraxSolver, Kvaerno3Solver):
+    pass
+
+
+class SEKvaerno5(SEDiffraxSolver, Kvaerno5Solver):
     pass

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -19,9 +19,18 @@ from ..core._utils import (
 from ..gradient import Gradient
 from ..options import Options
 from ..result import SEResult
-from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
+from ..solver import (
+    Dopri5,
+    Dopri8,
+    Euler,
+    Kvaerno3,
+    Kvaerno5,
+    Propagator,
+    Solver,
+    Tsit5,
+)
 from ..time_array import Shape, TimeArray
-from .sediffrax import SEDopri5, SEDopri8, SEEuler, SETsit5
+from .sediffrax import SEDopri5, SEDopri8, SEEuler, SEKvaerno3, SEKvaerno5, SETsit5
 from .sepropagator import SEPropagator
 
 __all__ = ['sesolve']
@@ -74,6 +83,8 @@ def sesolve(
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:
             [`Tsit5`][dynamiqs.solver.Tsit5], [`Dopri5`][dynamiqs.solver.Dopri5],
             [`Dopri8`][dynamiqs.solver.Dopri8],
+            [`Kvaerno3`][dynamiqs.solver.Kvaerno3],
+            [`Kvaerno5`][dynamiqs.solver.Kvaerno5],
             [`Euler`][dynamiqs.solver.Euler],
             [`Propagator`][dynamiqs.solver.Propagator]).
 
@@ -160,6 +171,8 @@ def _sesolve(
         Dopri5: SEDopri5,
         Dopri8: SEDopri8,
         Tsit5: SETsit5,
+        Kvaerno3: SEKvaerno3,
+        Kvaerno5: SEKvaerno5,
         Propagator: SEPropagator,
     }
     solver_class = get_solver_class(solvers, solver)

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -7,7 +7,17 @@ import equinox as eqx
 from ._utils import tree_str_inline
 from .gradient import Autograd, CheckpointAutograd, Gradient
 
-__all__ = ['Propagator', 'Euler', 'Rouchon1', 'Rouchon2', 'Dopri5', 'Dopri8', 'Tsit5']
+__all__ = [
+    'Propagator',
+    'Euler',
+    'Rouchon1',
+    'Rouchon2',
+    'Dopri5',
+    'Dopri8',
+    'Tsit5',
+    'Kvaerno3',
+    'Kvaerno5',
+]
 
 
 _TupleGradient = tuple[type[Gradient], ...]
@@ -245,6 +255,84 @@ class Tsit5(_ODEAdaptiveStep):
 
     This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
     library, see [`diffrax.Tsit5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Tsit5).
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+
+    Note-: Supported gradients
+        This solver supports differentiation with
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd].
+    """
+
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+
+    # dummy init to have the signature in the documentation
+    def __init__(
+        self,
+        rtol: float = 1e-6,
+        atol: float = 1e-6,
+        safety_factor: float = 0.9,
+        min_factor: float = 0.2,
+        max_factor: float = 5.0,
+        max_steps: int = 100_000,
+    ):
+        super().__init__(rtol, atol, safety_factor, min_factor, max_factor, max_steps)
+
+
+class Kvaerno3(_ODEAdaptiveStep):
+    """Kvaerno's method of order 3 (adaptive step size and implicit ODE solver).
+
+    This method is suitable for stiff problems, typically problems with Hamiltonians or
+    jump operators that feature large spectral gaps. This is for instance the case with
+    high-order polynomials in bosonic ladder operators in large dimensions.
+
+    This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
+    library, see [`diffrax.Kvaerno3`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Kvaerno3).
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+
+    Note-: Supported gradients
+        This solver supports differentiation with
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd].
+    """
+
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+
+    # dummy init to have the signature in the documentation
+    def __init__(
+        self,
+        rtol: float = 1e-6,
+        atol: float = 1e-6,
+        safety_factor: float = 0.9,
+        min_factor: float = 0.2,
+        max_factor: float = 5.0,
+        max_steps: int = 100_000,
+    ):
+        super().__init__(rtol, atol, safety_factor, min_factor, max_factor, max_steps)
+
+
+class Kvaerno5(_ODEAdaptiveStep):
+    """Kvaerno's method of order 5 (adaptive step size and implicit ODE solver).
+
+    This method is suitable for stiff problems, typically problems with Hamiltonians or
+    jump operators that feature large spectral gaps. This is for instance the case with
+    high-order polynomials in bosonic ladder operators in large dimensions.
+
+    This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
+    library, see [`diffrax.Kvaerno5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Kvaerno5).
 
     Args:
         rtol: Relative tolerance.

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -295,6 +295,14 @@ class Kvaerno3(_ODEAdaptiveStep):
     This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
     library, see [`diffrax.Kvaerno3`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Kvaerno3).
 
+    Warning:
+        Implicit solvers might suffer from **single-precision** floating-point numbers
+        at larger tolerances than explicit solvers. If you find that your simulation is
+        slow or that the progress bar gets stuck, consider switching to
+        double-precision with
+        [`dq.set_precision("double")`][dynamiqs.set_precision]. See more details in the
+        [Sharp bits](/documentation/getting_started/sharp-bits.html) documentation.
+
     Args:
         rtol: Relative tolerance.
         atol: Absolute tolerance.
@@ -333,6 +341,14 @@ class Kvaerno5(_ODEAdaptiveStep):
 
     This solver is implemented by the [Diffrax](https://docs.kidger.site/diffrax/)
     library, see [`diffrax.Kvaerno5`](https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Kvaerno5).
+
+    Warning:
+        Implicit solvers might suffer from single-precision floating-point numbers at
+        larger tolerances than explicit solvers. If you find that your simulation is
+        slow or that the progress bar gets stuck, consider switching to
+        double-precision with
+        [`dq.set_precision("double")`][dynamiqs.set_precision]. See more details in the
+        [Sharp bits](/documentation/getting_started/sharp-bits.html) documentation.
 
     Args:
         rtol: Relative tolerance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -152,6 +152,8 @@ nav:
               - Tsit5: python_api/solver/Tsit5.md
               - Dopri5: python_api/solver/Dopri5.md
               - Dopri8: python_api/solver/Dopri8.md
+              - Kvaerno3: python_api/solver/Kvaerno3.md
+              - Kvaerno5: python_api/solver/Kvaerno5.md
               - Euler: python_api/solver/Euler.md
               - Rouchon1: python_api/solver/Rouchon1.md
               - Rouchon2: python_api/solver/Rouchon2.md


### PR DESCRIPTION
Waiting on https://github.com/patrick-kidger/diffrax/issues/428 before marking the PR as ready.

Even on a very simple stiff problem (4-legged dissipative cat), the implicit solver is getting stuck. We may have to play with the root finding to improve this?
```python
import dynamiqs as dq
import jax.numpy as jnp

# units
kHz, MHz = 2 * jnp.pi * 1e-3, 2 * jnp.pi
ns, us = 1e-3, 1e0

# parameters
N = 16
alpha = jnp.sqrt(4.0)
k4 = 100.0 * kHz
T = 2 * us

# operators
a = dq.destroy(N)
i = dq.eye(N)

# Hamiltonian and jump operators
H = dq.zero(N)
jump_ops = [jnp.sqrt(k4) * (dq.powm(a, 4) - alpha**4 * i)]

# initial state
psi0 = dq.coherent(N, 0.0)

# time
tsave = jnp.linspace(0.0, T, 101)

# run simulation
solver = dq.solver.Kvaerno5(atol=1e-4, rtol=1e-4)
result = dq.mesolve(H, jump_ops, psi0, tsave, solver=solver)
print(result)
```

Closes DYN-159.