### PR TITLE
Add `Rouchon1` solver

### DIFF
--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -13,6 +13,10 @@ from .abstract_solver import BaseSolver
 
 
 class DiffraxSolver(BaseSolver):
+    # Subclasses should implement:
+    # - the attributes: stepsize_controller, dt0, max_steps, diffrax_solver, terms
+    # - the methods: result, infos
+
     stepsize_controller: dx.AbstractVar[dx.AbstractStepSizeController]
     dt0: dx.AbstractVar[float | None]
     max_steps: dx.AbstractVar[int]
@@ -67,6 +71,10 @@ class DiffraxSolver(BaseSolver):
 
 
 class FixedSolver(DiffraxSolver):
+    # Subclasses should implement:
+    # - the attributes: diffrax_solver, terms
+    # - the methods: result
+
     class Infos(eqx.Module):
         nsteps: Array
 
@@ -94,6 +102,10 @@ class EulerSolver(FixedSolver):
 
 
 class AdaptiveSolver(DiffraxSolver):
+    # Subclasses should implement:
+    # - the attributes: diffrax_solver, terms
+    # - the methods: result
+
     class Infos(eqx.Module):
         nsteps: Array
         naccepted: Array

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -19,7 +19,7 @@ class MEDiffraxSolver(DiffraxSolver, MESolver):
     def terms(self) -> dx.AbstractTerm:
         # define Lindblad term drho/dt
 
-        # The Lindblad equation is:
+        # The Lindblad equation for a single loss channel is:
         # (1) drho/dt = -i [H, rho] + L @ rho @ Ld - 0.5 Ld @ L @ rho - 0.5 rho @ Ld @ L
         # An alternative but similar equation is:
         # (2) drho/dt = (-i H @ rho + 0.5 L @ rho @ Ld - 0.5 Ld @ L @ rho) + h.c.

--- a/dynamiqs/mesolve/merouchon.py
+++ b/dynamiqs/mesolve/merouchon.py
@@ -1,0 +1,74 @@
+# ruff: noqa: ANN001, ANN201, ARG002
+# we mostly ignore type hinting in this file for readability purposes
+
+from __future__ import annotations
+
+import diffrax as dx
+import jax.numpy as jnp
+from diffrax._custom_types import RealScalarLike, Y
+from diffrax._local_interpolation import LocalLinearInterpolation
+from jax import Array
+
+from ..core.abstract_solver import MESolver
+from ..core.diffrax_solver import FixedSolver
+from ..utils.utils.general import dag
+
+
+class AbstractRouchonTerm(dx.AbstractTerm):
+    # this class bypasses the typical Diffrax term implementation, as Rouchon schemes
+    # don't match the vf/contr/prod structure
+
+    kraus_map: callable[[RealScalarLike, RealScalarLike, Y], Y]
+    # should be defined as `kraus_map(t0, t1, y0) -> y1`
+
+    def vf(self, t, y, args):
+        pass
+
+    def contr(self, t0, t1, **kwargs):
+        pass
+
+    def prod(self, vf, control):
+        pass
+
+
+class RouchonSolver(dx.AbstractSolver):
+    term_structure = AbstractRouchonTerm
+    interpolation_cls = LocalLinearInterpolation
+
+    def init(self, terms, t0, t1, y0, args):
+        pass
+
+    def order(self, terms):
+        return 1
+
+    def step(self, terms, t0, t1, y0, args, solver_state, made_jump):
+        del solver_state, made_jump
+        y1 = terms.term.kraus_map(t0, t1, y0)
+        dense_info = dict(y0=y0, y1=y1)
+        return y1, None, dense_info, None, dx.RESULTS.successful
+
+    def func(self, terms, t0, y0, args):
+        pass
+
+
+class MERouchon1(FixedSolver, MESolver):
+    diffrax_solver: dx.AbstractSolver = RouchonSolver()
+
+    @property
+    def Id(self) -> Array:
+        return jnp.eye(self.H.shape[-1], dtype=self.H.dtype)
+
+    @property
+    def terms(self) -> dx.AbstractTerm:
+        def kraus_map(t0, t1, y0):  # noqa: ANN202
+            Ls = jnp.stack([L(t0) for L in self.Ls])
+            Lsd = dag(Ls)
+            LdL = (Lsd @ Ls).sum(0)
+
+            delta_t = t1 - t0
+            M0 = self.Id - (1j * self.H(t0) + 0.5 * LdL) * delta_t
+            M1s = jnp.sqrt(delta_t) * Ls
+
+            return M0 @ y0 @ dag(M0) + jnp.sum(M1s @ y0 @ dag(M1s), axis=0)
+
+        return AbstractRouchonTerm(kraus_map)

--- a/dynamiqs/mesolve/merouchon.py
+++ b/dynamiqs/mesolve/merouchon.py
@@ -61,13 +61,19 @@ class MERouchon1(FixedSolver, MESolver):
     @property
     def terms(self) -> dx.AbstractTerm:
         def kraus_map(t0, t1, y0):  # noqa: ANN202
