### PR TITLE
New `QArray` and `DenseQArray` string `__repr__`

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -108,7 +108,10 @@ class DenseQArray(QArray):
         return np.asarray(self.data, dtype=dtype)
 
     def __repr__(self) -> str:
-        return repr(self.data)
+        return (
+            f'{type(self).__name__}: shape={self.shape}, dims={self.dims}, '
+            f'dtype={self.dtype}\n{self.data}'
+        )
 
     def __mul__(self, y: QArrayLike) -> QArray:
         super().__mul__(y)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -304,8 +304,8 @@ class QArray(eqx.Module):
 
     def __repr__(self) -> str:
         return (
-            f'{type(self).__name__}(shape={self.shape}, '
-            f'dims={self.dims}, dtype={self.dtype})'
+            f'{type(self).__name__}: shape={self.shape}, dims={self.dims}, '
+            f'dtype={self.dtype}'
         )
 
     def __neg__(self) -> QArray:


### PR DESCRIPTION
On top of #623.

Examples
```python
>>> dq.eye(3)
DenseQArray: shape=(3, 3), dims=(3,), dtype=complex64
[[1.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 1.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 1.+0.j]]
>>> dq.eye(2) & dq.eye(3)
DenseQArray: shape=(6, 6), dims=(2, 3), dtype=complex64
[[1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j]
 [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j]]
```