### PR TITLE
Specify time-arrays discontinuities in diffrax solvers

### DIFF
--- a/docs/documentation/basics/time-dependent-operators.md
+++ b/docs/documentation/basics/time-dependent-operators.md
@@ -224,6 +224,11 @@ The returned object can be called at different times:
     >>> H = dq.modulated(f, dq.sigmax())
     ```
 
+??? Note "Discontinuous function"
+    If there is a discontinuous jump in the function values, you should use the optional
+    argument `discontinuity_ts` to enforce adaptive step size solvers to stop at these
+    times (i.e., right before, and right after the jump).
+
 ### Arbitrary time-dependent operators
 
 An arbitrary time-dependent operator is defined by
@@ -283,3 +288,8 @@ The returned object can be called at different times:
     >>> f = functools.partial(func, a=1.0, amplitude=5.0)
     >>> H = dq.timecallable(f)
     ```
+
+??? Note "Discontinuous function"
+    If there is a discontinuous jump in the function values, you should use the optional
+    argument `discontinuity_ts` to enforce adaptive step size solvers to stop at these
+    times (i.e., right before, and right after the jump).

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -63,9 +63,8 @@ def expand_as_broadcastable(arrays: tuple[ArrayLike, ...]) -> tuple[ArrayLike, .
     return tuple(expanded_arrays)
 
 
-def merge(*args: Array | None) -> Array | None:
-    # jnp.unique also sorts in ascending order
+def _concatenate_sort(*args: Array | None) -> Array | None:
     args = [x for x in args if x is not None]
     if len(args) == 0:
         return None
-    return jnp.unique(jnp.concatenate(args))
+    return jnp.sort(jnp.concatenate(args))

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -61,3 +61,11 @@ def expand_as_broadcastable(arrays: tuple[ArrayLike, ...]) -> tuple[ArrayLike, .
         k += arr.ndim
 
     return tuple(expanded_arrays)
+
+
+def merge(*args: Array | None) -> Array | None:
+    # jnp.unique also sorts in ascending order
+    args = [x for x in args if x is not None]
+    if len(args) == 0:
+        return None
+    return jnp.unique(jnp.concatenate(args))

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -6,7 +6,7 @@ import equinox as eqx
 from jax import Array
 from jaxtyping import PyTree, Scalar
 
-from .._utils import merge
+from .._utils import _concatenate_sort
 from ..gradient import Gradient
 from ..options import Options
 from ..result import MEResult, Result, Saved, SEResult
@@ -86,4 +86,5 @@ class MESolver(BaseSolver):
 
     @property
     def discontinuity_ts(self) -> Array | None:
-        return merge(self.H.discontinuity_ts, *[L.discontinuity_ts for L in self.Ls])
+        ts = [x.discontinuity_ts for x in [self.H, *self.Ls]]
+        return _concatenate_sort(ts)

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -6,6 +6,7 @@ import equinox as eqx
 from jax import Array
 from jaxtyping import PyTree, Scalar
 
+from .._utils import merge
 from ..gradient import Gradient
 from ..options import Options
 from ..result import MEResult, Result, Saved, SEResult
@@ -36,6 +37,10 @@ class BaseSolver(AbstractSolver):
     @property
     def t1(self) -> Scalar:
         return self.ts[-1]
+
+    @property
+    def discontinuity_ts(self) -> Array | None:
+        return self.H.discontinuity_ts
 
     def save(self, y: PyTree) -> Saved:
         ysave, Esave, extra = None, None, None
@@ -78,3 +83,7 @@ class MESolver(BaseSolver):
 
     def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
         return MEResult(self.ts, self.solver, self.gradient, self.options, saved, infos)
+
+    @property
+    def discontinuity_ts(self) -> Array | None:
+        return merge(self.H.discontinuity_ts, *[L.discontinuity_ts for L in self.Ls])

--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -87,4 +87,4 @@ class MESolver(BaseSolver):
     @property
     def discontinuity_ts(self) -> Array | None:
         ts = [x.discontinuity_ts for x in [self.H, *self.Ls]]
-        return _concatenate_sort(ts)
+        return _concatenate_sort(*ts)

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -133,6 +133,7 @@ class AdaptiveSolver(DiffraxSolver):
             safety=self.solver.safety_factor,
             factormin=self.solver.min_factor,
             factormax=self.solver.max_factor,
+            jump_ts=self.discontinuity_ts,
         )
 
     @property

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -122,6 +122,7 @@ def modulated(
     # discontinuity_ts
     if discontinuity_ts is not None:
         discontinuity_ts = jnp.asarray(discontinuity_ts)
+        discontinuity_ts = jnp.sort(discontinuity_ts)
 
     # make f a valid PyTree that is vmap-compatible
     f = BatchedCallable(f)
@@ -163,6 +164,7 @@ def timecallable(
     # discontinuity_ts
     if discontinuity_ts is not None:
         discontinuity_ts = jnp.asarray(discontinuity_ts)
+        discontinuity_ts = jnp.sort(discontinuity_ts)
 
     # make f a valid PyTree that is vmap-compatible
     f = BatchedCallable(f)
@@ -236,6 +238,7 @@ class TimeArray(eqx.Module):
     @property
     @abstractmethod
     def discontinuity_ts(self) -> Array | None:
+        # must be sorted, not necessarily unique values
         pass
 
     @abstractmethod

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -179,7 +179,8 @@ class TimeArray(eqx.Module):
             dimensions.
         ndim _(int)_: Number of dimensions.
         discontinuity_ts _(Array | None)_: Times at which there is a discontinuous jump
-            in the time-array values.
+            in the time-array values (the array is always sorted, but does not
+            necessarily contain unique values).
 
     Note: Arithmetic operation support
         Time-arrays support elementary operations:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -12,7 +12,7 @@ from jax import Array, lax
 from jaxtyping import ArrayLike, PyTree, ScalarLike
 
 from ._checks import check_shape, check_times
-from ._utils import cdtype, merge, obj_type_str
+from ._utils import _concatenate_sort, cdtype, obj_type_str
 
 __all__ = ['constant', 'pwc', 'modulated', 'timecallable', 'TimeArray']
 
@@ -527,7 +527,8 @@ class SummedTimeArray(TimeArray):
 
     @property
     def discontinuity_ts(self) -> Array | None:
-        return merge(*[tarray.discontinuity_ts for tarray in self.timearrays])
+        ts = [tarray.discontinuity_ts for tarray in self.timearrays]
+        return _concatenate_sort(*ts)
 
     def reshape(self, *new_shape: int) -> TimeArray:
         return SummedTimeArray(

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -192,7 +192,7 @@ class TimeArray(eqx.Module):
     """
 
     # Subclasses should implement:
-    # - the properties: dtype, shape, mT, in_axes, discontinuity_ts (if needed)
+    # - the properties: dtype, shape, mT, in_axes, discontinuity_ts
     # - the methods: reshape, broadcast_to, conj, __call__, __neg__, __mul__, __add__
 
     # Note that a subclass implementation of `__add__` only need to support addition
@@ -225,8 +225,9 @@ class TimeArray(eqx.Module):
         return len(self.shape)
 
     @property
+    @abstractmethod
     def discontinuity_ts(self) -> Array | None:
-        return None
+        pass
 
     @abstractmethod
     def reshape(self, *new_shape: int) -> TimeArray:
@@ -315,6 +316,10 @@ class ConstantTimeArray(TimeArray):
     @property
     def in_axes(self) -> PyTree[int]:
         return ConstantTimeArray(Shape(self.array.shape[:-2]))
+
+    @property
+    def discontinuity_ts(self) -> Array | None:
+        return None
 
     def reshape(self, *new_shape: int) -> TimeArray:
         return ConstantTimeArray(self.array.reshape(*new_shape))

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -119,6 +119,10 @@ def modulated(
     array = jnp.asarray(array, dtype=cdtype())
     check_shape(array, 'array', '(n, n)')
 
+    # discontinuity_ts
+    if discontinuity_ts is not None:
+        discontinuity_ts = jnp.asarray(discontinuity_ts)
+
     # make f a valid PyTree that is vmap-compatible
     f = BatchedCallable(f)
 
@@ -155,6 +159,10 @@ def timecallable(
         raise TypeError(
             f'Argument `f` must be a function, but has type {obj_type_str(f)}.'
         )
+
+    # discontinuity_ts
+    if discontinuity_ts is not None:
+        discontinuity_ts = jnp.asarray(discontinuity_ts)
 
     # make f a valid PyTree that is vmap-compatible
     f = BatchedCallable(f)

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -167,6 +167,8 @@ class TimeArray(eqx.Module):
         mT _(TimeArray)_: Returns the time-array transposed over its last two
             dimensions.
         ndim _(int)_: Number of dimensions.
+        discontinuity_ts _(Array | None)_: Times at which there is a discontinuous jump
+            in the time-array values.
 
     Note: Arithmetic operation support
         Time-arrays support elementary operations:
@@ -213,7 +215,6 @@ class TimeArray(eqx.Module):
 
     @property
     def discontinuity_ts(self) -> Array | None:
-        # specify times when there is a discontinuous jump in the time-array values
         return None
 
     @abstractmethod


### PR DESCRIPTION
Fixes DYN-218.

Thanks to @xiasitan for spotting the bug. 😉

## MWE
```python
import dynamiqs as dq
import jax
import jax.numpy as jnp

# PWCTimeArray
times = [0, 1, 1.1, 2]
values = [0, 10, 0]
H = dq.pwc(times, values, -dq.sigmax())
result = dq.sesolve(H, dq.ground(), [0, 2])
print(result)
print(dq.expect(dq.sigmaz(), result.states[-1]).real)

# ModulatedTimeArray
f = lambda t: jax.lax.cond(
    jnp.logical_and(1 <= t, t < 1.1), lambda _: 10, lambda _: 0, None
)
H = dq.modulated(f, -dq.sigmax(), discontinuity_ts=[1.0, 1.1])
result = dq.sesolve(H, dq.ground(), [0, 2])
print(result)
print(dq.expect(dq.sigmaz(), result.states[-1]).real)
```

Before this PR (wrong result):
```
# 5 steps
# -1.0
# 5 steps
# -1.0
```

After this PR (correct result):
```
# 15 steps
# 0.4161431
# 15 steps
# 0.4161431
```

## Old comment
Note that this PR breaks the JIT. The reason is that `jnp.unique` is data-dependent, see doc here > https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.unique.html. We have three solutions:
1. Either `jump_ts` in Diffrax does not need an array with unique values, that would be ideal.
2. Otherwise we coud specify statically the `size` argument of `jnp.unique`, which is fine if the `H`, `jump_ops` are defined outside JIT, we can just feed `len(times)`.
3. Otherwise we could specify a default `size` to `jnp.unique` (specifically made for this purpose), but then we need to pick a `fill_value`, and we need to check what fits Diffrax.

Left to do to fully close the issue after we've fixed the JIT:
- [x] set `discontinuities_ts` to private or document in `TimeArray` API
- [x] pull `discontinuities_ts` up to the `modulated`/`timecallable` API
- [x] document this in the time-dependent tutorial

Note that for `modulated` _we could also_ automatically scan the function to detect discontinuities, but that's a bit niche, I think a first solution where we delegate to the user is good enough for now.