### PR TITLE
Start integrating `QArray` into utils

### DIFF
--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
-from jax import Array
+
+from ._types import Array
 
 _is_perfect_square = lambda n: int(n**0.5) ** 2 == n
 
@@ -61,7 +63,7 @@ def check_shape(
     )
 
 
-def check_times(x: Array, argname: str, allow_empty: bool = False) -> Array:
+def check_times(x: jax.Array, argname: str, allow_empty: bool = False) -> jax.Array:
     # check that an array of time is valid (it must be a 1D array sorted in strictly
     # ascending order)
 

--- a/dynamiqs/_types.py
+++ b/dynamiqs/_types.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Union, get_args
+
+import jax
+import jax.numpy as jnp
+import jaxtyping
+from qutip import Qobj
+
+from .qarrays.qarray import QArray
+
+# In this file we define two extended array types: `ArrayLike` and `Array`. Most
+# functions in the library take an `ArrayLike` as argument and return an `Array`.
+# `ArrayLike` can be any numeric type (bool, int, float, complex), a JAX Array, a NumPy
+# Array, a QuTiP Qobj, a dynamiqs QArray or a nested list of these types. Any
+# `ArrayLike` can be converted to an `Array` using `asarray`, resulting in either a JAX
+# Array or a dynamiqs QArray.
+
+# extended array like type
+_ArrayLike = Union[jaxtyping.ArrayLike, QArray, Qobj]
+# a type alias for nested list of _ArrayLike
+_NestedArrayLikeList = list[Union[_ArrayLike, '_NestedArrayLikeList']]
+# a type alias for any type compatible with asarray
+ArrayLike = Union[_ArrayLike, _NestedArrayLikeList]
+
+Array = Union[jax.Array, QArray]
+
+
+def is_arraylike(x: Any) -> bool:
+    if isinstance(x, get_args(_ArrayLike)):
+        return True
+    elif isinstance(x, list):
+        return all(isinstance(_x, get_args(_ArrayLike)) for _x in x)
+    return False
+
+
+def asarray(x: ArrayLike) -> Array:
+    return x if isinstance(x, QArray) else jnp.asarray(x)
+
+
+def asjaxarray(x: ArrayLike) -> jax.Array:
+    return x.to_jax() if isinstance(x, QArray) else jnp.asarray(x)

--- a/dynamiqs/_types.py
+++ b/dynamiqs/_types.py
@@ -4,39 +4,39 @@ from typing import Any, Union, get_args
 
 import jax
 import jax.numpy as jnp
-import jaxtyping
+from jaxtyping import ArrayLike
 from qutip import Qobj
 
 from .qarrays.qarray import QArray
 
-# In this file we define two extended array types: `ArrayLike` and `Array`. Most
-# functions in the library take an `ArrayLike` as argument and return an `Array`.
-# `ArrayLike` can be any numeric type (bool, int, float, complex), a JAX Array, a NumPy
+# In this file we define two extended array types: `QArrayLike` and `Array`. Most
+# functions in the library take a `QArrayLike` as argument and return an `Array`.
+# `QArrayLike` can be any numeric type (bool, int, float, complex), a JAX Array, a NumPy
 # Array, a QuTiP Qobj, a dynamiqs QArray or a nested list of these types. Any
-# `ArrayLike` can be converted to an `Array` using `asarray`, resulting in either a JAX
+# `QArrayLike` can be converted to an `Array` using `asarray`, resulting in either a JAX
 # Array or a dynamiqs QArray.
 
 # extended array like type
-_ArrayLike = Union[jaxtyping.ArrayLike, QArray, Qobj]
-# a type alias for nested list of _ArrayLike
-_NestedArrayLikeList = list[Union[_ArrayLike, '_NestedArrayLikeList']]
+_QArrayLike = Union[ArrayLike, QArray, Qobj]
+# a type alias for nested list of _QArrayLike
+_NestedQArrayLikeList = list[Union[_QArrayLike, '_NestedQArrayLikeList']]
 # a type alias for any type compatible with asarray
-ArrayLike = Union[_ArrayLike, _NestedArrayLikeList]
+QArrayLike = Union[_QArrayLike, _NestedQArrayLikeList]
 
 Array = Union[jax.Array, QArray]
 
 
-def is_arraylike(x: Any) -> bool:
-    if isinstance(x, get_args(_ArrayLike)):
+def is_qarraylike(x: Any) -> bool:
+    if isinstance(x, get_args(_QArrayLike)):
         return True
     elif isinstance(x, list):
