### PR TITLE
Filter FutureWarning: unhashable type

### DIFF
--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -28,9 +28,11 @@ class DiffraxSolver(BaseSolver):
         super().__init__(*args)
 
     def run(self) -> PyTree:
-        # TODO: remove once complex support is stabilized in diffrax
         with warnings.catch_warnings():
+            # TODO: remove once complex support is stabilized in diffrax
             warnings.simplefilter('ignore', UserWarning)
+            # TODO: remove once https://github.com/patrick-kidger/diffrax/issues/445 is
+            # closed
             warnings.simplefilter('ignore', FutureWarning)
 
             # === prepare diffrax arguments

--- a/dynamiqs/core/diffrax_solver.py
+++ b/dynamiqs/core/diffrax_solver.py
@@ -31,6 +31,7 @@ class DiffraxSolver(BaseSolver):
         # TODO: remove once complex support is stabilized in diffrax
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
+            warnings.simplefilter('ignore', FutureWarning)
 
             # === prepare diffrax arguments
             fn = lambda t, y, args: self.save(y)  # noqa: ARG005


### PR DESCRIPTION
Temporary fix for the warnings coming from diffrax + jax 0.4.30.
```
~/miniconda3/lib/python3.11/site-packages/jax/_src/core.py:678: FutureWarning: unhashable type: <class 'jax._src.interpreters.partial_eval.DynamicJaxprTracer'>. Attempting to hash a tracer will lead to an error in a future JAX release.
  warnings.warn(
```

See also https://github.com/patrick-kidger/diffrax/issues/445.

Closes DYN-223.