### PR TITLE
Update tqdm bar format

### DIFF
--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -32,7 +32,8 @@ class _DiffraxTqdmProgressMeter(dx.TqdmProgressMeter):
     @staticmethod
     def _init_bar() -> tqdm.tqdm:
         bar_format = (
-            '|{bar}| {percentage:5.1f}% ◆ total {elapsed} ◆ remaining {remaining}'
+            '|{bar}| {percentage:5.1f}% ◆ total {elapsed_s:.2f}s '
+            '◆ remaining {remaining}'
         )
         return tqdm.tqdm(total=100, unit='%', bar_format=bar_format)
 


### PR DESCRIPTION
Minor modification on the bar format to give information regarding short simulations (less than 1 second).

```
|███████▏  |  72.2% ◆ total 4.70s ◆ remaining 00:01
|██████████| 100.0% ◆ total 6.68s ◆ remaining 00:00
```

Related to DYN-213.