-        return all(isinstance(_x, get_args(_ArrayLike)) for _x in x)
+        return all(isinstance(_x, get_args(_QArrayLike)) for _x in x)
     return False
 
 
-def asarray(x: ArrayLike) -> Array:
+def asarray(x: QArrayLike) -> Array:
     return x if isinstance(x, QArray) else jnp.asarray(x)
 
 
-def asjaxarray(x: ArrayLike) -> jax.Array:
+def asjaxarray(x: QArrayLike) -> jax.Array:
     return x.to_jax() if isinstance(x, QArray) else jnp.asarray(x)

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
-from jaxtyping import Array, ArrayLike, PyTree
+from jaxtyping import ArrayLike, PyTree
 
 
 def type_str(type: Any) -> str:  # noqa: A002
@@ -18,7 +19,7 @@ def obj_type_str(x: Any) -> str:
     return type_str(type(x))
 
 
-def on_cpu(x: Array) -> str:
+def on_cpu(x: jax.Array) -> str:
     # TODO: this is a temporary solution, it won't work when we have multiple devices
     return x.devices().pop().device_kind == 'cpu'
 

--- a/dynamiqs/qarrays/__init__.py
+++ b/dynamiqs/qarrays/__init__.py
@@ -1,3 +1,3 @@
-from .dense_qarray import *
-from .qarray import *
-from .sparse_qarray import *
+# from .dense_qarray import *
+# from .qarray import *
+# from .sparse_qarray import *

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -5,9 +5,10 @@ from typing import get_args
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jaxtyping import ArrayLike
+from jaxtyping import ArrayLike, ScalarLike
 from qutip import Qobj
 
