### PR TITLE
Fix time array

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
-from jaxtyping import Array, ArrayLike, PyTree
+from jaxtyping import Array, PyTree
 
 
 def type_str(type: Any) -> str:  # noqa: A002
@@ -43,24 +43,6 @@ def cdtype() -> jnp.complex64 | jnp.complex128:
 def tree_str_inline(x: PyTree) -> str:
     # return an inline formatting of a pytree as a string
     return eqx.tree_pformat(x, indent=0).replace('\n', '').replace(',', ', ')
-
-
-def expand_as_broadcastable(arrays: tuple[ArrayLike, ...]) -> tuple[ArrayLike, ...]:
-    arrays = tuple([jnp.asarray(arr) for arr in arrays])
-    expanded_arrays = []
-
-    # number of dimensions of the expanded arrays
-    num_dims = sum([arr.ndim for arr in arrays])
-
-    # loop over the arrays and expand them
-    k = 0
-    for arr in arrays:
-        new_shape = [-1 if i in range(k, k + arr.ndim) else 1 for i in range(num_dims)]
-        new_arr = arr.reshape(new_shape)
-        expanded_arrays.append(new_arr)
-        k += arr.ndim
-
-    return tuple(expanded_arrays)
 
 
 def _concatenate_sort(*args: Array | None) -> Array | None:

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -150,7 +150,7 @@ def _flat_vectorize(  # noqa: C901
 
         return result
 
-    def wrap(*args: [PyTree]) -> PyTree:
+    def wrap(*args: PyTree) -> PyTree:
         squeezed_args = jtu.tree_map(squeeze_args, n_batch_false, args)
         result = f(*squeezed_args)
         return jtu.tree_map(unsqueeze_args, out_axes_false, result)

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -79,9 +79,12 @@ def is_shape(x: object) -> bool:
 
 
 def _flat_vectorize(
-    f: callable, n_batch: PyTree[int], out_axes: PyTree[int | None]
+    f: callable, n_batch: PyTree[int | False], out_axes: PyTree[int | False]
 ) -> callable:
     # todo: write doc
+    n_batch = tree_false_to_none(n_batch, is_leaf=is_shape)
+    out_axes = tree_false_to_none(out_axes)
+
     broadcast_shape = jtu.tree_leaves(n_batch, is_shape)
     broadcast_shape = jnp.broadcast_shapes(*broadcast_shape)
     in_axes = jtu.tree_map(
@@ -172,6 +175,8 @@ def _cartesian_vectorize(
     f: callable, n_batch: PyTree[int], out_axes: PyTree[int | None]
 ) -> callable:
     # todo :write doc
+    n_batch = tree_false_to_none(n_batch, is_leaf=is_shape)
+    out_axes = tree_false_to_none(out_axes)
 
     # We use `jax.tree_util` to handle nested batching (such as `jump_ops`).
     # Only the second to last batch terms are taken into account in order to

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import functools as ft
+from functools import partial, wraps
 
 import jax
 import jax.numpy as jnp
@@ -34,7 +34,7 @@ def catch_xla_runtime_error(func: callable) -> callable:
     # exception message. Note that this will not work for jitted function, as the
     # exception code will be traced out.
 
-    @ft.wraps(func)
+    @wraps(func)
     def wrapper(*args, **kwargs):  # noqa: ANN202
         try:
             return func(*args, **kwargs)
@@ -123,7 +123,7 @@ def _flat_vectorize(  # noqa: C901
     expand_dims = []  # dimensions '1' that will be lost during the vmap but that
     # we want to keep in the results.
     for i in range(len(broadcast_shape)):
-        in_axes = jtu.tree_map(ft.partial(tree_map_fn, i), n_batch, is_leaf=is_shape)
+        in_axes = jtu.tree_map(partial(tree_map_fn, i), n_batch, is_leaf=is_shape)
         if jtu.tree_all(jtu.tree_map(lambda x: x is None, in_axes)):
             expand_dims.append(n - i - 1)
         else:
@@ -145,7 +145,7 @@ def _flat_vectorize(  # noqa: C901
         if out_ax is not False:
             for dim in expand_dims:
                 result = jtu.tree_map(
-                    ft.partial(lambda t, dim: jnp.expand_dims(t, dim), dim=dim), result
+                    partial(lambda t, dim: jnp.expand_dims(t, dim), dim=dim), result
                 )
 
         return result

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -84,6 +84,7 @@ def _flat_vectorize(
     # todo: write doc
     broadcast_shape = jtu.tree_leaves(n_batch, is_shape)
     broadcast_shape = jnp.broadcast_shapes(*broadcast_shape)
+    print("broadcast_shape", broadcast_shape)
     in_axes = jtu.tree_map(
         lambda x: 0 if len(x) > 0 else None, n_batch, is_leaf=is_shape
     )
@@ -118,6 +119,6 @@ def _cartesian_vectorize(
                 f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
 
     # We flat vectorize on the first n_batch term, which is the
-    # Hamilonian. This prevents performing the Cartesian product
+    # Hamiltonian. This prevents performing the Cartesian product
     # on all terms for the sum Hamiltonian.
     return _flat_vectorize(f, n_batch[:1] + (None,) * len(n_batch[1:]), out_axes)

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import functools
+import functools as ft
 
 import jax
 import jax.numpy as jnp
@@ -34,7 +34,7 @@ def catch_xla_runtime_error(func: callable) -> callable:
     # exception message. Note that this will not work for jitted function, as the
     # exception code will be traced out.
 
-    @functools.wraps(func)
+    @ft.wraps(func)
     def wrapper(*args, **kwargs):  # noqa: ANN202
         try:
             return func(*args, **kwargs)
@@ -84,7 +84,6 @@ def _flat_vectorize(
     # todo: write doc
     broadcast_shape = jtu.tree_leaves(n_batch, is_shape)
     broadcast_shape = jnp.broadcast_shapes(*broadcast_shape)
-    print("broadcast_shape", broadcast_shape)
     in_axes = jtu.tree_map(
         lambda x: 0 if len(x) > 0 else None, n_batch, is_leaf=is_shape
     )
@@ -93,6 +92,57 @@ def _flat_vectorize(
         f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
 
     return f
+
+
+def _h_vectorize(f: TimeArray, n_batch, out_axes):
+    """Vectorize a Hamiltonian function.
+
+    Args:
+        f: the Hamiltonian function.
+        n_batch: the batch shape of the Hamiltonian.
+        out_axes: the out axes of the Hamiltonian.
+    """
+    # JAX completely dismisses leaves with a `None` when applying the `tree_map`, so we
+    # need to keep one version of the batch shape with `False` instead of `None`
+    # to keep the structure.
+    n_batch_false = n_batch
+    n_batch = jtu.tree_map(
+        lambda x: x if x != False else None, n_batch_false, is_leaf=is_shape
+    )
+    broadcast_shape = jtu.tree_leaves(n_batch, is_shape)
+    broadcast_shape = jnp.broadcast_shapes(*broadcast_shape)
+
+    def tree_map_fn(i: int, x: tuple[int, ...]) -> int | None:
+        """Args:
+            i: the index in `broadcast_shape`.
+            x: the shape of the leaf.
+
+        Returns:
+            The in axes for the vmap function.
+        """
+        if len(x) <= i or x[len(x) - i - 1] == 1:
+            return None
+        else:
+            return 0
+
+    for i in range(len(broadcast_shape)):
+        in_axes = jtu.tree_map(ft.partial(tree_map_fn, i), n_batch, is_leaf=is_shape)
+        f = jax.vmap(f, in_axes=in_axes, out_axes=out_axes)
+
+    def squeeze_args(size, arg):
+        """Squeeze the all the arguments with a dimension 1."""
+        if is_shape(size):
+            for i, s in enumerate(size):
+                if s == 1:
+                    arg = arg.squeeze(i)
+
+        return arg
+
+    def wrap(*args):
+        squeezed_args = jtu.tree_map(squeeze_args, n_batch_false, args)
+        return f(*squeezed_args)
+
+    return wrap
 
 
 def _cartesian_vectorize(
@@ -121,4 +171,4 @@ def _cartesian_vectorize(
     # We flat vectorize on the first n_batch term, which is the
     # Hamiltonian. This prevents performing the Cartesian product
     # on all terms for the sum Hamiltonian.
-    return _flat_vectorize(f, n_batch[:1] + (None,) * len(n_batch[1:]), out_axes)
+    return _h_vectorize(f, n_batch[:1] + (False,) * len(n_batch[1:]), out_axes)

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -166,9 +166,9 @@ def _vectorized_mesolve(
         def broadcast(x: TimeArray) -> TimeArray:
             return x.broadcast_to(*(broadcast_shape + x.shape[-2:]))
 
-        rho0 = jnp.broadcast_to(rho0, broadcast_shape + rho0.shape[-2:])
         H = broadcast(H)
         jump_ops = list(map(broadcast, jump_ops))
+        rho0 = jnp.broadcast_to(rho0, broadcast_shape + rho0.shape[-2:])
 
     n_batch = (
         H.in_axes,

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -156,7 +156,7 @@ def _vectorized_mesolve(
     # this leaf should be vmapped on.
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = MEResult(None, None, None, None, 0, 0)
+    out_axes = MEResult(False, False, False, False, 0, 0)
 
     # if not options.cartesian_batching:
     #     broadcast_shape = jnp.broadcast_shapes(

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -158,17 +158,11 @@ def _vectorized_mesolve(
     # the result is vectorized over `_saved` and `infos`
     out_axes = MEResult(None, None, None, None, 0, 0)
 
-    if not options.cartesian_batching:
-        broadcast_shape = jnp.broadcast_shapes(
-            H.shape[:-2], rho0.shape[:-2], *[jump_op.shape[:-2] for jump_op in jump_ops]
-        )
-
-        def broadcast(x: TimeArray) -> TimeArray:
-            return x.broadcast_to(*(broadcast_shape + x.shape[-2:]))
-
-        H = broadcast(H)
-        jump_ops = list(map(broadcast, jump_ops))
-        rho0 = jnp.broadcast_to(rho0, broadcast_shape + rho0.shape[-2:])
+    # if not options.cartesian_batching:
+    #     broadcast_shape = jnp.broadcast_shapes(
+    #         H.shape[:-2], rho0.shape[:-2], *[jump_op.shape[:-2] for jump_op in jump_ops]
+    #     )
+    #     rho0 = jnp.broadcast_to(rho0, broadcast_shape + rho0.shape[-2:])
 
     n_batch = (
         H.in_axes,

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -70,16 +70,16 @@ class Result(eqx.Module):
             'Infos   ': self.infos if self.infos is not None else None,
         }
 
-    def __str__(self) -> str:
-        parts = self._str_parts()
-
-        # remove None values
-        parts = {k: v for k, v in parts.items() if v is not None}
-
-        # pad to align colons
-        padding = max(len(k) for k in parts) + 1
-        parts_str = '\n'.join(f'{k:<{padding}}: {v}' for k, v in parts.items())
-        return f'==== {self.__class__.__name__} ====\n' + parts_str
+    # def __str__(self) -> str:
+    #     parts = self._str_parts()
+    #
+    #     # remove None values
+    #     parts = {k: v for k, v in parts.items() if v is not None}
+    #
+    #     # pad to align colons
+    #     padding = max(len(k) for k in parts) + 1
+    #     parts_str = '\n'.join(f'{k:<{padding}}: {v}' for k, v in parts.items())
+    #     return f'==== {self.__class__.__name__} ====\n' + parts_str
 
     def to_qutip(self) -> Result:
         raise NotImplementedError

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -70,16 +70,16 @@ class Result(eqx.Module):
             'Infos   ': self.infos if self.infos is not None else None,
         }
 
-    # def __str__(self) -> str:
-    #     parts = self._str_parts()
-    #
-    #     # remove None values
-    #     parts = {k: v for k, v in parts.items() if v is not None}
-    #
-    #     # pad to align colons
-    #     padding = max(len(k) for k in parts) + 1
-    #     parts_str = '\n'.join(f'{k:<{padding}}: {v}' for k, v in parts.items())
-    #     return f'==== {self.__class__.__name__} ====\n' + parts_str
+    def __str__(self) -> str:
+        parts = self._str_parts()
+
+        # remove None values
+        parts = {k: v for k, v in parts.items() if v is not None}
+
+        # pad to align colons
+        padding = max(len(k) for k in parts) + 1
+        parts_str = '\n'.join(f'{k:<{padding}}: {v}' for k, v in parts.items())
+        return f'==== {self.__class__.__name__} ====\n' + parts_str
 
     def to_qutip(self) -> Result:
         raise NotImplementedError

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -149,7 +149,7 @@ def _vectorized_sesolve(
     )
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = SEResult(None, None, None, None, 0, 0)
+    out_axes = SEResult(False, False, False, False, 0, 0)
 
     # compute vectorized function with given batching strategy
     if options.cartesian_batching:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -329,8 +329,8 @@ class TimeArray(eqx.Module):
     def __rsub__(self, y: ArrayLike | TimeArray) -> TimeArray:
         return y + (-self)
 
-    # def __repr__(self) -> str:
-    #     return f'{type(self).__name__}(shape={self.shape}, dtype={self.dtype})'
+    def __repr__(self) -> str:
+        return f'{type(self).__name__}(shape={self.shape}, dtype={self.dtype})'
 
 
 class ConstantTimeArray(TimeArray):
@@ -658,7 +658,7 @@ class BatchedCallable(eqx.Module):
     def conj(self) -> BatchedCallable:
         return BatchedCallable(lambda t: self.f(t).conj())
 
-    def squeeze(self, i) -> BatchedCallable:
+    def squeeze(self, i: int) -> BatchedCallable:
         return BatchedCallable(lambda t: jnp.squeeze(self.f(t), i))
 
     def __neg__(self) -> BatchedCallable:

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -664,5 +664,5 @@ class BatchedCallable(eqx.Module):
     def __neg__(self) -> BatchedCallable:
         return BatchedCallable(lambda t: -self.f(t))
 
-    def __mul__(self, other: Array) -> BatchedCallable:
-        return BatchedCallable(lambda t: self.f(t) * other)
+    def __mul__(self, y: ArrayLike) -> BatchedCallable:
+        return BatchedCallable(lambda t: self.f(t) * y)

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -540,7 +540,7 @@ class CallableTimeArray(TimeArray):
         return CallableTimeArray(f, self._disc_ts)
 
     def broadcast_to(self, *new_shape: int) -> TimeArray:
-        f = self.f.broadcast_to(new_shape)
+        f = self.f.broadcast_to(*new_shape)
         return CallableTimeArray(f, self._disc_ts)
 
     def conj(self) -> TimeArray:
@@ -561,23 +561,15 @@ class CallableTimeArray(TimeArray):
     def __add__(self, other: ArrayLike | TimeArray) -> TimeArray:
         if isinstance(other, get_args(ArrayLike)):
             other = ConstantTimeArray(jnp.asarray(other, dtype=cdtype()))
-            return SummedTimeArray.new([self, other])
+            return SummedTimeArray([self, other])
         elif isinstance(other, TimeArray):
-            return SummedTimeArray.new([self, other])
+            return SummedTimeArray([self, other])
         else:
             return NotImplemented
 
 
 class SummedTimeArray(TimeArray):
     timearrays: list[TimeArray]
-
-    @staticmethod
-    def new(timearrays):
-        broadcast_shape = jnp.broadcast_shapes(*[tarray.shape for tarray in timearrays])
-        for tarray in timearrays:
-            tarray = tarray.broadcast_to(*broadcast_shape)
-            timearrays.append(tarray)
-        return SummedTimeArray(timearrays)
 
     @property
     def dtype(self) -> np.dtype:

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -56,3 +56,26 @@ def test_flat_batching(nL1, npsi0):
     broadcast_shape = jnp.broadcast_shapes(nH, nL1, npsi0)
     assert result.states.shape == (*broadcast_shape, ntsave, n, n)
     assert result.expects.shape == (*broadcast_shape, nEs, ntsave)
+
+
+def test_batching_boris():
+    n = 9
+    a = dq.destroy(n)
+
+    # first modulated operator (20, 1, 9, 9)
+    omega1 = jnp.linspace(0, 1, 20)[None, :]
+    f = lambda t: jnp.cos(omega1 * t)
+    H1 = dq.modulated(f, a + dq.dag(a))
+
+    # second modulated operator 2 (1, 30, 9, 9)
+    omega2 = jnp.linspace(0, 1, 30)[:, None]
+    f = lambda t: jnp.cos(omega2 * t)
+    H2 = dq.modulated(f, 1j * a - 1j * dq.dag(a))
+
+    # Hamiltonian
+    H = H1 + H2
+
+    rho0 = dq.fock_dm(n, 1)  # (4, 9, 9)
+    jump_ops = [a]
+    result = dq.mesolve(H, jump_ops, rho0, [0, 1])
+    print(result.states.shape)

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -75,7 +75,7 @@ def test_batching_boris():
     # Hamiltonian
     H = H1 + H2
 
-    rho0 = dq.fock_dm(n, 1)  # (4, 9, 9)
+    rho0 = dq.fock_dm(n, range(3))  # (4, 9, 9)
     jump_ops = [a]
     result = dq.mesolve(H, jump_ops, rho0, [0, 1])
-    print(result.states.shape)
+    assert result.states.shape == (30, 1, 20, 1, 3, 2, 9, 9)

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -62,20 +62,20 @@ def test_batching_boris():
     n = 9
     a = dq.destroy(n)
 
-    # first modulated operator (20, 1, 9, 9)
-    omega1 = jnp.linspace(0, 1, 20)[None, :]
+    # first modulated operator (1, 5, 9, 9)
+    omega1 = jnp.linspace(0, 1, 5)[None, :]
     f = lambda t: jnp.cos(omega1 * t)
     H1 = dq.modulated(f, a + dq.dag(a))
 
-    # second modulated operator 2 (1, 30, 9, 9)
-    omega2 = jnp.linspace(0, 1, 30)[:, None]
+    # second modulated operator 2 (7, 1, 9, 9)
+    omega2 = jnp.linspace(0, 1, 7)[:, None]
     f = lambda t: jnp.cos(omega2 * t)
     H2 = dq.modulated(f, 1j * a - 1j * dq.dag(a))
 
     # Hamiltonian
     H = H1 + H2
 
-    rho0 = dq.fock_dm(n, range(3))  # (4, 9, 9)
+    rho0 = dq.fock_dm(n, range(3))  # (3, 9, 9)
     jump_ops = [a]
     result = dq.mesolve(H, jump_ops, rho0, [0, 1])
-    assert result.states.shape == (30, 20, 3, 2, 9, 9)
+    assert result.states.shape == (7, 5, 3, 2, 9, 9)

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -63,12 +63,12 @@ def test_batching_boris():
     a = dq.destroy(n)
 
     # first modulated operator (20, 1, 9, 9)
-    omega1 = jnp.linspace(0, 1, 20)[None, None, :, None]
+    omega1 = jnp.linspace(0, 1, 20)[None, :]
     f = lambda t: jnp.cos(omega1 * t)
     H1 = dq.modulated(f, a + dq.dag(a))
 
     # second modulated operator 2 (1, 30, 9, 9)
-    omega2 = jnp.linspace(0, 1, 30)[:, None, None, None]
+    omega2 = jnp.linspace(0, 1, 30)[:, None]
     f = lambda t: jnp.cos(omega2 * t)
     H2 = dq.modulated(f, 1j * a - 1j * dq.dag(a))
 
@@ -78,4 +78,4 @@ def test_batching_boris():
     rho0 = dq.fock_dm(n, range(3))  # (4, 9, 9)
     jump_ops = [a]
     result = dq.mesolve(H, jump_ops, rho0, [0, 1])
-    assert result.states.shape == (30, 1, 20, 1, 3, 2, 9, 9)
+    assert result.states.shape == (30, 20, 3, 2, 9, 9)

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -63,12 +63,12 @@ def test_batching_boris():
     a = dq.destroy(n)
 
     # first modulated operator (20, 1, 9, 9)
-    omega1 = jnp.linspace(0, 1, 20)[None, :]
+    omega1 = jnp.linspace(0, 1, 20)[None, None, :, None]
     f = lambda t: jnp.cos(omega1 * t)
     H1 = dq.modulated(f, a + dq.dag(a))
 
     # second modulated operator 2 (1, 30, 9, 9)
-    omega2 = jnp.linspace(0, 1, 30)[:, None]
+    omega2 = jnp.linspace(0, 1, 30)[:, None, None, None]
     f = lambda t: jnp.cos(omega2 * t)
     H2 = dq.modulated(f, 1j * a - 1j * dq.dag(a))
 


### PR DESCRIPTION
This PR fixes time arrays and especially sum of two time arrays that have different but broadcastable shapes. It paves the wave for getting rid of broadcasting altogether in me/sesolve functions.

Todo in follow up PR:
- [ ] More extensive test of time arrays (heterogene types, shapes, ...) 

Replaces https://github.com/dynamiqs/dynamiqs/pull/568
Closes https://linear.app/dynamiqs/issue/DYN-221/fix-time-array-bugs