### PR TITLE
Add support for scalar in ModulatedTimeArray

### DIFF
--- a/docs/documentation/basics/time-dependent-operators.md
+++ b/docs/documentation/basics/time-dependent-operators.md
@@ -176,7 +176,7 @@ where $f(t)$ is an time-dependent scalar.
 
 In dynamiqs, modulated operators are defined by:
 
-- `f`: a Python function with signature `f(t: float) -> Array` that returns the modulating factor $f(t)$ for any time $t$, as an array of shape _(...)_,
+- `f`: a Python function with signature `f(t: float) -> Scalar | Array` that returns the modulating factor $f(t)$ for any time $t$, as a scalar or an array of shape _(...)_,
 - `array`: the array defining the constant operator $O_0$, of shape _(n, n)_.
 
 To construct a modulated operator, pass these two arguments to the [`dq.modulated()`][dynamiqs.modulated] function, which returns a [`TimeArray`][dynamiqs.TimeArray] object. This object then returns an array with shape _(..., n, n)_ when called at any time $t$.

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -95,7 +95,7 @@ def modulated(
     shape _(...)_ for any time $t$.
 
     Args:
-        f _(function returning array of shape (...))_: Function with signature
+        f _(function returning scalar or array of shape (...))_: Function with signature
             `f(t: float) -> Scalar | Array` that returns the modulating factor
             $f(t)$.
         array _(array_like of shape (n, n))_: Constant array $O_0$.

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 import numpy as np
 from jax import Array, lax
-from jaxtyping import ArrayLike, PyTree, ScalarLike
+from jaxtyping import ArrayLike, PyTree, Scalar, ScalarLike
 
 from ._checks import check_shape, check_times
 from ._utils import cdtype, obj_type_str
@@ -84,17 +84,19 @@ def pwc(times: ArrayLike, values: ArrayLike, array: ArrayLike) -> PWCTimeArray:
     return PWCTimeArray(times, values, array)
 
 
-def modulated(f: callable[[float], Array], array: ArrayLike) -> ModulatedTimeArray:
+def modulated(
+    f: callable[[float], Scalar | Array], array: ArrayLike
+) -> ModulatedTimeArray:
     r"""Instantiate a modulated time-array.
 
     A modulated time-array is defined by $O(t) = f(t) O_0$ where $f(t)$ is a
     time-dependent scalar. The function $f$ is defined by passing a Python function
-    with signature `f(t: float) -> Array` that returns an array of shape
-    _(...)_ for any time $t$.
+    with signature `f(t: float) -> Scalar | Array` that returns a scalar or an array of
+    shape _(...)_ for any time $t$.
 
     Args:
         f _(function returning array of shape (...))_: Function with signature
-            `f(t: float) -> Array` that returns the modulating factor
+            `f(t: float) -> Scalar | Array` that returns the modulating factor
             $f(t)$.
         array _(array_like of shape (n, n))_: Constant array $O_0$.
 
@@ -556,9 +558,9 @@ class BatchedCallable(eqx.Module):
     f: callable[[float], Array]
     indices: list[Array]
 
-    def __init__(self, f: callable[[float], Array]):
-        # make f a valid PyTree with `Partial`
-        self.f = jtu.Partial(f)
+    def __init__(self, f: callable[[float], Scalar | Array]):
+        # make f a valid PyTree with `Partial` and convert its output to an array
+        self.f = jtu.Partial(lambda t: jnp.asarray(f(t)))
         shape = jax.eval_shape(f, 0.0).shape
         self.indices = list(jnp.indices(shape))
 


### PR DESCRIPTION
Went for the easy solution with a simple `f = lambda t: jnp.asarray(f(t))`. Did not check, but I'm pretty sure this should be transparent with the JIT.

Closes DYN-220.