### PR TITLE
Start integrating `QArray` into `sesolve` and `mesolve`

### DIFF
--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -9,23 +9,10 @@ from jax._src.lib import xla_client
 from jaxtyping import ArrayLike, PyTree
 
 from .._utils import obj_type_str
-from ..qarrays import QArray, dense_qarray
+from ..qarrays.types import asqarray
 from ..solver import Solver, _ODEAdaptiveStep
 from ..time_array import ConstantTimeArray, Shape, TimeArray
 from .abstract_solver import AbstractSolver
-
-
-def _asqarray(x: ArrayLike) -> QArray:
-    if isinstance(x, QArray):
-        return x
-    else:
-        try:
-            return dense_qarray(x)
-        except (TypeError, ValueError) as e:
-            raise TypeError(
-                'Argument must be an array-like or a quantum array object, but has'
-                f' type {obj_type_str(x)}.'
-            ) from e
 
 
 def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
@@ -34,7 +21,7 @@ def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
     else:
         try:
             # same as dq.constant() but not checking the shape
-            array = _asqarray(x)
+            array = asqarray(x)
             return ConstantTimeArray(array)
         except (TypeError, ValueError) as e:
             raise TypeError(

--- a/dynamiqs/core/_utils.py
+++ b/dynamiqs/core/_utils.py
@@ -6,16 +6,16 @@ import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 from jax._src.lib import xla_client
-from jaxtyping import ArrayLike, PyTree
+from jaxtyping import PyTree
 
 from .._utils import obj_type_str
-from ..qarrays.types import asqarray
+from ..qarrays import QArrayLike, asqarray
 from ..solver import Solver, _ODEAdaptiveStep
 from ..time_array import ConstantTimeArray, Shape, TimeArray
 from .abstract_solver import AbstractSolver
 
 
-def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
+def _astimearray(x: QArrayLike | TimeArray) -> TimeArray:
     if isinstance(x, TimeArray):
         return x
     else:
@@ -25,7 +25,7 @@ def _astimearray(x: ArrayLike | TimeArray) -> TimeArray:
             return ConstantTimeArray(array)
         except (TypeError, ValueError) as e:
             raise TypeError(
-                'Argument must be an array-like or a time-array object, but has type'
+                'Argument must be a qarray-like or a time-array object, but has type'
                 f' {obj_type_str(x)}.'
             ) from e
 

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -10,7 +10,6 @@ from jaxtyping import ArrayLike
 
 from .._checks import check_shape, check_times
 from ..core._utils import (
-    _asqarray,
     _astimearray,
     _cartesian_vectorize,
     _flat_vectorize,
@@ -19,6 +18,7 @@ from ..core._utils import (
 )
 from ..gradient import Gradient
 from ..options import Options
+from ..qarrays.types import asqarray
 from ..result import MEResult
 from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import Shape, TimeArray
@@ -101,9 +101,9 @@ def mesolve(
     # === convert arguments
     H = _astimearray(H)
     jump_ops = [_astimearray(L) for L in jump_ops]
-    rho0 = _asqarray(rho0)
+    rho0 = asqarray(rho0)
     tsave = jnp.asarray(tsave)
-    exp_ops = _asqarray(exp_ops) if exp_ops is not None else None
+    exp_ops = asqarray(exp_ops) if exp_ops is not None else None
 
     # === check arguments
     _check_mesolve_args(H, jump_ops, rho0, exp_ops)

--- a/dynamiqs/mesolve/mesolve.py
+++ b/dynamiqs/mesolve/mesolve.py
@@ -9,8 +9,8 @@ from jax import Array
 from jaxtyping import ArrayLike
 
 from .._checks import check_shape, check_times
-from .._utils import cdtype
 from ..core._utils import (
+    _asqarray,
     _astimearray,
     _cartesian_vectorize,
     _flat_vectorize,
@@ -101,9 +101,9 @@ def mesolve(
     # === convert arguments
     H = _astimearray(H)
     jump_ops = [_astimearray(L) for L in jump_ops]
-    rho0 = jnp.asarray(rho0, dtype=cdtype())
+    rho0 = _asqarray(rho0)
     tsave = jnp.asarray(tsave)
-    exp_ops = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
+    exp_ops = _asqarray(exp_ops) if exp_ops is not None else None
 
     # === check arguments
     _check_mesolve_args(H, jump_ops, rho0, exp_ops)

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -5,13 +5,24 @@ from typing import get_args
 import jax
 import jax.numpy as jnp
 import numpy as np
-from equinox.internal._omega import _Metaω
 from jax import Array, Device
 from jaxtyping import ScalarLike
 from qutip import Qobj
 
 from ..utils.jax_utils import to_qutip
-from ..utils.utils.general import norm, ptrace
+from ..utils.utils.general import (
+    dag,
+    isbra,
+    isdm,
+    isket,
+    isop,
+    norm,
+    ptrace,
+    tensor,
+    tobra,
+    todm,
+    toket,
+)
 from .qarray import QArray
 from .types import QArrayLike, asjaxarray
 
@@ -191,12 +202,7 @@ class DenseQArray(QArray):
 
         return DenseQArray(dims, data)
 
-    def __pow__(self, power: int) -> QArray:
-        # to deal with the x**ω notation from equinox (used in diffrax internals)
-        if isinstance(power, _Metaω):
-            return _Metaω.__rpow__(power, self)
-
-        super().__pow__(power)
+    def _pow(self, power: int) -> QArray:
         data = self.data**power
         return DenseQArray(self.dims, data)
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -5,6 +5,7 @@ from typing import get_args
 import jax
 import jax.numpy as jnp
 import numpy as np
+from equinox.internal._omega import _Metaω
 from jax import Array, Device
 from jaxtyping import ScalarLike
 from qutip import Qobj
@@ -191,6 +192,10 @@ class DenseQArray(QArray):
         return DenseQArray(dims, data)
 
     def __pow__(self, power: int) -> QArray:
+        # to deal with the x**ω notation from equinox (used in diffrax internals)
+        if isinstance(power, _Metaω):
+            return _Metaω.__rpow__(power, self)
+
         super().__pow__(power)
         data = self.data**power
         return DenseQArray(self.dims, data)

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -10,19 +10,7 @@ from jaxtyping import ScalarLike
 from qutip import Qobj
 
 from ..utils.jax_utils import to_qutip
-from ..utils.utils.general import (
-    dag,
-    isbra,
-    isdm,
-    isket,
-    isop,
-    norm,
-    ptrace,
-    tensor,
-    tobra,
-    todm,
-    toket,
-)
+from ..utils.utils.general import norm, ptrace
 from .qarray import QArray
 from .types import QArrayLike, asjaxarray
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -194,3 +194,7 @@ class DenseQArray(QArray):
         super().__pow__(power)
         data = self.data**power
         return DenseQArray(self.dims, data)
+
+    def __getitem__(self, key: int | slice) -> QArray:
+        data = self.data[key]
+        return DenseQArray(self.dims, data)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -33,11 +33,11 @@ class QArray(eqx.Module):
     #   - returning a JAX array or other: norm, trace, sum, squeeze, _eigh, _eigvals,
     #                                     _eigvalsh, devices, isherm
     #   - conversion methods: to_qutip, to_jax, __array__
-    #   - arithmetic methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
+    #   - special methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
     #                         __and__, _pow, __getitem__
 
-    # Setting dims as static for now. Otherwise, I believe it is upgraded to a complex
-    # dtype during the computation, which raises an error on diffrax side.
+    # TODO: Setting dims as static for now. Otherwise, I believe it is upgraded to a
+    # complex dtype during the computation, which raises an error on diffrax side.
     dims: tuple[int, ...] = eqx.field(static=True)
 
     def __check_init__(self):

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -34,7 +34,7 @@ class QArray(eqx.Module):
     #                                     _eigvalsh, devices, isherm
     #   - conversion methods: to_qutip, to_jax, __array__
     #   - arithmetic methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
-    #                         __and__, _pow
+    #                         __and__, _pow, __getitem__
 
     # Setting dims as static for now. Otherwise, I believe it is upgraded to a complex
     # dtype during the computation, which raises an error on diffrax side.

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -382,15 +382,14 @@ class QArray(eqx.Module):
         """Tensor product between two quantum states."""
 
     def __pow__(self, power: int | _Metaω) -> QArray:
-        logging.warning(
-            'Using the `**` operator performs element-wise power. For matrix power, '
-            'use `x @ x @ ... @ x` or `dq.powm(x, power)` instead.'
-        )
-
         # to deal with the x**ω notation from equinox (used in diffrax internals)
         if isinstance(power, _Metaω):
             return _Metaω.__rpow__(power, self)
         else:
+            logging.warning(
+                'Using the `**` operator performs element-wise power. For matrix '
+                'power, use `x @ x @ ... @ x` or `dq.powm(x, power)` instead.'
+            )
             return self._pow(power)
 
     @abstractmethod

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -35,7 +35,9 @@ class QArray(eqx.Module):
     #   - arithmetic methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
     #                         __and__, __pow__
 
-    dims: tuple[int, ...]
+    # Setting dims as static for now. Otherwise, I believe it is upgraded to a complex
+    # dtype during the computation, which raises an error on diffrax side.
+    dims: tuple[int, ...] = eqx.field(static=True)
 
     def __check_init__(self):
         # ensure dims is a tuple of ints

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -384,3 +384,7 @@ class QArray(eqx.Module):
             'Using the `**` operator performs element-wise power. For matrix power, '
             'use `x @ x @ ... @ x` or `dq.powm(x, power)` instead.'
         )
+
+    @abstractmethod
+    def __getitem__(self, key: int | slice) -> QArray:
+        pass

--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -253,6 +253,9 @@ class SparseDIAQArray(QArray):
     def __pow__(self, y: Scalar) -> QArray:
         return NotImplemented
 
+    def __getitem__(self, key: int | slice) -> QArray:
+        return NotImplemented
+
 
 def _check_compatible_dims(dims1: tuple[int, ...], dims2: tuple[int, ...]):
     if dims1 != dims2:

--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -250,7 +250,7 @@ class SparseDIAQArray(QArray):
     def __and__(self, y: QArray) -> QArray:
         return NotImplemented
 
-    def __pow__(self, y: Scalar) -> QArray:
+    def _pow(self, power: int) -> QArray:  # noqa: ARG002
         return NotImplemented
 
     def __getitem__(self, key: int | slice) -> QArray:

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -17,7 +17,7 @@ from ..core._utils import (
 )
 from ..gradient import Gradient
 from ..options import Options
-from ..qarrays.types import asqarray
+from ..qarrays import QArray, QArrayLike, asqarray
 from ..result import SEResult
 from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import Shape, TimeArray
@@ -28,11 +28,11 @@ __all__ = ['sesolve']
 
 
 def sesolve(
-    H: ArrayLike | TimeArray,
-    psi0: ArrayLike,
+    H: QArrayLike | TimeArray,
+    psi0: QArrayLike,
     tsave: ArrayLike,
     *,
-    exp_ops: list[ArrayLike] | None = None,
+    exp_ops: list[QArrayLike] | None = None,
     solver: Solver = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
     options: Options = Options(),  # noqa: B008
@@ -63,12 +63,12 @@ def sesolve(
         tutorial for more details.
 
     Args:
-        H _(array-like or time-array of shape (...H, n, n))_: Hamiltonian.
-        psi0 _(array-like of shape (...psi0, n, 1))_: Initial state.
+        H _(qarray-like or time-array of shape (...H, n, n))_: Hamiltonian.
+        psi0 _(qarray-like of shape (...psi0, n, 1))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
-        exp_ops _(list of array-like, each of shape (n, n), optional)_: List of
+        exp_ops _(list of qarray-like, each of shape (n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration. Defaults to
             [`dq.solver.Tsit5`][dynamiqs.solver.Tsit5] (supported:
@@ -105,9 +105,9 @@ def sesolve(
 @partial(jax.jit, static_argnames=('solver', 'gradient', 'options'))
 def _vectorized_sesolve(
     H: TimeArray,
-    psi0: Array,
+    psi0: QArray,
     tsave: Array,
-    exp_ops: Array | None,
+    exp_ops: QArray | None,
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
@@ -147,9 +147,9 @@ def _vectorized_sesolve(
 
 def _sesolve(
     H: TimeArray,
-    psi0: Array,
+    psi0: QArray,
     tsave: Array,
-    exp_ops: Array | None,
+    exp_ops: QArray | None,
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
@@ -177,7 +177,7 @@ def _sesolve(
     return result  # noqa: RET504
 
 
-def _check_sesolve_args(H: TimeArray, psi0: Array, exp_ops: Array | None):
+def _check_sesolve_args(H: TimeArray, psi0: QArray, exp_ops: QArray | None):
     # === check H shape
     check_shape(H, 'H', '(..., n, n)', subs={'...': '...H'})
 

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -9,7 +9,6 @@ from jaxtyping import ArrayLike
 
 from .._checks import check_shape, check_times
 from ..core._utils import (
-    _asqarray,
     _astimearray,
     _cartesian_vectorize,
     _flat_vectorize,
@@ -18,6 +17,7 @@ from ..core._utils import (
 )
 from ..gradient import Gradient
 from ..options import Options
+from ..qarrays.types import asqarray
 from ..result import SEResult
 from ..solver import Dopri5, Dopri8, Euler, Propagator, Solver, Tsit5
 from ..time_array import Shape, TimeArray
@@ -88,9 +88,9 @@ def sesolve(
     """  # noqa: E501
     # === convert arguments
     H = _astimearray(H)
-    psi0 = _asqarray(psi0)
+    psi0 = asqarray(psi0)
     tsave = jnp.asarray(tsave)
-    exp_ops = _asqarray(exp_ops) if exp_ops is not None else None
+    exp_ops = asqarray(exp_ops) if exp_ops is not None else None
 
     # === check arguments
     _check_sesolve_args(H, psi0, exp_ops)

--- a/dynamiqs/sesolve/sesolve.py
+++ b/dynamiqs/sesolve/sesolve.py
@@ -8,8 +8,8 @@ from jax import Array
 from jaxtyping import ArrayLike
 
 from .._checks import check_shape, check_times
-from .._utils import cdtype
 from ..core._utils import (
+    _asqarray,
     _astimearray,
     _cartesian_vectorize,
     _flat_vectorize,
@@ -88,9 +88,9 @@ def sesolve(
     """  # noqa: E501
     # === convert arguments
     H = _astimearray(H)
-    psi0 = jnp.asarray(psi0, dtype=cdtype())
+    psi0 = _asqarray(psi0)
     tsave = jnp.asarray(tsave)
-    exp_ops = jnp.asarray(exp_ops, dtype=cdtype()) if exp_ops is not None else None
+    exp_ops = _asqarray(exp_ops) if exp_ops is not None else None
 
     # === check arguments
     _check_sesolve_args(H, psi0, exp_ops)


### PR DESCRIPTION
Begin the integration of `QArrays` into the global workflow. With this PR, the following minimal code snippet now works without errors.

```python
import dynamiqs as dq
import jax.numpy as jnp

H = dq.number(8)
tlist = jnp.linspace(0.0, 1.0, 10)
psi0 = dq.basis(8, 0)
result = dq.sesolve(H, psi0, tlist)
```

A few notes on this PR:
 - Had to make `dims` static for now. I couldn't quite figure out why it was required, but I think it's related to dtype promotion of `dims` from `int` to `complex`. To be fixed later on (if @abocquet @pierreguilmin you have an idea?).
 - Not sure about my construction to handle the equinox omega. Down for feedback if it's not correct.
 - `__getitem__` is required for the line `saved = self.collect_saved(save_a, save_b[0])` inside `diffrax_solver.py`.
 - This is a very rough first PR, but there's already quite a few things. To be continued in other PRs.