### PR TITLE
New progress meter format that suits any duration

### DIFF
--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 
 import diffrax as dx
 import equinox as eqx
-import tqdm
+from tqdm import tqdm
 
 __all__ = [
     'AbstractProgressMeter',
@@ -28,14 +28,51 @@ class TextProgressMeter(AbstractProgressMeter):
         return dx.TextProgressMeter()
 
 
+def format_duration(duration_s: float) -> str:
+    hours, remainder = divmod(duration_s, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    milliseconds = seconds * 1000
+
+    if hours > 0:  # e.g. 34h07m37s
+        return f'{hours:02.0f}h{minutes:02.0f}m{seconds:02.0f}s'
+    elif minutes > 0:  # e.g. 07m37s
+        return f'{minutes:02.0f}m{seconds:02.0f}s'
+    elif seconds >= 1:  # e.g. 56.79s
+        return f'{seconds:.2f}s'
+    else:  # e.g. 789.12ms
+        return f'{milliseconds:.2f}ms'
+
+
+class _TqdmCustom(tqdm):
+    @property
+    def format_dict(self):  # noqa: ANN202
+        d = super().format_dict
+
+        # compute and format remaining
+        n, total, rate, elapsed = (d[k] for k in ['n', 'total', 'rate', 'elapsed'])
+        if elapsed == 0:
+            remaining_custom = '?'
+        else:
+            remaining = (total - n) / rate if rate and total else 0
+            remaining_custom = format_duration(remaining)
+
+        # format elapsed
+        elapsed_custom = format_duration(elapsed)
+
+        # update dict
+        d.update(elapsed_custom=elapsed_custom, remaining_custom=remaining_custom)
+
+        return d
+
+
 class _DiffraxTqdmProgressMeter(dx.TqdmProgressMeter):
     @staticmethod
-    def _init_bar() -> tqdm.tqdm:
+    def _init_bar() -> tqdm:
         bar_format = (
-            '|{bar}| {percentage:5.1f}% ◆ total {elapsed_s:.2f}s '
-            '◆ remaining {remaining}'
+            '|{bar}| {percentage:5.1f}% ◆ elapsed {elapsed_custom} '
+            '◆ remaining {remaining_custom}'
         )
-        return tqdm.tqdm(total=100, unit='%', bar_format=bar_format)
+        return _TqdmCustom(total=100, unit='%', bar_format=bar_format)
 
 
 class TqdmProgressMeter(AbstractProgressMeter):


### PR DESCRIPTION
Related to DYN-213.

Example output:
```
|███████▏  |  72.2% ◆ elapsed 3.12ms ◆ remaining 0.20ms
|███████▏  |  72.2% ◆ elapsed 4.70s ◆ remaining 1.23s
|███████▏  |  72.2% ◆ elapsed 03m45s ◆ remaining 01m12s
|███████▏  |  72.2% ◆ elapsed 01h13m45s ◆ remaining 12.4s
```