### PR TITLE
Start integrating QArray into utils 

### DIFF
--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -4,6 +4,8 @@ import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
 
+from .qarrays import QArray
+
 _is_perfect_square = lambda n: int(n**0.5) ** 2 == n
 
 
@@ -28,7 +30,7 @@ _cases = {
 }
 
 
-def has_shape(x: Array, shape: str) -> bool:
+def has_shape(x: Array | QArray, shape: str) -> bool:
     if shape in _cases:
         return _cases[shape](x)
     else:
@@ -36,7 +38,7 @@ def has_shape(x: Array, shape: str) -> bool:
 
 
 def check_shape(
-    x: Array, argname: str, *shapes: str, subs: dict[str, str] | None = None
+    x: Array | QArray, argname: str, *shapes: str, subs: dict[str, str] | None = None
 ):
     # subs is used to replace symbols in the error message, this can be used to e.g.
     # specify a shape (?, n, n) but print an error message with (nH?, n, n), by passing
@@ -85,7 +87,7 @@ def check_times(x: Array, argname: str, allow_empty: bool = False) -> Array:
     )
 
 
-def check_type_int(x: Array, argname: str):
+def check_type_int(x: Array | QArray, argname: str):
     if not jnp.issubdtype(x.dtype, jnp.integer):
         raise ValueError(
             f'Argument {argname} must be of type integer, but is of type'

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -4,7 +4,10 @@ from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
-from jaxtyping import Array, ArrayLike, PyTree
+from jax import Array
+from jaxtyping import ArrayLike, PyTree
+
+from .qarrays import QArray
 
 
 def type_str(type: Any) -> str:  # noqa: A002
@@ -18,7 +21,7 @@ def obj_type_str(x: Any) -> str:
     return type_str(type(x))
 
 
-def on_cpu(x: Array) -> str:
+def on_cpu(x: Array | QArray) -> str:
     # TODO: this is a temporary solution, it won't work when we have multiple devices
     return x.devices().pop().device_kind == 'cpu'
 

--- a/dynamiqs/qarrays/__init__.py
+++ b/dynamiqs/qarrays/__init__.py
@@ -1,3 +1,1 @@
-from .dense_qarray import *
-from .qarray import *
-from .sparse_qarray import *
+from .types import *

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -4,6 +4,7 @@ from typing import get_args
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from jax import Array, Device
 from jaxtyping import ScalarLike
 from qutip import Qobj
@@ -100,8 +101,11 @@ class DenseQArray(QArray):
     def to_qutip(self) -> Qobj:
         return to_qutip(self.data, dims=self.dims)
 
-    def __jax_array__(self) -> Array:
+    def to_jax(self) -> Array:
         return self.data
+
+    def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
+        return np.asarray(self.data, dtype=dtype)
 
     def __repr__(self) -> str:
         return repr(self.data)

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -2,44 +2,21 @@ from __future__ import annotations
 
 from typing import get_args
 
+import jax
 import jax.numpy as jnp
-import numpy as np
-from jax import Array
-from jaxtyping import ArrayLike
+from jax import Array, Device
+from jaxtyping import ScalarLike
 from qutip import Qobj
 
 from ..utils.jax_utils import to_qutip
-from ..utils.utils.general import (
-    dag,
-    isbra,
-    isdm,
-    isket,
-    isop,
-    norm,
-    powm,
-    ptrace,
-    tensor,
-    tobra,
-    todm,
-    toket,
-)
+from ..utils.utils.general import dag, norm, ptrace
 from .qarray import QArray
+from .types import QArrayLike, asjaxarray
 
-__all__ = ['dense_qarray', 'DenseQArray']
+__all__ = ['DenseQArray']
 
-
-def dense_qarray(data: ArrayLike, dims: tuple[int, ...] | None = None) -> DenseQArray:
-    if not (isbra(data) or isket(data) or isdm(data) or isop(data)):
-        raise ValueError(
-            f'DenseQArray data must be a bra, a ket, a density matrix '
-            f'or and operator. Got array with size {data.shape}'
-        )
-    if dims is None:
-        dims = data.shape[-2] if isket(data) else data.shape[-1]
-        dims = (dims,)
-
-    data = jnp.asarray(data)
-    return DenseQArray(dims, data)
+# batched Kronecker product of two arrays
+_bkron = jnp.vectorize(jnp.kron, signature='(a,b),(c,d)->(ac,bd)')
 
 
 class DenseQArray(QArray):
@@ -56,8 +33,8 @@ class DenseQArray(QArray):
         return self.data.shape
 
     @property
-    def I(self) -> QArray:  # noqa: E743
-        data = jnp.eye(jnp.prod(jnp.asarray(self.dims)))
+    def mT(self) -> QArray:
+        data = self.data.mT
         return DenseQArray(self.dims, data)
 
     def conj(self) -> QArray:
@@ -66,10 +43,6 @@ class DenseQArray(QArray):
 
     def dag(self) -> QArray:
         data = dag(self.data)
-        return DenseQArray(self.dims, data)
-
-    def norm(self) -> QArray:
-        data = norm(self.data)
         return DenseQArray(self.dims, data)
 
     def reshape(self, *shape: int) -> QArray:
@@ -85,83 +58,115 @@ class DenseQArray(QArray):
         data = ptrace(self.data, keep, self.dims)
         return DenseQArray(dims, data)
 
-    def isket(self) -> bool:
-        return isket(self.data)
-
-    def isbra(self) -> bool:
-        return isbra(self.data)
-
-    def isdm(self) -> bool:
-        return isdm(self.data)
-
-    def isherm(self) -> bool:
-        # TODO: could be made more efficient
-        return jnp.allclose(self.data, dag(self.data))
-
-    def toket(self) -> QArray:
-        data = toket(self.data)
+    def powm(self, n: int) -> QArray:
+        data = jnp.linalg.matrix_power(self.data, n)
         return DenseQArray(self.dims, data)
 
-    def tobra(self) -> QArray:
-        data = tobra(self.data)
+    def expm(self, *, max_squarings: int = 16) -> QArray:
+        data = jax.scipy.linalg.expm(self.data, max_squarings=max_squarings)
         return DenseQArray(self.dims, data)
 
-    def todm(self) -> QArray:
-        data = todm(self.data)
+    def _abs(self) -> QArray:
+        data = jnp.abs(self.data)
         return DenseQArray(self.dims, data)
 
-    def to_numpy(self) -> np.ndarray:
-        return np.asarray(self.data)
+    def norm(self) -> Array:
+        return norm(self.data)
+
+    def trace(self) -> Array:
+        return self.data.trace(axis1=-1, axis2=-2)
+
+    def sum(self, axis: int | tuple[int, ...] | None = None) -> Array:
+        return self.data.sum(axis=axis)
+
+    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> Array:
+        return self.data.squeeze(axis=axis)
+
+    def _eigh(self) -> tuple[Array, Array]:
+        return jnp.linalg.eigh(self.data)
+
+    def _eigvals(self) -> Array:
+        return jnp.linalg.eigvals(self.data)
+
+    def _eigvalsh(self) -> Array:
+        return jnp.linalg.eigvalsh(self.data)
+
+    def devices(self) -> set[Device]:
+        return self.data.devices()
+
+    def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+        return jnp.allclose(self.data, self.data.mT.conj(), rtol=rtol, atol=atol)
 
     def to_qutip(self) -> Qobj:
         return to_qutip(self.data, dims=self.dims)
 
-    def to_jax(self) -> Array:
+    def __jax_array__(self) -> Array:
         return self.data
 
-    def __mul__(self, y: ArrayLike) -> QArray:
+    def __repr__(self) -> str:
+        return repr(self.data)
+
+    def __mul__(self, y: QArrayLike) -> QArray:
         super().__mul__(y)
 
+        if isinstance(y, get_args(ScalarLike)):
+            data = self.data * y
         if isinstance(y, DenseQArray):
             data = self.data * y.data
-        elif isinstance(y, get_args(ArrayLike)):
-            data = self.data * y
+        elif isinstance(y, get_args(QArrayLike)):
+            data = self.data * asjaxarray(y)
         else:
             return NotImplemented
 
         return DenseQArray(self.dims, data)
 
-    def __add__(self, y: ArrayLike) -> QArray:
+    def __truediv__(self, y: QArrayLike) -> QArray:
+        super().__truediv__(y)
+
+        if isinstance(y, get_args(ScalarLike)):
+            data = self.data / y
+        if isinstance(y, DenseQArray):
+            data = self.data / y.data
+        elif isinstance(y, get_args(QArrayLike)):
+            data = self.data / asjaxarray(y)
+        else:
+            return NotImplemented
+
+        return DenseQArray(self.dims, data)
+
+    def __add__(self, y: QArrayLike) -> QArray:
         super().__add__(y)
 
-        if isinstance(y, DenseQArray):
-            data = self.data + y.data
-        elif isinstance(y, get_args(ArrayLike)):
+        if isinstance(y, get_args(ScalarLike)):
             data = self.data + y
+        elif isinstance(y, DenseQArray):
+            data = self.data + y.data
+        elif isinstance(y, get_args(QArrayLike)):
+            data = self.data + asjaxarray(y)
         else:
             return NotImplemented
 
         return DenseQArray(self.dims, data)
 
-    def __matmul__(self, y: ArrayLike) -> QArray:
+    def __matmul__(self, y: QArrayLike) -> QArray:
         super().__matmul__(y)
 
         if isinstance(y, DenseQArray):
             data = self.data @ y.data
-        elif isinstance(y, get_args(ArrayLike)):
-            data = self.data @ y
+        elif isinstance(y, get_args(QArrayLike)):
+            data = self.data @ asjaxarray(y)
         else:
             return NotImplemented
 
         return DenseQArray(self.dims, data)
 
-    def __rmatmul__(self, y: ArrayLike) -> QArray:
+    def __rmatmul__(self, y: QArrayLike) -> QArray:
         super().__rmatmul__(y)
 
         if isinstance(y, DenseQArray):
             data = y.data @ self.data
-        elif isinstance(y, get_args(ArrayLike)):
-            data = y @ self.data
+        elif isinstance(y, get_args(QArrayLike)):
+            data = asjaxarray(y) @ self.data
         else:
             return NotImplemented
 
@@ -172,7 +177,7 @@ class DenseQArray(QArray):
         dims = self.dims + y.dims
 
         if isinstance(y, DenseQArray):
-            data = tensor(self.data, y.data)
+            data = _bkron(self.data, y.data)
         else:
             return NotImplemented
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -185,5 +185,5 @@ class DenseQArray(QArray):
 
     def __pow__(self, power: int) -> QArray:
         super().__pow__(power)
-        data = powm(self.data, power)
+        data = self.data**power
         return DenseQArray(self.dims, data)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -31,7 +31,7 @@ class QArray(eqx.Module):
     #                     _abs
     #   - returning a JAX array or other: norm, trace, sum, squeeze, _eigh, _eigvals,
     #                                     _eigvalsh, devices, isherm
-    #   - conversion methods: to_qutip, __jax_array__
+    #   - conversion methods: to_qutip, to_jax, __array__
     #   - arithmetic methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
     #                         __and__, __pow__
 
@@ -282,11 +282,16 @@ class QArray(eqx.Module):
             A QuTiP object representation of the quantum state.
         """
 
-    def __array__(self) -> np.ndarray:
-        return np.asarray(jnp.asarray(self))
+    @abstractmethod
+    def to_jax(self) -> Array:
+        """Convert the quantum state to a JAX array.
+
+        Returns:
+            The JAX array representation of the quantum state.
+        """
 
     @abstractmethod
-    def __jax_array__(self) -> Array:
+    def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
         pass
 
     def to_numpy(self) -> np.ndarray:
@@ -296,14 +301,6 @@ class QArray(eqx.Module):
             The NumPy array representation of the quantum state.
         """
         return np.asarray(self)
-
-    def to_jax(self) -> Array:
-        """Convert the quantum state to a JAX array.
-
-        Returns:
-            The JAX array representation of the quantum state.
-        """
-        return jnp.asarray(self)
 
     def __repr__(self) -> str:
         return (

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -2,14 +2,17 @@ from __future__ import annotations
 
 import logging
 from abc import abstractmethod
-from typing import get_args
+from typing import TYPE_CHECKING, get_args
 
 import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
-from jax import Array
-from jaxtyping import ArrayLike, ScalarLike
+from jax import Array, Device
+from jaxtyping import ScalarLike
 from qutip import Qobj
+
+if TYPE_CHECKING:  # avoid circular import by importing only during type checking
+    from .types import QArrayLike
 
 __all__ = ['QArray']
 
@@ -22,12 +25,15 @@ class QArray(eqx.Module):
     """
 
     # Subclasses should implement:
-    # - the properties: dtype, shape
-    # - the methods: conj, dag, norm, reshape, broadcast_to, ptrace, to_numpy, to_qutip,
-    #                to_jax, __mul__, __add__, __matmul__, __rmatmul__, __and__, __pow__
-
-    # (for now also property I and methods is_ket, is_bra, is_dm, is_herm, toket, tobra,
-    # todm)
+    # - the properties: dtype, shape, mT
+    # - the methods:
+    #   - QArray methods: conj, dag, reshape, broadcast_to, ptrace, powm, expm,
+    #                     _abs
+    #   - returning a JAX array or other: norm, trace, sum, squeeze, _eigh, _eigvals,
+    #                                     _eigvalsh, devices, isherm
+    #   - conversion methods: to_qutip, __jax_array__
+    #   - arithmetic methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
+    #                         __and__, __pow__
 
     dims: tuple[int, ...]
 
@@ -50,6 +56,11 @@ class QArray(eqx.Module):
         """
 
     @property
+    @abstractmethod
+    def mT(self) -> QArray:
+        pass
+
+    @property
     def ndim(self) -> int:
         """Returns the number of dimensions of the quantum state.
 
@@ -57,15 +68,6 @@ class QArray(eqx.Module):
             The number of dimensions of the quantum state.
         """
         return len(self.shape)
-
-    @property
-    @abstractmethod
-    def I(self) -> QArray:  # noqa: E743
-        """Returns the identity operator compatible with the quantum state.
-
-        Returns:
-            The identity operator.
-        """
 
     @abstractmethod
     def conj(self) -> QArray:
@@ -82,22 +84,6 @@ class QArray(eqx.Module):
         Returns:
             The dagger of the quantum state.
         """
-
-    @abstractmethod
-    def norm(self) -> Array:
-        """Returns the norm of the quantum state.
-
-        Returns:
-            The norm of the quantum state.
-        """
-
-    def unit(self) -> QArray:
-        """Returns the normalized the quantum state.
-
-        Returns:
-            The normalized quantum state.
-        """
-        return self / self.norm()[..., None, None]
 
     @abstractmethod
     def reshape(self, *shape: int) -> QArray:
@@ -130,28 +116,105 @@ class QArray(eqx.Module):
         """
 
     @abstractmethod
+    def powm(self, n: int) -> QArray:
+        pass
+
+    @abstractmethod
+    def expm(self, *, max_squarings: int = 16) -> QArray:
+        pass
+
+    def cosm(self) -> QArray:
+        from ..utils import cosm
+
+        return cosm(self)
+
+    def sinm(self) -> QArray:
+        from ..utils import sinm
+
+        return sinm(self)
+
+    @abstractmethod
+    def _abs(self) -> QArray:
+        pass
+
+    def unit(self) -> QArray:
+        """Returns the normalized the quantum state.
+
+        Returns:
+            The normalized quantum state.
+        """
+        return self / self.norm()[..., None, None]
+
+    @abstractmethod
+    def norm(self) -> Array:
+        """Returns the norm of the quantum state.
+
+        Returns:
+            The norm of the quantum state.
+        """
+
+    @abstractmethod
+    def trace(self) -> Array:
+        pass
+
+    def entropy_vn(self) -> Array:
+        from ..utils import entropy_vn
+
+        return entropy_vn(self)
+
+    @abstractmethod
+    def sum(self, axis: int | tuple[int, ...] | None = None) -> Array:
+        pass
+
+    @abstractmethod
+    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> Array:
+        pass
+
+    @abstractmethod
+    def _eigh(self) -> tuple[Array, Array]:
+        pass
+
+    @abstractmethod
+    def _eigvals(self) -> Array:
+        pass
+
+    @abstractmethod
+    def _eigvalsh(self) -> Array:
+        pass
+
+    @abstractmethod
+    def devices(self) -> set[Device]:
+        pass
+
     def isket(self) -> bool:
         """Returns the check if the quantum state is a ket.
 
         Returns:
             True if the quantum state is a ket, False otherwise.
         """
+        from ..utils import isket
 
-    @abstractmethod
+        return isket(self)
+
     def isbra(self) -> bool:
         """Returns the check if the quantum state is a bra.
 
         Returns:
             True if the quantum state is a bra, False otherwise.
         """
+        from ..utils import isbra
 
-    @abstractmethod
+        return isbra(self)
+
     def isdm(self) -> bool:
         """Returns the check if the quantum state is a density matrix.
 
         Returns:
             True if the quantum state is a density matrix, False otherwise.
         """
+        from ..utils import isdm
+
+        return isdm(self)
 
     def isop(self) -> bool:
         """Returns the check if the quantum state is an operator.
@@ -159,47 +222,47 @@ class QArray(eqx.Module):
         Returns:
             True if the quantum state is an operator, False otherwise.
         """
-        return self.isdm()
+        from ..utils import isop
+
+        return isop(self)
 
     @abstractmethod
-    def isherm(self) -> bool:
+    def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
         """Returns the check if the quantum state is Hermitian.
 
         Returns:
             True if the quantum state is Hermitian, False otherwise.
         """
 
-    @abstractmethod
     def toket(self) -> QArray:
         """Convert the quantum state to a ket.
 
         Returns:
             The ket representation of the quantum state.
         """
+        from ..utils import toket
 
-    @abstractmethod
+        return toket(self)
+
     def tobra(self) -> QArray:
         """Convert the quantum state to a bra.
 
         Returns:
             The bra representation of the quantum state.
         """
+        from ..utils import tobra
 
-    @abstractmethod
+        return tobra(self)
+
     def todm(self) -> QArray:
         """Convert the quantum state to a density matrix.
 
         Returns:
             The density matrix representation of the quantum state.
         """
+        from ..utils import todm
 
-    def toop(self) -> QArray:
-        """Convert the quantum state to an operator.
-
-        Returns:
-            The operator representation of the quantum state.
-        """
-        return self.todm()
+        return todm(self)
 
     def proj(self) -> QArray:
         """Projector of the quantum state.
@@ -207,15 +270,9 @@ class QArray(eqx.Module):
         Returns:
             The projector of the quantum state.
         """
-        return self.todm()
+        from ..utils import proj
 
-    @abstractmethod
-    def to_numpy(self) -> np.ndarray:
-        """Convert the quantum state to a NumPy array.
-
-        Returns:
-            The NumPy array representation of the quantum state.
-        """
+        return proj(self)
 
     @abstractmethod
     def to_qutip(self) -> Qobj:
@@ -225,13 +282,28 @@ class QArray(eqx.Module):
             A QuTiP object representation of the quantum state.
         """
 
+    def __array__(self) -> np.ndarray:
+        return np.asarray(jnp.asarray(self))
+
     @abstractmethod
+    def __jax_array__(self) -> Array:
+        pass
+
+    def to_numpy(self) -> np.ndarray:
+        """Convert the quantum state to a NumPy array.
+
+        Returns:
+            The NumPy array representation of the quantum state.
+        """
+        return np.asarray(self)
+
     def to_jax(self) -> Array:
         """Convert the quantum state to a JAX array.
 
         Returns:
             The JAX array representation of the quantum state.
         """
+        return jnp.asarray(self)
 
     def __repr__(self) -> str:
         return (
@@ -244,7 +316,7 @@ class QArray(eqx.Module):
         return self * (-1)
 
     @abstractmethod
-    def __mul__(self, y: ArrayLike) -> QArray:
+    def __mul__(self, y: QArrayLike) -> QArray:
         """Element-wise multiplication with a scalar or an array."""
         if not isinstance(y, get_args(ScalarLike)):
             logging.warning(
@@ -253,12 +325,19 @@ class QArray(eqx.Module):
                 'instead.'
             )
 
-    def __rmul__(self, y: ArrayLike) -> QArray:
+    def __rmul__(self, y: QArrayLike) -> QArray:
         """Element-wise multiplication with a scalar or an array on the right."""
         return self * y
 
     @abstractmethod
-    def __add__(self, y: ArrayLike) -> QArray:
+    def __truediv__(self, y: QArrayLike) -> QArray:
+        pass
+
+    def __rtruediv__(self, y: QArrayLike) -> QArray:
+        return self * 1 / y
+
+    @abstractmethod
+    def __add__(self, y: QArrayLike) -> QArray:
         """Element-wise addition with a scalar or an array."""
         if isinstance(y, get_args(ScalarLike)):
             logging.warning(
@@ -267,24 +346,24 @@ class QArray(eqx.Module):
                 'identity matrix, use e.g. `x + 2 * x.I` instead.'
             )
 
-    def __radd__(self, y: ArrayLike) -> QArray:
+    def __radd__(self, y: QArrayLike) -> QArray:
         """Element-wise addition with a scalar or an array on the right."""
         return self + y
 
-    def __sub__(self, y: ArrayLike) -> QArray:
+    def __sub__(self, y: QArrayLike) -> QArray:
         """Element-wise subtraction with a scalar or an array."""
         return self + (-y)
 
-    def __rsub__(self, y: ArrayLike) -> QArray:
+    def __rsub__(self, y: QArrayLike) -> QArray:
         """Element-wise subtraction with a scalar or an array on the right."""
         return -self + y
 
     @abstractmethod
-    def __matmul__(self, y: ArrayLike) -> QArray:
+    def __matmul__(self, y: QArrayLike) -> QArray:
         """Matrix multiplication with another quantum state or JAX array."""
 
     @abstractmethod
-    def __rmatmul__(self, y: ArrayLike) -> QArray:
+    def __rmatmul__(self, y: QArrayLike) -> QArray:
         """Matrix multiplication with another quantum state or JAX array
         on the right.
         """

--- a/dynamiqs/qarrays/types.py
+++ b/dynamiqs/qarrays/types.py
@@ -34,7 +34,7 @@ def is_qarraylike(x: Any) -> bool:
     if isinstance(x, get_args(_QArrayLike)):
         return True
     elif isinstance(x, list):
-        return all(isinstance(_x, get_args(_QArrayLike)) for _x in x)
+        return all(is_qarraylike(_x) for _x in x)
     return False
 
 
@@ -55,7 +55,7 @@ def dense_qarray(x: ArrayLike, dims: tuple[int, ...] | None = None) -> QArray:
 
     x = jnp.asarray(x)
     if dims is None:
-        dims = (x.shape[-2],)
+        dims = (x.shape[-2],)  # TODO: fix for bra
     return DenseQArray(dims, x)
 
 

--- a/dynamiqs/qarrays/types.py
+++ b/dynamiqs/qarrays/types.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any, Union, get_args
+
+import jax.numpy as jnp
+from jax import Array
+from jaxtyping import ArrayLike
+from qutip import Qobj
+
+from .qarray import QArray
+
+__all__ = ['QArray', 'QArrayLike', 'asqarray', 'asjaxarray', 'dense_qarray']
+
+# In this file we define an extended array type named `QArrayLike`. Most
+# functions in the library take a `QArrayLike` as argument and return a `QArray`.
+# `QArrayLike` can be:
+# - any numeric type (bool, int, float, complex),
+# - a JAX array,
+# - a NumPy array,
+# - a QuTiP Qobj,
+# - a dynamiqs QArray,
+# - a nested list of these types.
+# An object of type `QArrayLike` can be converted to a `QArray` with `asqarray`.
+
+# extended array like type
+_QArrayLike = Union[ArrayLike, QArray, Qobj]
+# a type alias for nested list of _QArrayLike
+_NestedQArrayLikeList = list[Union[_QArrayLike, '_NestedQArrayLikeList']]
+# a type alias for any type compatible with asqarray
+QArrayLike = Union[_QArrayLike, _NestedQArrayLikeList]
+
+
+def is_qarraylike(x: Any) -> bool:
+    if isinstance(x, get_args(_QArrayLike)):
+        return True
+    elif isinstance(x, list):
+        return all(isinstance(_x, get_args(_QArrayLike)) for _x in x)
+    return False
+
+
+def asqarray(x: QArrayLike, dims: tuple[int, ...] | None = None) -> QArray:
+    return x if isinstance(x, QArray) else dense_qarray(x, dims=dims)
+
+
+def dense_qarray(x: ArrayLike, dims: tuple[int, ...] | None = None) -> QArray:
+    from .dense_qarray import DenseQArray
+
+    # TODO: check if is bra, ket, dm or op
+    # if not (isbra(data) or isket(data) or isdm(data) or isop(data)):
+    # raise ValueError(
+    #     f'DenseQArray data must be a bra, a ket, a density matrix '
+    #     f'or and operator. Got array with size {data.shape}'
+    # )
+    # TODO: check that dims and shape work
+
+    x = jnp.asarray(x)
+    if dims is None:
+        dims = (x.shape[-2],)
+    return DenseQArray(dims, x)
+
+
+def asjaxarray(x: QArrayLike) -> Array:
+    return x.to_jax() if isinstance(x, QArray) else jnp.asarray(x)

--- a/dynamiqs/utils/utils/general.py
+++ b/dynamiqs/utils/utils/general.py
@@ -10,6 +10,7 @@ from jaxtyping import ArrayLike
 
 from ..._checks import check_shape
 from ..._utils import on_cpu
+from ...qarrays import QArray, QArrayLike, asqarray
 
 __all__ = [
     'dag',
@@ -42,14 +43,14 @@ __all__ = [
 ]
 
 
-def dag(x: ArrayLike) -> Array:
+def dag(x: QArrayLike) -> QArray:
     r"""Returns the adjoint (complex conjugate transpose) of a matrix.
 
     Args:
-        x _(array_like of shape (..., m, n))_: Matrix.
+        x _(qarray_like of shape (..., m, n))_: Matrix.
 
     Returns:
-       _(array of shape (..., n, m))_ Adjoint of `x`.
+       _(qarray of shape (..., n, m))_ Adjoint of `x`.
 
     Note-: Equivalent JAX syntax
         This function is equivalent to `x.mT.conj()`.
@@ -61,20 +62,20 @@ def dag(x: ArrayLike) -> Array:
         >>> dq.dag(dq.fock(2, 0))
         Array([[1.-0.j, 0.-0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., m, n)')
     return x.mT.conj()
 
 
-def powm(x: ArrayLike, n: int) -> Array:
+def powm(x: QArrayLike, n: int) -> QArray:
     """Returns the $n$-th matrix power of an array.
 
     Args:
-        x _(array_like of shape (..., n, n))_: Square matrix.
+        x _(qarray_like of shape (..., n, n))_: Square matrix.
         n: Integer exponent.
 
     Returns:
-        _(array of shape (..., n, n))_ Matrix power of `x`.
+        _(qarray of shape (..., n, n))_ Matrix power of `x`.
 
     Note-: Equivalent JAX syntax
         This function is equivalent to `jnp.linalg.matrix_power(x, n)`.
@@ -84,22 +85,22 @@ def powm(x: ArrayLike, n: int) -> Array:
         Array([[1.+0.j, 0.+0.j],
                [0.+0.j, 1.+0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
-    return jnp.linalg.matrix_power(x, n)
+    return x.powm(n)
 
 
-def expm(x: ArrayLike, *, max_squarings: int = 16) -> Array:
+def expm(x: QArrayLike, *, max_squarings: int = 16) -> QArray:
     """Returns the matrix exponential of an array.
 
     The exponential is computed using the scaling-and-squaring approximation method.
 
     Args:
-        x _(array_like of shape (..., n, n))_: Square matrix.
+        x _(qarray_like of shape (..., n, n))_: Square matrix.
         max_squarings: Number of squarings.
 
     Returns:
-        _(array of shape (..., n, n))_ Matrix exponential of `x`.
+        _(qarray of shape (..., n, n))_ Matrix exponential of `x`.
 
     Note-: Equivalent JAX syntax
         This function is equivalent to
@@ -110,19 +111,19 @@ def expm(x: ArrayLike, *, max_squarings: int = 16) -> Array:
         Array([[2.718+0.j, 0.   +0.j],
                [0.   +0.j, 0.368+0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
-    return jax.scipy.linalg.expm(x, max_squarings=max_squarings)
+    return x.expm(max_squarings=max_squarings)
 
 
-def cosm(x: ArrayLike) -> Array:
+def cosm(x: QArrayLike) -> QArray:
     r"""Returns the cosine of an array.
 
     Args:
-        x _(array_like of shape (..., n, n))_: Square matrix.
+        x _(qarray_like of shape (..., n, n))_: Square matrix.
 
     Returns:
-        _(array of shape (..., n, n))_ Cosine of `x`.
+        _(qarray of shape (..., n, n))_ Cosine of `x`.
 
     Note:
         This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
@@ -136,19 +137,19 @@ def cosm(x: ArrayLike) -> Array:
         Array([[-1.+0.j,  0.+0.j],
                [ 0.+0.j, -1.+0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
     return 0.5 * (expm(1j * x) + expm(-1j * x))
 
 
-def sinm(x: ArrayLike) -> Array:
+def sinm(x: QArrayLike) -> QArray:
     r"""Returns the sine of an array.
 
     Args:
-        x _(array_like of shape (..., n, n))_: Square matrix.
+        x _(qarray_like of shape (..., n, n))_: Square matrix.
 
     Returns:
-        _(array of shape (..., n, n))_ Sine of `x`.
+        _(qarray of shape (..., n, n))_ Sine of `x`.
 
     Note:
         This function uses [`jax.scipy.linalg.expm()`](https://jax.readthedocs.io/en/latest/_autosummary/jax.scipy.linalg.expm.html)
@@ -162,16 +163,16 @@ def sinm(x: ArrayLike) -> Array:
         Array([[0.-0.j, 1.-0.j],
                [1.-0.j, 0.-0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
     return -0.5j * (expm(1j * x) - expm(-1j * x))
 
 
-def trace(x: ArrayLike) -> Array:
+def trace(x: QArrayLike) -> Array:
     r"""Returns the trace of an array along its last two dimensions.
 
     Args:
-        x _(array_like of shape (..., n, n))_: Array.
+        x _(qarray_like of shape (..., n, n))_: Array.
 
     Returns:
         _(array of shape (...))_ Trace of `x`.
@@ -181,12 +182,12 @@ def trace(x: ArrayLike) -> Array:
         >>> dq.trace(x)
         Array(3., dtype=float32)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
-    return x.trace(axis1=-1, axis2=-2)
+    return x.trace()
 
 
-def tracemm(x: ArrayLike, y: ArrayLike) -> Array:
+def tracemm(x: QArrayLike, y: QArrayLike) -> Array:
     r"""Return the trace of a matrix multiplication using a fast implementation.
 
     The trace is computed as `sum(x * y.T)` where `*` is the element-wise product,
@@ -204,8 +205,8 @@ def tracemm(x: ArrayLike, y: ArrayLike) -> Array:
         instead of $\mathcal{O}(n^3)$ with the naive formula.
 
     Args:
-        x _(array_like of shape (..., n, n))_: Array.
-        y _(array_like of shape (..., n, n))_: Array.
+        x _(qarray_like of shape (..., n, n))_: Array.
+        y _(qarray_like of shape (..., n, n))_: Array.
 
     Returns:
         _(array of shape (...))_ Trace of `x @ y`.
@@ -216,15 +217,15 @@ def tracemm(x: ArrayLike, y: ArrayLike) -> Array:
         >>> dq.tracemm(x, y)
         Array(9., dtype=float32)
     """
-    x = jnp.asarray(x)
-    y = jnp.asarray(y)
+    x = asqarray(x)
+    y = asqarray(y)
     check_shape(x, 'x', '(..., n, n)')
     check_shape(y, 'y', '(..., n, n)')
     return (x * y.mT).sum((-2, -1))
 
 
-def _hdim(x: ArrayLike) -> int:
-    x = jnp.asarray(x)
+def _hdim(x: QArrayLike) -> int:
+    x = asqarray(x)
     return x.shape[-2] if isket(x) else x.shape[-1]
 
 
@@ -314,7 +315,7 @@ def ptrace(x: ArrayLike, keep: int | tuple[int, ...], dims: tuple[int, ...]) -> 
     return x.reshape(*bshape, nkeep, nkeep)  # e.g. (..., 10, 10)
 
 
-def tensor(*args: ArrayLike) -> Array:
+def tensor(*args: QArrayLike) -> QArray:
     r"""Returns the tensor product of multiple kets, bras, density matrices or
     operators.
 
@@ -328,29 +329,23 @@ def tensor(*args: ArrayLike) -> Array:
       operators with shape $(..., n_k, n_k)$.
 
     Args:
-        *args _(array_like of shape (..., n_k, 1) or (..., 1, n_k) or (..., n_k, n_k))_:
+        *args _(qarray_like of shape (..., n_k, 1) or (..., 1, n_k) or (..., n_k, n_k))_:
             Variable length argument list of kets, bras, density matrices or operators.
 
     Returns:
-        _(array of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Tensor product of
+        _(qarray of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Tensor product of
             the input arrays.
 
     Examples:
         >>> psi = dq.tensor(dq.fock(3, 0), dq.fock(4, 2), dq.fock(5, 1))
         >>> psi.shape
         (60, 1)
-    """
-    args = [jnp.asarray(arg) for arg in args]
-
-    # TODO: use jax.lax.reduce
-    return reduce(_bkron, args)
+    """  # noqa: E501
+    args = [asqarray(arg) for arg in args]
+    return reduce(lambda x, y: x & y, args)  # TODO: use jax.lax.reduce
 
 
-# batched Kronecker product of two arrays
-_bkron = jnp.vectorize(jnp.kron, signature='(a,b),(c,d)->(ac,bd)')
-
-
-def expect(O: ArrayLike, x: ArrayLike) -> Array:
+def expect(O: QArrayLike, x: QArrayLike) -> Array:
     r"""Returns the expectation value of an operator or list of operators on a ket, bra
     or density matrix.
 
@@ -366,9 +361,9 @@ def expect(O: ArrayLike, x: ArrayLike) -> Array:
         `dq.expect(O, x).real`.
 
     Args:
-        O _(array_like of shape (nO?, n, n))_: Arbitrary operator or list of _nO_
+        O _(qarray_like of shape (nO?, n, n))_: Arbitrary operator or list of _nO_
             operators.
-        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket,
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket,
             bra or density matrix.
 
     Returns:
@@ -389,8 +384,8 @@ def expect(O: ArrayLike, x: ArrayLike) -> Array:
         >>> dq.expect(Os, psis).shape
         (2, 5)
     """
-    O = jnp.asarray(O)
-    x = jnp.asarray(x)
+    O = asqarray(O)
+    x = asqarray(x)
     check_shape(O, 'O', '(?, n, n)', subs={'?': 'nO?'})
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 
@@ -400,7 +395,7 @@ def expect(O: ArrayLike, x: ArrayLike) -> Array:
     return f(O, x)
 
 
-def _expect_single(O: Array, x: Array) -> Array:
+def _expect_single(O: QArray, x: QArray) -> Array:
     # O: (n, n), x: (..., n, m)
     if isket(x):
         return (dag(x) @ O @ x).squeeze((-1, -2))  # <x|O|x>
@@ -410,15 +405,15 @@ def _expect_single(O: Array, x: Array) -> Array:
         return tracemm(O, x)  # tr(Ox)
 
 
-def norm(x: ArrayLike) -> Array:
+def norm(x: QArrayLike) -> Array:
     r"""Returns the norm of a ket, bra or density matrix.
 
     For a ket or a bra, the returned norm is $\sqrt{\braket{\psi|\psi}}$. For a density
     matrix, it is $\tr{\rho}$.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
-            density matrix.
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
+            or density matrix.
 
     Returns:
         _(array of shape (...))_ Real-valued norm of `x`.
@@ -437,26 +432,26 @@ def norm(x: ArrayLike) -> Array:
         >>> dq.norm(rho)
         Array(3., dtype=float32)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 
     if isket(x) or isbra(x):
-        return jnp.linalg.norm(x, axis=(-1, -2)).real
+        return jnp.sqrt((x._abs() ** 2).sum((-2, -1)))  # noqa: SLF001
     else:
         return trace(x).real
 
 
-def unit(x: ArrayLike) -> Array:
+def unit(x: QArrayLike) -> QArray:
     r"""Normalize a ket, bra or density matrix to unit norm.
 
     The returned object is divided by its norm (see [`dq.norm()`][dynamiqs.norm]).
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
-            density matrix.
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
+            or density matrix.
 
     Returns:
-        _(array of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Normalized ket,
+        _(qarray of shape (..., n, 1) or (..., 1, n) or (..., n, n))_ Normalized ket,
             bra or density matrix.
 
     Examples:
@@ -467,13 +462,12 @@ def unit(x: ArrayLike) -> Array:
         >>> dq.norm(psi)
         Array(1., dtype=float32)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
-
     return x / norm(x)[..., None, None]
 
 
-def dissipator(L: ArrayLike, rho: ArrayLike) -> Array:
+def dissipator(L: QArrayLike, rho: QArrayLike) -> QArray:
     r"""Applies the Lindblad dissipation superoperator to a density matrix.
 
     The dissipation superoperator $\mathcal{D}[L]$ is defined by:
@@ -483,11 +477,11 @@ def dissipator(L: ArrayLike, rho: ArrayLike) -> Array:
     $$
 
     Args:
-        L _(array_like of shape (..., n, n))_: Jump operator.
-        rho _(array_like of shape (..., n, n))_: Density matrix.
+        L _(qarray_like of shape (..., n, n))_: Jump operator.
+        rho _(qarray_like of shape (..., n, n))_: Density matrix.
 
     Returns:
-        _(array of shape (..., n, n))_ Resulting operator (it is not a density matrix).
+        _(qarray of shape (..., n, n))_ Resulting operator (it is not a density matrix).
 
     Examples:
         >>> L = dq.destroy(4)
@@ -498,8 +492,8 @@ def dissipator(L: ArrayLike, rho: ArrayLike) -> Array:
                [ 0.+0.j,  0.+0.j, -2.+0.j,  0.+0.j],
                [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j]], dtype=complex64)
     """
-    L = jnp.asarray(L)
-    rho = jnp.asarray(rho)
+    L = asqarray(L)
+    rho = asqarray(rho)
     check_shape(L, 'L', '(..., n, n)')
     check_shape(rho, 'rho', '(..., n, n)')
 
@@ -508,7 +502,7 @@ def dissipator(L: ArrayLike, rho: ArrayLike) -> Array:
     return L @ rho @ Ldag - 0.5 * LdagL @ rho - 0.5 * rho @ LdagL
 
 
-def lindbladian(H: ArrayLike, jump_ops: ArrayLike, rho: ArrayLike) -> Array:
+def lindbladian(H: QArrayLike, jump_ops: QArrayLike, rho: QArrayLike) -> QArray:
     r"""Applies the Lindbladian superoperator to a density matrix.
 
     The Lindbladian superoperator $\mathcal{L}$ is defined by:
@@ -524,12 +518,12 @@ def lindbladian(H: ArrayLike, jump_ops: ArrayLike, rho: ArrayLike) -> Array:
         This superoperator is also sometimes called *Liouvillian*.
 
     Args:
-        H _(array_like of shape (..., n, n))_: Hamiltonian.
-        jump_ops _(array_like of shape (N, ..., n, n))_: Sequence of jump operators.
-        rho _(array_like of shape (..., n, n))_: Density matrix.
+        H _(qarray_like of shape (..., n, n))_: Hamiltonian.
+        jump_ops _(qarray_like of shape (N, ..., n, n))_: Sequence of jump operators.
+        rho _(qarray_like of shape (..., n, n))_: Density matrix.
 
     Returns:
-        _(array of shape (..., n, n))_ Resulting operator (it is not a density matrix).
+        _(qarray of shape (..., n, n))_ Resulting operator (it is not a density matrix).
 
     Examples:
         >>> a = dq.destroy(4)
@@ -542,9 +536,9 @@ def lindbladian(H: ArrayLike, jump_ops: ArrayLike, rho: ArrayLike) -> Array:
                [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j],
                [ 0.+0.j,  0.+0.j,  0.+0.j,  0.+0.j]], dtype=complex64)
     """
-    H = jnp.asarray(H)
-    jump_ops = jnp.asarray(jump_ops)
-    rho = jnp.asarray(rho)
+    H = asqarray(H)
+    jump_ops = asqarray(jump_ops)
+    rho = asqarray(rho)
     check_shape(H, 'H', '(..., n, n)')
     check_shape(jump_ops, 'jump_ops', '(N, ..., n, n)')
     check_shape(rho, 'rho', '(..., n, n)')
@@ -552,11 +546,11 @@ def lindbladian(H: ArrayLike, jump_ops: ArrayLike, rho: ArrayLike) -> Array:
     return -1j * (H @ rho - rho @ H) + dissipator(jump_ops, rho).sum(0)
 
 
-def isket(x: ArrayLike) -> bool:
+def isket(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of a ket.
 
     Args:
-        x _(array_like of shape (...))_: Array.
+        x _(qarray_like of shape (...))_: Array.
 
     Returns:
         True if the last dimension of `x` is 1, False otherwise.
@@ -569,15 +563,15 @@ def isket(x: ArrayLike) -> bool:
         >>> dq.isket(jnp.ones((3, 3)))
         False
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     return x.shape[-1] == 1
 
 
-def isbra(x: ArrayLike) -> bool:
+def isbra(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of a bra.
 
     Args:
-        x _(array_like of shape (...))_: Array.
+        x _(qarray_like of shape (...))_: Array.
 
     Returns:
         True if the second to last dimension of `x` is 1, False otherwise.
@@ -590,15 +584,15 @@ def isbra(x: ArrayLike) -> bool:
         >>> dq.isbra(jnp.ones((3, 3)))
         False
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     return x.shape[-2] == 1
 
 
-def isdm(x: ArrayLike) -> bool:
+def isdm(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of a density matrix.
 
     Args:
-        x _(array_like of shape (...))_: Array.
+        x _(qarray_like of shape (...))_: Array.
 
     Returns:
         True if the last two dimensions of `x` are equal, False otherwise.
@@ -611,15 +605,15 @@ def isdm(x: ArrayLike) -> bool:
         >>> dq.isdm(jnp.ones((3, 1)))
         False
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     return x.shape[-1] == x.shape[-2]
 
 
-def isop(x: ArrayLike) -> bool:
+def isop(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of an operator.
 
     Args:
-        x _(array_like of shape (...))_: Array.
+        x _(qarray_like of shape (...))_: Array.
 
     Returns:
         True if the last two dimensions of `x` are equal, False otherwise.
@@ -632,15 +626,15 @@ def isop(x: ArrayLike) -> bool:
         >>> dq.isop(jnp.ones((3, 1)))
         False
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     return x.shape[-1] == x.shape[-2]
 
 
-def isherm(x: ArrayLike, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+def isherm(x: QArrayLike, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
     r"""Returns True if the array is Hermitian.
 
     Args:
-        x _(array_like of shape (..., n, n))_: Array.
+        x _(qarray_like of shape (..., n, n))_: Array.
         rtol: Relative tolerance of the check.
         atol: Absolute tolerance of the check.
 
@@ -653,19 +647,19 @@ def isherm(x: ArrayLike, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
         >>> dq.isherm([[0, 1j], [1j, 0]])
         Array(False, dtype=bool)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
-    return jnp.allclose(x, dag(x), rtol=rtol, atol=atol)
+    return x.isherm(rtol=rtol, atol=atol)
 
 
-def toket(x: ArrayLike) -> Array:
+def toket(x: QArrayLike) -> QArray:
     r"""Returns the ket representation of a pure quantum state.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
-        _(array of shape (..., n, 1))_ Ket.
+        _(qarray of shape (..., n, 1))_ Ket.
 
     Examples:
         >>> psi = dq.tobra(dq.fock(3, 0))  # shape: (1, 3)
@@ -676,7 +670,7 @@ def toket(x: ArrayLike) -> Array:
                [0.+0.j],
                [0.+0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)')
 
     if isbra(x):
@@ -685,14 +679,14 @@ def toket(x: ArrayLike) -> Array:
         return x
 
 
-def tobra(x: ArrayLike) -> Array:
+def tobra(x: QArrayLike) -> QArray:
     r"""Returns the bra representation of a pure quantum state.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
-        _(array of shape (..., 1, n))_ Bra.
+        _(qarray of shape (..., 1, n))_ Bra.
 
     Examples:
         >>> psi = dq.fock(3, 0)  # shape: (3, 1)
@@ -703,7 +697,7 @@ def tobra(x: ArrayLike) -> Array:
         >>> dq.tobra(psi)  # shape: (1, 3)
         Array([[1.-0.j, 0.-0.j, 0.-0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)')
 
     if isbra(x):
@@ -712,7 +706,7 @@ def tobra(x: ArrayLike) -> Array:
         return dag(x)
 
 
-def todm(x: ArrayLike) -> Array:
+def todm(x: QArrayLike) -> QArray:
     r"""Returns the density matrix representation of a quantum state.
 
     Note:
@@ -720,11 +714,11 @@ def todm(x: ArrayLike) -> Array:
         density matrix, it is returned directly.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra or
-            density matrix.
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
+            or density matrix.
 
     Returns:
-        _(array of shape (..., n, n))_ Density matrix.
+        _(qarray of shape (..., n, n))_ Density matrix.
 
     Examples:
         >>> psi = dq.fock(3, 0)  # shape: (3, 1)
@@ -737,7 +731,7 @@ def todm(x: ArrayLike) -> Array:
                [0.+0.j, 0.+0.j, 0.+0.j],
                [0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 
     if isbra(x) or isket(x):
@@ -746,17 +740,17 @@ def todm(x: ArrayLike) -> Array:
         return x
 
 
-def proj(x: ArrayLike) -> Array:
+def proj(x: QArrayLike) -> QArray:
     r"""Returns the projection operator onto a pure quantum state.
 
     The projection operator onto the state $\ket\psi$ is defined as
     $P_{\ket\psi} = \ket\psi\bra\psi$.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
+        x _(qarray_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
-        _(array of shape (..., n, n))_ Projection operator.
+        _(qarray of shape (..., n, n))_ Projection operator.
 
     Examples:
         >>> psi = dq.fock(3, 0)
@@ -765,7 +759,7 @@ def proj(x: ArrayLike) -> Array:
                [0.+0.j, 0.+0.j, 0.+0.j],
                [0.+0.j, 0.+0.j, 0.+0.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)')
 
     if isbra(x):
@@ -774,12 +768,12 @@ def proj(x: ArrayLike) -> Array:
         return x @ dag(x)
 
 
-def braket(x: ArrayLike, y: ArrayLike) -> Array:
+def braket(x: QArrayLike, y: QArrayLike) -> Array:
     r"""Returns the inner product $\braket{\psi|\varphi}$ between two kets.
 
     Args:
-        x (array_like of shape _(..., n, 1))_: Left-side ket.
-        y (array_like of shape _(..., n, 1))_: Right-side ket.
+        x (qarray_like of shape _(..., n, 1))_: Left-side ket.
+        y (qarray_like of shape _(..., n, 1))_: Right-side ket.
 
     Returns:
         _(array of shape (...))_ Complex-valued inner product.
@@ -790,15 +784,15 @@ def braket(x: ArrayLike, y: ArrayLike) -> Array:
         >>> dq.braket(fock0, fock01)
         Array(0.707+0.j, dtype=complex64)
     """
-    x = jnp.asarray(x)
-    y = jnp.asarray(y)
+    x = asqarray(x)
+    y = asqarray(y)
     check_shape(x, 'x', '(..., n, 1)')
     check_shape(y, 'y', '(..., n, 1)')
 
     return (dag(x) @ y).squeeze((-1, -2))
 
 
-def overlap(x: ArrayLike, y: ArrayLike) -> Array:
+def overlap(x: QArrayLike, y: QArrayLike) -> Array:
     r"""Returns the overlap between two quantum states.
 
     The overlap is computed
@@ -811,8 +805,8 @@ def overlap(x: ArrayLike, y: ArrayLike) -> Array:
       $\sigma$.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
-        y _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        x _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        y _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
         _(array of shape (...))_ Real-valued overlap.
@@ -825,8 +819,8 @@ def overlap(x: ArrayLike, y: ArrayLike) -> Array:
         >>> dq.overlap(fock0, fock01_dm)
         Array(0.5, dtype=float32)
     """
-    x = jnp.asarray(x)
-    y = jnp.asarray(y)
+    x = asqarray(x)
+    y = asqarray(y)
     check_shape(x, 'x', '(..., n, 1)', '(..., n, n)')
     check_shape(y, 'y', '(..., n, 1)', '(..., n, n)')
 
@@ -840,7 +834,7 @@ def overlap(x: ArrayLike, y: ArrayLike) -> Array:
         return tracemm(dag(x), y).real
 
 
-def fidelity(x: ArrayLike, y: ArrayLike) -> Array:
+def fidelity(x: QArrayLike, y: QArrayLike) -> Array:
     r"""Returns the fidelity of two states, kets or density matrices.
 
     The fidelity is computed
@@ -857,8 +851,8 @@ def fidelity(x: ArrayLike, y: ArrayLike) -> Array:
         fidelity $F_\text{qutip} = \sqrt{F}$.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
-        y _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        x _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        y _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
         _(array of shape (...))_ Real-valued fidelity.
@@ -873,8 +867,8 @@ def fidelity(x: ArrayLike, y: ArrayLike) -> Array:
         >>> dq.fidelity(fock0, fock01_dm)
         Array(0.5, dtype=float32)
     """
-    x = jnp.asarray(x)
-    y = jnp.asarray(y)
+    x = asqarray(x)
+    y = asqarray(y)
     check_shape(x, 'x', '(..., n, 1)', '(..., n, n)')
     check_shape(y, 'y', '(..., n, 1)', '(..., n, n)')
 
@@ -886,7 +880,7 @@ def fidelity(x: ArrayLike, y: ArrayLike) -> Array:
         return _dm_fidelity_gpu(x, y)
 
 
-def _dm_fidelity_cpu(x: Array, y: Array) -> Array:
+def _dm_fidelity_cpu(x: QArray, y: QArray) -> Array:
     # returns the fidelity of two density matrices: Tr[sqrt(sqrt(x) @ y @ sqrt(x))]^2
     # x: (..., n, n), y: (..., n, n) -> (...)
 
@@ -901,13 +895,13 @@ def _dm_fidelity_cpu(x: Array, y: Array) -> Array:
     # matrix x @ y is not Hermitian.
 
     # note that we can't use `eigvalsh` here because x @ y is not necessarily Hermitian
-    w = jnp.linalg.eigvals(x @ y).real
+    w = (x @ y)._eigvals().real  # noqa: SLF001
     # we set small negative eigenvalues errors to zero to avoid `nan` propagation
     w = jnp.where(w < 0, 0, w)
     return jnp.sqrt(w).sum(-1) ** 2
 
 
-def _dm_fidelity_gpu(x: Array, y: Array) -> Array:
+def _dm_fidelity_gpu(x: QArray, y: QArray) -> Array:
     # returns the fidelity of two density matrices: Tr[sqrt(sqrt(x) @ y @ sqrt(x))]^2
     # x: (..., n, n), y: (..., n, n) -> (...)
 
@@ -915,13 +909,13 @@ def _dm_fidelity_gpu(x: Array, y: Array) -> Array:
     # and compute the fidelity as F = (\sum_i \sqrt{w_i})^2.
 
     sqrtm_x = _sqrtm_gpu(x)
-    w = jnp.linalg.eigvalsh(sqrtm_x @ y @ sqrtm_x)
+    w = (sqrtm_x @ y @ sqrtm_x)._eigvalsh()  # noqa: SLF001
     # we set small negative eigenvalues errors to zero to avoid `nan` propagation
     w = jnp.where(w < 0, 0, w)
     return jnp.sqrt(w).sum(-1) ** 2
 
 
-def _sqrtm_gpu(x: Array) -> Array:
+def _sqrtm_gpu(x: QArray) -> Array:
     # returns the square root of a symmetric or Hermitian positive definite matrix
     # x: (..., n, n) -> (..., n, n)
 
@@ -931,7 +925,7 @@ def _sqrtm_gpu(x: Array) -> Array:
     # This method is a GPU-compatible implementation of `jax.scipy.linalg.sqrtm` for
     # symmetric or Hermitian positive definite matrix.
 
-    w, v = jnp.linalg.eigh(x)
+    w, v = x._eigh()  # noqa: SLF001
     # we set small negative eigenvalues errors to zero to avoid `nan` propagation
     w = jnp.where(w < 0, 0, w)
     # numerical trick to compute 'v @ jnp.diag(jnp.sqrt(w)) @ v.mT.conj()' faster with
@@ -939,13 +933,13 @@ def _sqrtm_gpu(x: Array) -> Array:
     return (v * jnp.sqrt(w)[None, :]) @ v.mT.conj()
 
 
-def entropy_vn(x: ArrayLike) -> Array:
+def entropy_vn(x: QArrayLike) -> Array:
     r"""Returns the Von Neumann entropy of a ket or density matrix.
 
     It is defined by $S(\rho) = -\tr{\rho \ln \rho}$.
 
     Args:
-        x _(array_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        x _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
         _(array of shape (...))_ Real-valued Von Neumann entropy.
@@ -958,14 +952,14 @@ def entropy_vn(x: ArrayLike) -> Array:
         >>> dq.entropy_vn(psis).shape
         (5,)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, 1)', '(..., n, n)')
 
     if isket(x):
         return jnp.zeros(x.shape[:-2])
 
     # compute sum(w_i log(w_i)) where w_i are rho's eigenvalues
-    w = jnp.linalg.eigvalsh(x)
+    w = x._eigvalsh()  # noqa: SLF001
     # we set small negative or null eigenvalues to 1.0 to avoid `nan` propagation
     w = jnp.where(w <= 0, 1.0, w)
     return -(w * jnp.log(w)).sum(-1)

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-import jax.numpy as jnp
 import numpy as np
-from jax import Array
-from jaxtyping import ArrayLike
 
 from .._checks import check_shape
+from ..qarrays import QArray, QArrayLike, asqarray
 from .operators import eye
 from .utils import dag
-from .utils.general import _bkron
 
 __all__ = [
     'operator_to_vector',
@@ -21,7 +18,7 @@ __all__ = [
 ]
 
 
-def operator_to_vector(x: ArrayLike) -> Array:
+def operator_to_vector(x: QArrayLike) -> QArray:
     r"""Returns the vectorized version of an operator.
 
     The vectorized column vector $\kett{A}$ (shape $n^2\times 1$) is obtained by
@@ -33,10 +30,10 @@ def operator_to_vector(x: ArrayLike) -> Array:
     $$
 
     Args:
-        x _(array_like of shape (..., n, n))_: Operator.
+        x _(qarray_like of shape (..., n, n))_: Operator.
 
     Returns:
-        _(array of shape (..., n^2, 1))_ Vectorized operator.
+        _(qarray of shape (..., n^2, 1))_ Vectorized operator.
 
     Examples:
         >>> A = jnp.array([[1 + 1j, 2 + 2j], [3 + 3j, 4 + 4j]])
@@ -49,13 +46,13 @@ def operator_to_vector(x: ArrayLike) -> Array:
                [2.+2.j],
                [4.+4.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
     bshape = x.shape[:-2]
     return x.mT.reshape(*bshape, -1, 1)
 
 
-def vector_to_operator(x: ArrayLike) -> Array:
+def vector_to_operator(x: QArrayLike) -> QArray:
     r"""Returns the operator version of a vectorized operator.
 
     The matrix $A$ (shape $n\times n$) is obtained by stacking horizontally next to
@@ -68,10 +65,10 @@ def vector_to_operator(x: ArrayLike) -> Array:
     $$
 
     Args:
-        x _(array_like of shape (..., n^2, 1))_: Vectorized operator.
+        x _(qarray_like of shape (..., n^2, 1))_: Vectorized operator.
 
     Returns:
-        _(array of shape (..., n, n))_ Operator.
+        _(qarray of shape (..., n, n))_ Operator.
 
     Examples:
         >>> Avec = jnp.array([[1 + 1j], [2 + 2j], [3 + 3j], [4 + 4j]])
@@ -84,14 +81,14 @@ def vector_to_operator(x: ArrayLike) -> Array:
         Array([[1.+1.j, 3.+3.j],
                [2.+2.j, 4.+4.j]], dtype=complex64)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n^2, 1)')
     bshape = x.shape[:-2]
     n = int(np.sqrt(x.shape[-2]))
     return x.reshape(*bshape, n, n).mT
 
 
-def spre(x: ArrayLike) -> Array:
+def spre(x: QArrayLike) -> QArray:
     r"""Returns the superoperator formed from pre-multiplication by an operator.
 
     Pre-multiplication by matrix $A$ is defined by the superoperator
@@ -101,23 +98,22 @@ def spre(x: ArrayLike) -> Array:
     $$
 
     Args:
-        x _(array_like of shape (..., n, n))_: Operator.
+        x _(qarray_like of shape (..., n, n))_: Operator.
 
     Returns:
-        _(array of shape (..., n^2, n^2))_ Pre-multiplication superoperator.
+        _(qarray of shape (..., n^2, n^2))_ Pre-multiplication superoperator.
 
     Examples:
         >>> dq.spre(dq.destroy(3)).shape
         (9, 9)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
     n = x.shape[-1]
-    Id = eye(n)
-    return _bkron(Id, x)
+    return eye(n) & x
 
 
-def spost(x: ArrayLike) -> Array:
+def spost(x: QArrayLike) -> QArray:
     r"""Returns the superoperator formed from post-multiplication by an operator.
 
     Post-multiplication by matrix $A$ is defined by the superoperator
@@ -127,23 +123,22 @@ def spost(x: ArrayLike) -> Array:
     $$
 
     Args:
-        x _(array_like of shape (..., n, n))_: Operator.
+        x _(qarray_like of shape (..., n, n))_: Operator.
 
     Returns:
-        _(array of shape (..., n^2, n^2))_ Post-multiplication superoperator.
+        _(qarray of shape (..., n^2, n^2))_ Post-multiplication superoperator.
 
     Examples:
         >>> dq.spost(dq.destroy(3)).shape
         (9, 9)
     """
-    x = jnp.asarray(x)
+    x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
     n = x.shape[-1]
-    Id = eye(n)
-    return _bkron(x.mT, Id)
+    return x.mT & eye(n)
 
 
-def sprepost(x: ArrayLike, y: ArrayLike) -> Array:
+def sprepost(x: QArrayLike, y: QArrayLike) -> QArray:
     r"""Returns the superoperator formed from pre- and post-multiplication by operators.
 
     Pre-multiplication by matrix $A$ and post-multiplication by matrix $B$ is defined
@@ -153,24 +148,24 @@ def sprepost(x: ArrayLike, y: ArrayLike) -> Array:
     $$
 
     Args:
-        x _(array_like of shape (..., n, n))_: Operator for pre-multiplication.
-        y _(array_like of shape (..., n, n))_: Operator for post-multiplication.
+        x _(qarray_like of shape (..., n, n))_: Operator for pre-multiplication.
+        y _(qarray_like of shape (..., n, n))_: Operator for post-multiplication.
 
     Returns:
-        _(array of shape (..., n^2, n^2))_ Pre- and post-multiplication superoperator.
+        _(Qarray of shape (..., n^2, n^2))_ Pre- and post-multiplication superoperator.
 
     Examples:
         >>> dq.sprepost(dq.destroy(3), dq.create(3)).shape
         (9, 9)
     """
-    x = jnp.asarray(x)
-    y = jnp.asarray(y)
+    x = asqarray(x)
+    y = asqarray(y)
     check_shape(x, 'x', '(..., n, n)')
     check_shape(y, 'y', '(..., n, n)')
-    return _bkron(y.mT, x)
+    return y.mT & x
 
 
-def sdissipator(L: ArrayLike) -> Array:
+def sdissipator(L: QArrayLike) -> QArray:
     r"""Returns the Lindblad dissipation superoperator (in matrix form).
 
     The dissipation superoperator $\mathcal{D}[L]$ is defined by:
@@ -187,19 +182,19 @@ def sdissipator(L: ArrayLike) -> Array:
     $$
 
     Args:
-        L _(array_like of shape (..., n, n))_: Jump operator.
+        L _(qarray_like of shape (..., n, n))_: Jump operator.
 
     Returns:
-        _(array of shape (..., n^2, n^2))_ Dissipation superoperator.
+        _(qarray of shape (..., n^2, n^2))_ Dissipation superoperator.
     """
-    L = jnp.asarray(L)
+    L = asqarray(L)
     check_shape(L, 'L', '(..., n, n)')
     Ldag = dag(L)
     LdagL = Ldag @ L
     return sprepost(L, Ldag) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
 
 
-def slindbladian(H: ArrayLike, jump_ops: ArrayLike) -> Array:
+def slindbladian(H: QArrayLike, jump_ops: QArrayLike) -> QArray:
     r"""Returns the Lindbladian superoperator (in matrix form).
 
     The Lindbladian superoperator $\mathcal{L}$ is defined by:
@@ -224,14 +219,14 @@ def slindbladian(H: ArrayLike, jump_ops: ArrayLike) -> Array:
         This superoperator is also sometimes called *Liouvillian*.
 
     Args:
-        H _(array_like of shape (..., n, n))_: Hamiltonian.
-        jump_ops _(array_like of shape (N, ..., n, n))_: Sequence of jump operators.
+        H _(qarray_like of shape (..., n, n))_: Hamiltonian.
+        jump_ops _(qarray_like of shape (N, ..., n, n))_: Sequence of jump operators.
 
     Returns:
-        _(array of shape (..., n^2, n^2))_ Lindbladian superoperator.
+        _(qarray of shape (..., n^2, n^2))_ Lindbladian superoperator.
     """
-    H = jnp.asarray(H)
-    jump_ops = jnp.asarray(jump_ops)
+    H = asqarray(H)
+    jump_ops = asqarray(jump_ops)
     check_shape(H, 'H', '(..., n, n)')
     check_shape(jump_ops, 'jump_ops', '(N, ..., n, n)')
     return -1j * (spre(H) - spost(H)) + sdissipator(jump_ops).sum(0)


### PR DESCRIPTION
Replaces #621. Documentation will come later (see incoming PR).

I ported
- [x] `utils/utils/general.py`
- [x] `_utils.py`
- [x] `_checks.py`
- [x] `utils/vectorization.py`
- [x] `utils/jax_utils.py`

Remaining things from these files (but I'm tired and this PR is already massive, tasks added to https://linear.app/dynamiqs/issue/DYN-210/qarray-object):
- [ ] `ptrace()` in `utils/utils/general.py` and in `QArray` API
- [ ] `expect()` vmap is bugged

I also added a few technical points to https://linear.app/dynamiqs/issue/DYN-210/qarray-object.

Few random remarks:
- Note that for now vectorization depends on `eye(n)` returning a `QArray` which will soon be fixed.
- I had to be a bit siouks to avoid circular imports, any other solution is welcome. :)
- Doctest can be quickly run for `utils/utils/general.py` by implementing `DenseQArray.__repr__` with `repr(self.data)`, which I did in this PR for convenience. This will be fixed soon.

For later PRs (tasks added to https://linear.app/dynamiqs/issue/DYN-210/qarray-object):
- [ ] implement a proper `__repr__` and fix the docstrings
- [ ]  creation utilities: `utils/operators.py`, `utils/states.py`, `utils/optimal_control.py`, `dark/dark.py`
- [ ] `utils/wigner.py`
- [ ] `plots/`
- [ ] `utils/random.py`
- [ ] `sesolve/`, `mesolve/`, `smesolve/`, `core/`, `result.py`, `time_array.py`
- [ ] sparse DIA
- [ ] make objects in `types.py` public and documented
- [ ] fix the tutorials and the documentation everywhere