### PR TITLE
Small timearray improvements (renaming and readability)

### DIFF
--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -581,11 +581,13 @@ class SummedTimeArray(TimeArray):
 
     @property
     def mT(self) -> TimeArray:
-        return SummedTimeArray([tarray.mT for tarray in self.timearrays])
+        timearrays = [tarray.mT for tarray in self.timearrays]
+        return SummedTimeArray(timearrays)
 
     @property
     def in_axes(self) -> PyTree[int]:
-        return SummedTimeArray([tarray.in_axes for tarray in self.timearrays])
+        timearrays = [tarray.in_axes for tarray in self.timearrays]
+        return SummedTimeArray(timearrays)
 
     @property
     def discontinuity_ts(self) -> Array | None:
@@ -593,15 +595,16 @@ class SummedTimeArray(TimeArray):
         return _concatenate_sort(*ts)
 
     def reshape(self, *shape: int) -> TimeArray:
-        return SummedTimeArray([tarray.reshape(*shape) for tarray in self.timearrays])
+        timearrays = [tarray.reshape(*shape) for tarray in self.timearrays]
+        return SummedTimeArray(timearrays)
 
     def broadcast_to(self, *shape: int) -> TimeArray:
-        return SummedTimeArray(
-            [tarray.broadcast_to(*shape) for tarray in self.timearrays]
-        )
+        timearrays = [tarray.broadcast_to(*shape) for tarray in self.timearrays]
+        return SummedTimeArray(timearrays)
 
     def conj(self) -> TimeArray:
-        return SummedTimeArray([tarray.conj() for tarray in self.timearrays])
+        timearrays = [tarray.conj() for tarray in self.timearrays]
+        return SummedTimeArray(timearrays)
 
     def __call__(self, t: ScalarLike) -> Array:
         return jax.tree_util.tree_reduce(
@@ -609,10 +612,12 @@ class SummedTimeArray(TimeArray):
         )
 
     def __neg__(self) -> TimeArray:
-        return SummedTimeArray([-tarray for tarray in self.timearrays])
+        timearrays = [-tarray for tarray in self.timearrays]
+        return SummedTimeArray(timearrays)
 
     def __mul__(self, y: ArrayLike) -> TimeArray:
-        return SummedTimeArray([tarray * y for tarray in self.timearrays])
+        timearrays = [tarray * y for tarray in self.timearrays]
+        return SummedTimeArray(timearrays)
 
     def __add__(self, other: ArrayLike | TimeArray) -> TimeArray:
         if isinstance(other, get_args(ArrayLike)):
@@ -648,19 +653,25 @@ class BatchedCallable(eqx.Module):
         return jax.eval_shape(self.f, 0.0).shape
 
     def reshape(self, *shape: tuple[int, ...]) -> BatchedCallable:
-        return BatchedCallable(lambda t: self.f(t).reshape(shape))
+        f = lambda t: self.f(t).reshape(shape)
+        return BatchedCallable(f)
 
     def broadcast_to(self, *shape: tuple[int, ...]) -> BatchedCallable:
-        return BatchedCallable(lambda t: jnp.broadcast_to(self.f(t), shape))
+        f = lambda t: jnp.broadcast_to(self.f(t), shape)
+        return BatchedCallable(f)
 
     def conj(self) -> BatchedCallable:
-        return BatchedCallable(lambda t: self.f(t).conj())
+        f = lambda t: self.f(t).conj()
+        return BatchedCallable(f)
 
     def squeeze(self, i: int) -> BatchedCallable:
-        return BatchedCallable(lambda t: jnp.squeeze(self.f(t), i))
+        f = lambda t: jnp.squeeze(self.f(t), i)
+        return BatchedCallable(f)
 
     def __neg__(self) -> BatchedCallable:
-        return BatchedCallable(lambda t: -self.f(t))
+        f = lambda t: -self.f(t)
+        return BatchedCallable(f)
 
     def __mul__(self, y: ArrayLike) -> BatchedCallable:
-        return BatchedCallable(lambda t: self.f(t) * y)
+        f = lambda t: self.f(t) * y
+        return BatchedCallable(f)

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -7,7 +7,6 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
-import numpy as np
 from jax import Array, lax
 from jaxtyping import ArrayLike, PyTree, Scalar, ScalarLike
 
@@ -211,7 +210,7 @@ class TimeArray(eqx.Module):
 
     @property
     @abstractmethod
-    def dtype(self) -> np.dtype:
+    def dtype(self) -> jnp.dtype:
         pass
 
     @property
@@ -337,7 +336,7 @@ class ConstantTimeArray(TimeArray):
     array: Array
 
     @property
-    def dtype(self) -> np.dtype:
+    def dtype(self) -> jnp.dtype:
         return self.array.dtype
 
     @property
@@ -391,7 +390,7 @@ class PWCTimeArray(TimeArray):
     array: Array  # (n, n)
 
     @property
-    def dtype(self) -> np.dtype:
+    def dtype(self) -> jnp.dtype:
         return self.array.dtype
 
     @property
@@ -459,7 +458,7 @@ class ModulatedTimeArray(TimeArray):
     _disc_ts: Array | None
 
     @property
-    def dtype(self) -> np.dtype:
+    def dtype(self) -> jnp.dtype:
         return self.array.dtype
 
     @property
@@ -515,7 +514,7 @@ class CallableTimeArray(TimeArray):
     _disc_ts: Array | None
 
     @property
-    def dtype(self) -> np.dtype:
+    def dtype(self) -> jnp.dtype:
         return self.f.dtype
 
     @property
@@ -572,7 +571,7 @@ class SummedTimeArray(TimeArray):
     timearrays: list[TimeArray]
 
     @property
-    def dtype(self) -> np.dtype:
+    def dtype(self) -> jnp.dtype:
         return self.timearrays[0].dtype
 
     @property


### PR DESCRIPTION
Small PRs with a few various things on time-array
- the renaming of `new_shape` to `shape` is to match JAX/Numpy API
- splitting assignement vs class initialisation is just a proposition for readability
- replace `np.dtype` with `jnp.dtype` to uniformize with `QArray`
- implement `__neg__` in the base clas