### PR TITLE
Add Kronecker Product support to sparse dia qarrays

### DIFF
--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -284,13 +284,15 @@ class SparseDIAQArray(QArray):
             tuple(o.item() for o in unique_offsets), out_diags, self.dims
         )
 
-    def __and__(self, other: QArrayLike) -> SparseDIAQArray | Array:
+    def __and__(self, other: QArrayLike) -> QArray:
         if isinstance(other, SparseDIAQArray):
             temp_o, temp_d = self._kronecker_dia(other=other)
             return self._clean_kronecker_dia(temp_o, temp_d)
 
         elif isinstance(other, get_args(QArrayLike)):
-            return jnp.kron(self.to_dense(), other)
+            return DenseQArray(
+                other.dims, jnp.kron(self.to_dense(), jnp.asarray(other))
+            )
 
         return NotImplemented
 

--- a/dynamiqs/qarrays/sparse_qarray.py
+++ b/dynamiqs/qarrays/sparse_qarray.py
@@ -11,6 +11,7 @@ import numpy as np
 from jax._src.core import concrete_or_error
 from jaxtyping import Array, ArrayLike, Scalar, ScalarLike
 
+from ..utils.utils.general import isbra, isdm, isket
 from .dense_qarray import DenseQArray
 from .qarray import QArray
 
@@ -69,6 +70,15 @@ class SparseQArray(QArray):
 
     def unit(self) -> SparseQArray:
         return SparseQArray(self.diags / self.norm(), self.offsets, self.dims)
+
+    def isket(self) -> bool:
+        return isket(self.to_dense())
+
+    def isbra(self) -> bool:
+        return isbra(self.to_dense())
+
+    def isdm(self) -> bool:
+        return isdm(self.to_dense())
 
     def __neg__(self) -> QArray:
         return -1 * self

--- a/dynamiqs/qarrays/sparse_qarray.py
+++ b/dynamiqs/qarrays/sparse_qarray.py
@@ -298,8 +298,8 @@ class SparseQArray(QArray):
 
         return tuple(out_offsets), out_diags
 
-    def __and__(self, other: Array) -> Array:
-        if isinstance(other, Array):
+    def __and__(self, other: Array) -> QArray:
+        if isinstance(other, DenseQArray):
             return self._tensor_dense(other=other)
 
         elif isinstance(other, SparseQArray):

--- a/dynamiqs/qarrays/sparse_qarray.py
+++ b/dynamiqs/qarrays/sparse_qarray.py
@@ -11,7 +11,6 @@ import numpy as np
 from jax._src.core import concrete_or_error
 from jaxtyping import Array, ArrayLike, Scalar, ScalarLike
 
-from ..utils.utils.general import isbra, isdm, isket
 from .dense_qarray import DenseQArray
 from .qarray import QArray
 
@@ -70,15 +69,6 @@ class SparseQArray(QArray):
 
     def unit(self) -> SparseQArray:
         return SparseQArray(self.offsets, self.diags / self.norm(), self.dims)
-
-    def isket(self) -> bool:
-        return isket(self.to_dense())
-
-    def isbra(self) -> bool:
-        return isbra(self.to_dense())
-
-    def isdm(self) -> bool:
-        return isdm(self.to_dense())
 
     def __neg__(self) -> QArray:
         return -1 * self

--- a/dynamiqs/qarrays/sparse_qarray.py
+++ b/dynamiqs/qarrays/sparse_qarray.py
@@ -288,13 +288,13 @@ class SparseQArray(QArray):
             tuple(o.item() for o in unique_offsets), out_diags, self.dims
         )
 
-    def __and__(self, other: Array) -> Array:
-        if isinstance(other, Array):
-            return jnp.kron(self.to_dense(), other)
-
-        elif isinstance(other, SparseQArray):
+    def __and__(self, other: Array) -> QArray:
+        if isinstance(other, SparseQArray):
             temp_o, temp_d = self._kronecker_dia(other=other)
             return self._clean_kronecker_dia(temp_o, temp_d)
+
+        elif isinstance(other, Array):
+            return jnp.kron(self.to_dense(), other)
 
         return NotImplemented
 

--- a/tests/qarrays/test_sparse_qarray.py
+++ b/tests/qarrays/test_sparse_qarray.py
@@ -66,3 +66,11 @@ class TestSparseDIA:
         assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
         assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
         assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
+
+    def test_kronecker(self, rtol=1e-05, atol=1e-08):
+        out_dia_dia = (self.sparseA & self.sparseB).to_dense()
+        out_dia_dense = self.sparseA & self.matrixB
+        out_dense_dense = jnp.kron(self.matrixA, self.matrixB)
+
+        assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
+        assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)


### PR DESCRIPTION
This PR adds the `__and__` dunder with 2 methods to calculate the kronecker product between a SparseQArray matrix and a another SparseQArray matrix and between a SparseQArray matrix and a Dense matrix. 