+            # The Rouchon update for a single loss channel is:
+            #   rho_{k+1} = M0 @ rho @ M0d + \sum M1 @ rho @ M1d
+            # with
+            #   M0 = I - (iH + 0.5 Ld @ L) dt
+            #   M1 = L sqrt(dt)
+
             Ls = jnp.stack([L(t0) for L in self.Ls])
             Lsd = dag(Ls)
             LdL = (Lsd @ Ls).sum(0)
 
             delta_t = t1 - t0
             M0 = self.Id - (1j * self.H(t0) + 0.5 * LdL) * delta_t
-            Mks = jnp.sqrt(delta_t) * Ls
+            Mks = Ls * jnp.sqrt(delta_t)
 
             return M0 @ y0 @ dag(M0) + jnp.sum(Mks @ y0 @ dag(Mks), axis=0)
 

--- a/dynamiqs/mesolve/merouchon.py
+++ b/dynamiqs/mesolve/merouchon.py
@@ -38,9 +38,6 @@ class RouchonSolver(dx.AbstractSolver):
     def init(self, terms, t0, t1, y0, args):
         pass
 
-    def order(self, terms):
-        return 1
-
     def step(self, terms, t0, t1, y0, args, solver_state, made_jump):
         del solver_state, made_jump
         y1 = terms.term.kraus_map(t0, t1, y0)
@@ -51,8 +48,13 @@ class RouchonSolver(dx.AbstractSolver):
         pass
 
 
+class Rouchon1Solver(RouchonSolver):
+    def order(self, terms):
+        return 1
+
+
 class MERouchon1(FixedSolver, MESolver):
-    diffrax_solver: dx.AbstractSolver = RouchonSolver()
+    diffrax_solver: dx.AbstractSolver = Rouchon1Solver()
 
     @property
     def Id(self) -> Array:

--- a/dynamiqs/mesolve/merouchon.py
+++ b/dynamiqs/mesolve/merouchon.py
@@ -67,8 +67,8 @@ class MERouchon1(FixedSolver, MESolver):
 
             delta_t = t1 - t0
             M0 = self.Id - (1j * self.H(t0) + 0.5 * LdL) * delta_t
-            M1s = jnp.sqrt(delta_t) * Ls
+            Mks = jnp.sqrt(delta_t) * Ls
 
-            return M0 @ y0 @ dag(M0) + jnp.sum(M1s @ y0 @ dag(M1s), axis=0)
+            return M0 @ y0 @ dag(M0) + jnp.sum(Mks @ y0 @ dag(Mks), axis=0)
 
         return AbstractRouchonTerm(kraus_map)

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -20,11 +20,12 @@ from ..core._utils import (
 from ..gradient import Gradient
 from ..options import Options
 from ..result import MEResult
-from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
+from ..solver import Dopri5, Dopri8, Euler, Propagator, Rouchon1, Solver, Tsit5
 from ..time_array import Shape, TimeArray
 from ..utils.utils import todm
 from .mediffrax import MEDopri5, MEDopri8, MEEuler, METsit5
 from .mepropagator import MEPropagator
+from .merouchon import MERouchon1
 
 __all__ = ['mesolve']
 
@@ -185,6 +186,7 @@ def _mesolve(
     # === select solver class
     solvers = {
         Euler: MEEuler,
+        Rouchon1: MERouchon1,
         Dopri5: MEDopri5,
         Dopri8: MEDopri8,
         Tsit5: METsit5,

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -123,8 +123,8 @@ class Euler(_ODEFixedStep):
 class Rouchon1(_ODEFixedStep):
     """First-order Rouchon method (fixed step size ODE solver).
 
-    Warning:
-        This solver has not been ported to JAX yet.
+    Args:
+        dt _(float)_: Fixed time step.
 
     Note-: Supported gradients
         This solver supports differentiation with

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -1,0 +1,20 @@
+import pytest
+
+from dynamiqs.gradient import Autograd, CheckpointAutograd
+from dynamiqs.solver import Rouchon1
+
+from ..solver_tester import SolverTester
+from .open_system import ocavity, otdqubit
+
+
+class TestMERouchon1(SolverTester):
+    @pytest.mark.parametrize('system', [ocavity, otdqubit])
+    def test_correctness(self, system):
+        solver = Rouchon1(dt=1e-4)
+        self._test_correctness(system, solver, esave_atol=1e-3)
+
+    @pytest.mark.parametrize('system', [ocavity, otdqubit])
+    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    def test_gradient(self, system, gradient):
+        solver = Rouchon1(dt=1e-4)
+        self._test_gradient(system, solver, gradient, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
Related to DYN-165.

Turned out to be pretty straightforward.

A few things left to do in subsequent PRs, I voluntarly kept this one as small as possible:
- [ ] `Id` is rebuilt at every time step, fix it (or maybe no need bc of magic caching?)
- [ ] check if magic caching works here too, or if `M0` and `Mks` are recomputed every time for constant Hamiltonians
- [ ] improve solver documentation (explain the update rule, link relevant papers)
- [ ] add normalization
- [ ] add `Rouchon2`

To define higher-order versions we just need to implement `kraus_map(t0, t1, y0) -> y1`. 😉