### PR TITLE
Explain where extra saved data can be retrieved in options documentation

### DIFF
--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -32,7 +32,9 @@ class Options(eqx.Module):
         save_extra _(function, optional)_: A function with signature
             `f(Array) -> PyTree` that takes a state as input and returns a PyTree.
             This can be used to save additional arbitrary data during the
-            integration. The results are saved in extra of class Result, see [dynamiqs/result.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/result.py)
+            integration. The additional data is accessible in the `extra` attribute of
+            the result object returned by the solvers (see
+            [`SEResult`][dynamiqs.SEResult] or [`MEResult`][dynamiqs.MEResult]).
     """
 
     save_states: bool = True

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -32,7 +32,7 @@ class Options(eqx.Module):
         save_extra _(function, optional)_: A function with signature
             `f(Array) -> PyTree` that takes a state as input and returns a PyTree.
             This can be used to save additional arbitrary data during the
-            integration. The results are saved in extra of class Result [dynamiqs/result.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/result.py)
+            integration. The results are saved in extra of class Result, see [dynamiqs/result.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/result.py)
     """
 
     save_states: bool = True

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -32,7 +32,7 @@ class Options(eqx.Module):
         save_extra _(function, optional)_: A function with signature
             `f(Array) -> PyTree` that takes a state as input and returns a PyTree.
             This can be used to save additional arbitrary data during the
-            integration.
+            integration. The results are saved in extra of class Result [dynamiqs/result.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/result.py)
     """
 
     save_states: bool = True

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -96,7 +96,7 @@ class SEResult(Result):
         expects _(array of shape (..., len(exp_ops), ntsave) or None)_: Saved
             expectation values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
-            specified in `options`.
+            specified in `options` (see [`dq.Options`][dynamiqs.Options]).
         infos _(PyTree or None)_: Solver-dependent information on the resolution.
         tsave _(array of shape (ntsave,))_: Times for which results were saved.
         solver _(Solver)_: Solver used.
@@ -146,7 +146,7 @@ class MEResult(Result):
         expects _(array of shape (..., len(exp_ops), ntsave) or None)_: Saved
             expectation values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
-            specified in `options`.
+            specified in `options` (see [`dq.Options`][dynamiqs.Options]).
         infos _(PyTree or None)_: Solver-dependent information on the resolution.
         tsave _(array of shape (ntsave,))_: Times for which results were saved.
         solver _(Solver)_: Solver used.


### PR DESCRIPTION
Added some documentation to the options regarding the use of save_extra.
This was a training to do PR and run the CI, as suggested by Pierre Guilmin.