### PR TITLE
Add  `__pow__` and `powm()` features

### DIFF
--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -250,8 +250,14 @@ class SparseDIAQArray(QArray):
     def __and__(self, y: QArray) -> QArray:
         return NotImplemented
 
-    def __pow__(self, y: Scalar) -> QArray:
-        return NotImplemented
+    def powm(self, n: ScalarLike) -> QArray:
+        result = self
+        for _ in range(n - 1):
+            result = result @ self
+        return result
+
+    def __pow__(self, n: ScalarLike) -> SparseDIAQArray:
+        return SparseDIAQArray(self.dims, self.offsets, jnp.power(self.diags, n))
 
 
 def _check_compatible_dims(dims1: tuple[int, ...], dims2: tuple[int, ...]):

--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -250,13 +250,11 @@ class SparseDIAQArray(QArray):
     def __and__(self, y: QArray) -> QArray:
         return NotImplemented
 
-    def powm(self, n: ScalarLike) -> QArray:
-        result = self
-        for _ in range(n - 1):
-            result = result @ self
-        return result
+    def powm(self, n: int) -> QArray:
+        f = lambda carry, _: (carry @ self, None)
+        return jax.lax.scan(f, self, length=n - 1)
 
-    def __pow__(self, n: ScalarLike) -> SparseDIAQArray:
+    def __pow__(self, n: int) -> SparseDIAQArray:
         return SparseDIAQArray(self.dims, self.offsets, jnp.power(self.diags, n))
 
 

--- a/tests/qarrays/test_sparse_dia_qarray.py
+++ b/tests/qarrays/test_sparse_dia_qarray.py
@@ -69,3 +69,19 @@ class TestSparseDIAQArray:
         assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
         assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
         assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
+
+    def test_pow(self, rtol=1e-05, atol=1e-08):
+        N = 3
+        out_dia = dq.to_dense(self.sparseA**N)
+        out_dense = self.matrixA**N
+
+        assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)
+
+    def test_powm(self, rtol=1e-05, atol=1e-08):
+        N = 3
+        out_dia = dq.to_dense(self.sparseA.powm(N))
+        out_dense = self.matrixA
+        for _ in range(N - 1):
+            out_dense = out_dense @ self.matrixA
+
+        assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)

--- a/tests/qarrays/test_sparse_dia_qarray.py
+++ b/tests/qarrays/test_sparse_dia_qarray.py
@@ -80,8 +80,6 @@ class TestSparseDIAQArray:
     def test_powm(self, rtol=1e-05, atol=1e-08):
         N = 3
         out_dia = dq.to_dense(self.sparseA.powm(N))
-        out_dense = self.matrixA
-        for _ in range(N - 1):
-            out_dense = out_dense @ self.matrixA
+        out_dense = jnp.linalg.matrix_power(self.matrixA, N)
 
         assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)


### PR DESCRIPTION
This PR adds the `__pow__` magic method and the ̀powm()` method with associated tests. We still need to figure out the circular import problems to make everything work but the code runs smoothly locally.