+from .._types import QArrayLike, asarray
 from ..utils.jax_utils import to_qutip
 from ..utils.utils.general import (
     dag,
@@ -142,49 +143,53 @@ class DenseQArray(QArray):
         data = expm(self.data, n)
         return DenseQArray(self.dims, data)
 
-    def __mul__(self, y: ArrayLike) -> QArray:
+    def __mul__(self, y: QArrayLike) -> QArray:
         super().__mul__(y)
 
+        if isinstance(y, ScalarLike):
+            data = self.data * y
         if isinstance(y, DenseQArray):
             data = self.data * y.data
-        elif isinstance(y, get_args(ArrayLike)):
-            data = self.data * y
+        elif isinstance(y, get_args(QArrayLike)):
+            data = self.data * asarray(y)
         else:
             return NotImplemented
 
         return DenseQArray(self.dims, data)
 
-    def __add__(self, y: ArrayLike) -> QArray:
+    def __add__(self, y: QArrayLike) -> QArray:
         super().__add__(y)
 
-        if isinstance(y, DenseQArray):
-            data = self.data + y.data
-        elif isinstance(y, get_args(ArrayLike)):
+        if isinstance(y, ScalarLike):
             data = self.data + y
+        elif isinstance(y, DenseQArray):
+            data = self.data + y.data
+        elif isinstance(y, get_args(QArrayLike)):
+            data = self.data + asarray(y)
         else:
             return NotImplemented
 
         return DenseQArray(self.dims, data)
 
-    def __matmul__(self, y: ArrayLike) -> QArray:
+    def __matmul__(self, y: QArrayLike) -> QArray:
         super().__matmul__(y)
 
         if isinstance(y, DenseQArray):
             data = self.data @ y.data
-        elif isinstance(y, get_args(ArrayLike)):
-            data = self.data @ y
+        elif isinstance(y, get_args(QArrayLike)):
+            data = self.data @ asarray(y)
         else:
             return NotImplemented
 
         return DenseQArray(self.dims, data)
 
-    def __rmatmul__(self, y: ArrayLike) -> QArray:
+    def __rmatmul__(self, y: QArrayLike) -> QArray:
         super().__rmatmul__(y)
 
         if isinstance(y, DenseQArray):
             data = y.data @ self.data
-        elif isinstance(y, get_args(ArrayLike)):
-            data = y @ self.data
+        elif isinstance(y, get_args(QArrayLike)):
+            data = asarray(y) @ self.data
         else:
             return NotImplemented
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import get_args
 
+import jax
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
 from jaxtyping import ArrayLike
 from qutip import Qobj
 
@@ -48,7 +48,7 @@ def dense_qarray(data: ArrayLike, dims: tuple[int, ...] | None = None) -> DenseQ
 class DenseQArray(QArray):
     r"""DenseQArray is QArray that uses JAX arrays as data storage."""
 
-    data: Array
+    data: jax.Array
 
     @property
     def dtype(self) -> jnp.dtype:
@@ -76,16 +76,16 @@ class DenseQArray(QArray):
         data = dag(self.data)
         return DenseQArray(self.dims, data)
 
-    def trace(self) -> Array:
+    def trace(self) -> jax.Array:
         return trace(self.data)
 
-    def sum(self, axis: int | tuple[int, ...] | None = None) -> Array:
+    def sum(self, axis: int | tuple[int, ...] | None = None) -> jax.Array:
         return self.data.sum(axis=axis)
 
-    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> Array:
+    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> jax.Array:
         return self.data.squeeze(axis=axis)
 
-    def norm(self) -> Array:
+    def norm(self) -> jax.Array:
         return norm(self.data)
 
     def reshape(self, *shape: int) -> QArray:
@@ -131,7 +131,7 @@ class DenseQArray(QArray):
     def to_qutip(self) -> Qobj:
         return to_qutip(self.data, dims=self.dims)
 
-    def to_jax(self) -> Array:
+    def to_jax(self) -> jax.Array:
         return self.data
 
     def _powm(self, n: int) -> QArray:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -5,9 +5,9 @@ from abc import abstractmethod
 from typing import get_args
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
 from jaxtyping import ArrayLike, ScalarLike
 from qutip import Qobj
 
@@ -90,19 +90,19 @@ class QArray(eqx.Module):
         """
 
     @abstractmethod
-    def trace(self) -> Array:
+    def trace(self) -> jax.Array:
         pass
 
     @abstractmethod
-    def sum(self, axis: int | tuple[int, ...] | None = None) -> Array:
+    def sum(self, axis: int | tuple[int, ...] | None = None) -> jax.Array:
         pass
 
     @abstractmethod
-    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> Array:
+    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> jax.Array:
         pass
 
     @abstractmethod
-    def norm(self) -> Array:
+    def norm(self) -> jax.Array:
         """Returns the norm of the quantum state.
 
         Returns:
@@ -244,7 +244,7 @@ class QArray(eqx.Module):
         """
 
     @abstractmethod
-    def to_jax(self) -> Array:
+    def to_jax(self) -> jax.Array:
         """Convert the quantum state to a JAX array.
 
         Returns:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -8,8 +8,10 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jaxtyping import ArrayLike, ScalarLike
+from jaxtyping import ScalarLike
 from qutip import Qobj
+
+from .._types import QArrayLike
 
 __all__ = ['QArray']
 
@@ -270,7 +272,7 @@ class QArray(eqx.Module):
         return self * (-1)
 
     @abstractmethod
-    def __mul__(self, y: ArrayLike) -> QArray:
+    def __mul__(self, y: QArrayLike) -> QArray:
         """Element-wise multiplication with a scalar or an array."""
         if not isinstance(y, get_args(ScalarLike)):
             logging.warning(
@@ -279,12 +281,12 @@ class QArray(eqx.Module):
                 'instead.'
             )
 
-    def __rmul__(self, y: ArrayLike) -> QArray:
+    def __rmul__(self, y: QArrayLike) -> QArray:
         """Element-wise multiplication with a scalar or an array on the right."""
         return self * y
 
     @abstractmethod
-    def __add__(self, y: ArrayLike) -> QArray:
+    def __add__(self, y: QArrayLike) -> QArray:
         """Element-wise addition with a scalar or an array."""
         if isinstance(y, get_args(ScalarLike)):
             logging.warning(
@@ -293,24 +295,24 @@ class QArray(eqx.Module):
                 'identity matrix, use e.g. `x + 2 * x.I` instead.'
             )
 
-    def __radd__(self, y: ArrayLike) -> QArray:
+    def __radd__(self, y: QArrayLike) -> QArray:
         """Element-wise addition with a scalar or an array on the right."""
         return self + y
 
-    def __sub__(self, y: ArrayLike) -> QArray:
+    def __sub__(self, y: QArrayLike) -> QArray:
         """Element-wise subtraction with a scalar or an array."""
         return self + (-y)
 
-    def __rsub__(self, y: ArrayLike) -> QArray:
+    def __rsub__(self, y: QArrayLike) -> QArray:
         """Element-wise subtraction with a scalar or an array on the right."""
         return -self + y
 
     @abstractmethod
-    def __matmul__(self, y: ArrayLike) -> QArray:
+    def __matmul__(self, y: QArrayLike) -> QArray:
         """Matrix multiplication with another quantum state or JAX array."""
 
     @abstractmethod
-    def __rmatmul__(self, y: ArrayLike) -> QArray:
+    def __rmatmul__(self, y: QArrayLike) -> QArray:
         """Matrix multiplication with another quantum state or JAX array
         on the right.
         """

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -22,9 +22,10 @@ class QArray(eqx.Module):
     """
 
     # Subclasses should implement:
-    # - the properties: dtype, shape
-    # - the methods: conj, dag, norm, reshape, broadcast_to, ptrace, to_numpy, to_qutip,
-    #                to_jax, __mul__, __add__, __matmul__, __rmatmul__, __and__, __pow__
+    # - the properties: dtype, shape, mT
+    # - the methods: conj, dag, trace, sum, squeeze, norm, reshape, broadcast_to,
+    #                ptrace, to_numpy, to_qutip, to_jax, _powm, _expm, __mul__,
+    #                __add__, __matmul__, __rmatmul__, __and__, __pow__
 
     # (for now also property I and methods is_ket, is_bra, is_dm, is_herm, toket, tobra,
     # todm)
@@ -48,6 +49,11 @@ class QArray(eqx.Module):
         Returns:
             The shape of the quantum state.
         """
+
+    @property
+    @abstractmethod
+    def mT(self) -> QArray:
+        pass
 
     @property
     def ndim(self) -> int:
@@ -82,6 +88,18 @@ class QArray(eqx.Module):
         Returns:
             The dagger of the quantum state.
         """
+
+    @abstractmethod
+    def trace(self) -> Array:
+        pass
+
+    @abstractmethod
+    def sum(self, axis: int | tuple[int, ...] | None = None) -> Array:
+        pass
+
+    @abstractmethod
+    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> Array:
+        pass
 
     @abstractmethod
     def norm(self) -> Array:
@@ -162,7 +180,7 @@ class QArray(eqx.Module):
         return self.isdm()
 
     @abstractmethod
-    def isherm(self) -> bool:
+    def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
         """Returns the check if the quantum state is Hermitian.
 
         Returns:
@@ -232,6 +250,14 @@ class QArray(eqx.Module):
         Returns:
             The JAX array representation of the quantum state.
         """
+
+    @abstractmethod
+    def _powm(self, n: int) -> QArray:
+        pass
+
+    @abstractmethod
+    def _expm(self, *, max_squarings: int = 16) -> QArray:
+        pass
 
     def __repr__(self) -> str:
         return (

--- a/dynamiqs/utils/jax_utils.py
+++ b/dynamiqs/utils/jax_utils.py
@@ -6,19 +6,19 @@ import jax
 from qutip import Qobj
 
 from .._checks import check_shape
-from .._types import ArrayLike, asjaxarray
+from .._types import QArrayLike, asjaxarray
 from .utils import isbra, isket, isop
 from .utils.general import _hdim
 
 __all__ = ['to_qutip', 'set_device', 'set_precision', 'set_matmul_precision']
 
 
-def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:
+def to_qutip(x: QArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:
     r"""Convert an array-like object into a QuTiP quantum object (or a list of QuTiP
     quantum objects if it has more than two dimensions).
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,
             density matrix or operator.
         dims _(tuple of ints or None)_: Dimensions of each subsystem in the large
             Hilbert space of the composite system, defaults to `None` (a single system

--- a/dynamiqs/utils/jax_utils.py
+++ b/dynamiqs/utils/jax_utils.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from typing import Literal
 
 import jax
-import numpy as np
-from jax.typing import ArrayLike
 from qutip import Qobj
 
 from .._checks import check_shape
+from .._types import ArrayLike, asjaxarray
 from .utils import isbra, isket, isop
 from .utils.general import _hdim
 
@@ -70,7 +69,7 @@ def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Q
          [0. 0. 0. 0. 1. 0.]
          [0. 0. 0. 0. 0. 1.]]
     """  # noqa: E501
-    x = np.asarray(x)
+    x = asjaxarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 
     if x.ndim > 2:


### PR DESCRIPTION
Integrate `QArray` into dynamiqs utilities.

I ported
- [x] `utils/utils/general.py`
- [x] `utils/jax_utils.py`
- [x] `_utils.py`
- [x] `_checks.py`
- [x] `utils/vectorization.py`

For later PRs:
- [ ]  creation utilities: `utils/operators.py`, `utils/states.py`, `utils/optimal_control.py`, `dark/dark.py`
- [ ] `utils/wigner.py`
- [ ] `plots/`
- [ ] `utils/random.py`
- [ ] `sesolve/`, `mesolve/`, `smesolve/`, `core/`, `result.py`, `time_array.py`
- [ ] sparse DIA
- [ ] make things in `_types.py` public and documented
- [ ] fix the tutorials in the documentation