### PR TITLE
Fix infos precision for batched simulation

### DIFF
--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -114,8 +114,8 @@ class AdaptiveSolver(DiffraxSolver):
         def __str__(self) -> str:
             if self.nsteps.ndim >= 1:
                 return (
-                    f'avg. {self.nsteps.mean()} steps ({self.naccepted.mean()}'
-                    f' accepted, {self.nrejected.mean()} rejected) | infos shape'
+                    f'avg. {self.nsteps.mean():.1f} steps ({self.naccepted.mean():.1f}'
+                    f' accepted, {self.nrejected.mean():.1f} rejected) | infos shape'
                     f' {self.nsteps.shape}'
                 )
             return (

--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -21,7 +21,7 @@ class PropagatorSolver(BaseSolver):
                 # note: propagator solvers can make different number of steps between
                 # batch elements when batching over PWC objects
                 return (
-                    f'avg. {self.nsteps.mean()} steps | infos shape'
+                    f'avg. {self.nsteps.mean():.1f} steps | infos shape'
                     f' {self.nsteps.shape}'
                 )
             return f'{self.nsteps} steps'


### PR DESCRIPTION
Before:
```
|██████████| 100.0% ◆ total 0.15s ◆ remaining 00:00
==== SEResult ====
Solver   : NoneType
States   : Array complex64 (2, 3, 2, 16, 1) | 1.50 Kb
Infos    : avg. 1019.1666870117188 steps (1018.0 accepted, 1.1666667461395264 rejected) | infos shape (2, 3)
```
After:
```
|██████████| 100.0% ◆ total 0.13s ◆ remaining 00:00
==== SEResult ====
Solver   : NoneType
States   : Array complex64 (2, 3, 2, 16, 1) | 1.50 Kb
Infos    : avg. 1019.2 steps (1018.0 accepted, 1.2 rejected) | infos shape (2, 3)
```

Code:
```python
import dynamiqs as dq
n = 16
a = dq.destroy(n)
adag = dq.dag(a)
H = [adag @ a, 100 * adag @ a]
psi0 = dq.coherent(n, [1, 2, 3])
print(dq.sesolve(H, psi0, [0, 1]))
```