### PR TITLE
Add progress meter output to documentation and replace `np.*` by `jnp.*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ print(result)
 ```
 
 ```text
+|██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
 ==== MEResult ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
@@ -105,6 +106,7 @@ print(f'Gradient w.r.t. alpha={grads[2]:.2f}')
 ```
 
 ```text
+|██████████| 100.0% ◆ elapsed 86.63ms ◆ remaining 0.00ms
 Gradient w.r.t. omega=0.00
 Gradient w.r.t. kappa=-0.90
 Gradient w.r.t. alpha=1.81

--- a/docs/documentation/basics/closed-systems.md
+++ b/docs/documentation/basics/closed-systems.md
@@ -105,6 +105,7 @@ print(res.states[-1])             # print the final state
 ```
 
 ```text title="Output"
+|██████████| 100.0% ◆ elapsed 2.52ms ◆ remaining 0.00ms
 Array([[0.  +0.j   ],
        [0.54+0.841j]], dtype=complex64)
 ```

--- a/docs/documentation/basics/open-systems.md
+++ b/docs/documentation/basics/open-systems.md
@@ -120,6 +120,7 @@ print(res.states[-1])                       # print the final state
 ```
 
 ```text title="Output"
+|██████████| 100.0% ◆ elapsed 4.47ms ◆ remaining 0.00ms
 Array([[0.368+0.j, 0.   +0.j],
        [0.   +0.j, 0.632+0.j]], dtype=complex64)
 ```

--- a/docs/documentation/basics/workflow.md
+++ b/docs/documentation/basics/workflow.md
@@ -76,6 +76,7 @@ print(result)
 ```
 
 ```text title="Output"
+|██████████| 100.0% ◆ elapsed 3.25ms ◆ remaining 0.00ms
 `result` is of type <class 'dynamiqs.result.SEResult'>.
 `result` has the following attributes:
 ['Esave', '_abc_impl', 'expects', 'gradient', 'options', 'solver', 'states', 'to_numpy', 'to_qutip', 'tsave', 'ysave']

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -29,6 +29,7 @@ print(result)
 ```
 
 ```text title="Output"
+|██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
 ==== MEResult ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
@@ -73,6 +74,7 @@ print(f'Gradient w.r.t. alpha={grads[2]:.2f}')
 ```
 
 ```text title="Output"
+|██████████| 100.0% ◆ elapsed 86.63ms ◆ remaining 0.00ms
 Gradient w.r.t. omega=0.00
 Gradient w.r.t. kappa=-0.90
 Gradient w.r.t. alpha=1.81

--- a/dynamiqs/plots/plots_fock.py
+++ b/dynamiqs/plots/plots_fock.py
@@ -112,7 +112,7 @@ def plot_fock_evolution(
         >>> a = dq.destroy(n)
         >>> psi0 = dq.coherent(n, 0.0)
         >>> H = 2.0 * (a + dq.dag(a))
-        >>> tsave = np.linspace(0, 1.0, 11)
+        >>> tsave = jnp.linspace(0, 1.0, 11)
         >>> result = dq.sesolve(H, psi0, tsave)
         >>> dq.plot_fock_evolution(result.states, times=tsave)
         >>> renderfig('plot_fock_evolution')

--- a/dynamiqs/plots/plots_hinton.py
+++ b/dynamiqs/plots/plots_hinton.py
@@ -177,7 +177,7 @@ def plot_hinton(
         >>> _, axs = dq.gridplot(2)
         >>> x = np.random.uniform(-1.0, 1.0, (10, 10))
         >>> dq.plot_hinton(x, ax=next(axs), vmin=-1.0, vmax=1.0)
-        >>> dq.plot_hinton(np.abs(x), ax=next(axs), cmap='Greys', vmax=1.0, ecolor='black')
+        >>> dq.plot_hinton(jnp.abs(x), ax=next(axs), cmap='Greys', vmax=1.0, ecolor='black')
         >>> renderfig('plot_hinton_real')
 
         ![plot_hinton_real](/figs_code/plot_hinton_real.png){.fig-half}

--- a/dynamiqs/plots/plots_misc.py
+++ b/dynamiqs/plots/plots_misc.py
@@ -27,7 +27,7 @@ def plot_pwc_pulse(
 
     Examples:
         >>> n = 20
-        >>> times = np.linspace(0, 1.0, n + 1)
+        >>> times = jnp.linspace(0, 1.0, n + 1)
         >>> key = jax.random.PRNGKey(42)
         >>> values = dq.rand_complex(key, n)
         >>> dq.plot_pwc_pulse(times, values)

--- a/dynamiqs/plots/plots_wigner.py
+++ b/dynamiqs/plots/plots_wigner.py
@@ -179,7 +179,7 @@ def plot_wigner_mosaic(
         >>> H = dq.zero(n)
         >>> jump_ops = [a @ a - 4.0 * dq.eye(n)]  # cat state inflation
         >>> psi0 = dq.coherent(n, 0)
-        >>> tsave = np.linspace(0, 1.0, 101)
+        >>> tsave = jnp.linspace(0, 1.0, 101)
         >>> result = dq.mesolve(H, jump_ops, psi0, tsave)
         >>> dq.plot_wigner_mosaic(result.states, n=6, xmax=4.0, ymax=2.0)
         >>> renderfig('plot_wigner_mosaic_cat')
@@ -190,7 +190,7 @@ def plot_wigner_mosaic(
         >>> a = dq.destroy(n)
         >>> H = dq.dag(a) @ dq.dag(a) @ a @ a  # Kerr Hamiltonian
         >>> psi0 = dq.coherent(n, 2)
-        >>> tsave = np.linspace(0, np.pi, 101)
+        >>> tsave = jnp.linspace(0, jnp.pi, 101)
         >>> result = dq.sesolve(H, psi0, tsave)
         >>> dq.plot_wigner_mosaic(result.states, n=25, nrows=5, xmax=4.0)
         >>> renderfig('plot_wigner_mosaic_kerr')
@@ -275,7 +275,7 @@ def plot_wigner_gif(
         >>> H = dq.zero(n)
         >>> jump_ops = [a @ a - 4.0 * dq.eye(n)]  # cat state inflation
         >>> psi0 = dq.coherent(n, 0)
-        >>> tsave = np.linspace(0, 1.0, 1001)
+        >>> tsave = jnp.linspace(0, 1.0, 1001)
         >>> result = dq.mesolve(H, jump_ops, psi0, tsave)
         >>> dq.plot_wigner_gif(
         ...     result.states,
@@ -293,7 +293,7 @@ def plot_wigner_gif(
         >>> a = dq.destroy(n)
         >>> H = dq.dag(a) @ dq.dag(a) @ a @ a  # Kerr Hamiltonian
         >>> psi0 = dq.coherent(n, 2)
-        >>> tsave = np.linspace(0, np.pi, 1001)
+        >>> tsave = jnp.linspace(0, jnp.pi, 1001)
         >>> result = dq.sesolve(H, psi0, tsave)
         >>> dq.plot_wigner_gif(
         ...     result.states,

--- a/dynamiqs/plots/utils.py
+++ b/dynamiqs/plots/utils.py
@@ -97,8 +97,8 @@ def gridplot(
     Examples:
         For example, to plot six different curves:
 
-        >>> x = np.linspace(0, 1, 101)
-        >>> ys = [np.sin(f * 2 * np.pi * x) for f in range(6)]  # (6, 101)
+        >>> x = jnp.linspace(0, 1, 101)
+        >>> ys = [jnp.sin(f * 2 * jnp.pi * x) for f in range(6)]  # (6, 101)
 
         Replace the usual Matplotlib code
 
@@ -155,8 +155,8 @@ def mplstyle(*, usetex: bool = False):
         Documentation redaction in progress.
 
     Examples:
-        >>> x = np.linspace(0, 2 * np.pi, 101)
-        >>> ys = [np.sin(x), np.sin(2 * x), np.sin(3 * x)]
+        >>> x = jnp.linspace(0, 2 * jnp.pi, 101)
+        >>> ys = [jnp.sin(x), jnp.sin(2 * x), jnp.sin(3 * x)]
         >>> default_mpl_style()
 
         Before (default Matplotlib style):

--- a/dynamiqs/utils/random.py
+++ b/dynamiqs/utils/random.py
@@ -64,7 +64,7 @@ def rand_complex(
         ax0.scatter(x.real, x.imag, s=1.0)
 
         # option 2: uniformly distributed magnitude and phase
-        x = np.random.rand(n) * np.exp(1j * 2 * np.pi * np.random.rand(n))
+        x = np.random.rand(n) * jnp.exp(1j * 2 * jnp.pi * np.random.rand(n))
         ax1.scatter(x.real, x.imag, s=1.0)
 
         # option 3: uniformly distributed in a disk (in dynamiqs)


### PR DESCRIPTION
Relates to DYN-213.

Regex to find `np.*` occurences in e.g. vscode: `[^j]np\.` 😉

![Screenshot 2024-06-24 at 13 39 54](https://github.com/dynamiqs/dynamiqs/assets/38159029/34cfbf1a-670e-4d3a-b550-5fb70777c37b)
