### PR TITLE
Update qutip minimal version from 4.0 to 4.7.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ version = "0.2.0"
 requires-python = ">=3.9"
 description = "Quantum systems simulation with JAX."
 dependencies = [
-    "qutip>=4.0,<5.0",
-    "scipy<=1.12",  # fix QuTiP unspecified dependency on scipy
+    "qutip>=4.7.5,<5.0",
+    "scipy",
     "numpy",
     "matplotlib",
     "tqdm",


### PR DESCRIPTION
On QuTiP<=4.7.1, `import dynamiqs` raises:
```python
AttributeError: property 'format' of 'fast_csr_matrix' object has no setter
```
On QuTiP<=4.7.4 and scipy>=1.13.0, `import dynamiqs` raises:
```python
ImportError: cannot import name 'array' from 'scipy' (/Users/rgautier/miniconda3/lib/python3.11/site-packages/scipy/__init__.py)
```

Both errors come from QuTiP, so I suggest raising the QuTiP minimal version and removing the scipy version dependency.