### PR TITLE
Exclude JIT time from batching tutorial benchmarking

### DIFF
--- a/docs/documentation/basics/batching-simulations.md
+++ b/docs/documentation/basics/batching-simulations.md
@@ -243,6 +243,10 @@ def run_unbatched():
 def run_batched():
     return dq.sesolve(H, psi0, tsave, options=options)
 
+# exclude JIT time from benchmarking by running each function once first
+%timeit -n1 -r1 -q run_unbatched()
+%timeit -n1 -r1 -q run_batched()
+
 # time functions
 %timeit run_unbatched()
 %timeit run_batched()


### PR DESCRIPTION
It doesn't change anything to the result, but I would be suspicious of them at first read without these lines. This is a bit more rigorous. It ouptuts nothing bc we use `-q`.