### PR TITLE
Fix typings in various files to migrate

### DIFF
--- a/dynamiqs/core/abstract_solver.py
+++ b/dynamiqs/core/abstract_solver.py
@@ -8,6 +8,7 @@ from jaxtyping import PyTree, Scalar
 
 from ..gradient import Gradient
 from ..options import Options
+from ..qarrays import QArray
 from ..result import MEResult, Result, Saved, SEResult
 from ..solver import Solver
 from ..time_array import TimeArray
@@ -22,9 +23,9 @@ class AbstractSolver(eqx.Module):
 
 class BaseSolver(AbstractSolver):
     ts: Array
-    y0: Array
+    y0: QArray
     H: TimeArray
-    Es: Array
+    Es: QArray
     solver: Solver
     gradient: Gradient | None
     options: Options
@@ -48,7 +49,7 @@ class BaseSolver(AbstractSolver):
 
         return Saved(ysave, Esave, extra)
 
-    def collect_saved(self, saved: Saved, ylast: Array) -> Saved:
+    def collect_saved(self, saved: Saved, ylast: QArray) -> Saved:
         # if save_states is False save only last state
         if not self.options.save_states:
             saved = eqx.tree_at(

--- a/dynamiqs/core/propagator_solver.py
+++ b/dynamiqs/core/propagator_solver.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 from jax import Array
 from jaxtyping import PyTree, Scalar
 
+from ..qarrays import QArray
 from ..time_array import ConstantTimeArray
 from .abstract_solver import BaseSolver, MESolver, SESolver
 
@@ -59,7 +60,7 @@ class PropagatorSolver(BaseSolver):
         return self.result(saved, infos=self.Infos(nsteps))
 
     @abstractmethod
-    def forward(self, delta_t: Scalar, y: Array) -> Array:
+    def forward(self, delta_t: Scalar, y: QArray) -> QArray:
         pass
 
 

--- a/dynamiqs/mesolve/mepropagator.py
+++ b/dynamiqs/mesolve/mepropagator.py
@@ -23,6 +23,6 @@ class MEPropagator(MEPropagatorSolver):
 
     def save(self, y: QArray) -> Saved:
         # TODO: implement bexpect for vectorized operators and convert at the end
-        #       instead ofat each step
+        #       instead of at each step
         y = vector_to_operator(y)
         return super().save(y)

--- a/dynamiqs/mesolve/mepropagator.py
+++ b/dynamiqs/mesolve/mepropagator.py
@@ -1,8 +1,8 @@
 import jax
-from jax import Array
 from jaxtyping import Scalar
 
 from ..core.propagator_solver import MEPropagatorSolver
+from ..qarrays import QArray
 from ..result import Saved
 from ..utils.vectorization import operator_to_vector, slindbladian, vector_to_operator
 
@@ -10,18 +10,18 @@ from ..utils.vectorization import operator_to_vector, slindbladian, vector_to_op
 class MEPropagator(MEPropagatorSolver):
     # supports only ConstantTimeArray
     # TODO: support PWCTimeArray
-    lindbladian: Array
+    lindbladian: QArray
 
     def __init__(self, *args):
         super().__init__(*args)
         self.lindbladian = slindbladian(self.H, self.Ls)  # (n^2, n^2)
         self.y0 = operator_to_vector(self.y0)  # (n^2, 1)
 
-    def forward(self, delta_t: Scalar, y: Array) -> Array:
+    def forward(self, delta_t: Scalar, y: QArray) -> QArray:
         propagator = jax.scipy.linalg.expm(delta_t * self.lindbladian)
         return propagator @ y
 
-    def save(self, y: Array) -> Saved:
+    def save(self, y: QArray) -> Saved:
         # TODO: implement bexpect for vectorized operators and convert at the end
         #       instead ofat each step
         y = vector_to_operator(y)

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -6,6 +6,7 @@ from jaxtyping import PyTree
 
 from .gradient import Gradient
 from .options import Options
+from .qarrays import QArray, asjaxarray
 from .solver import Solver
 
 __all__ = ['SEResult', 'MEResult']
@@ -25,13 +26,15 @@ def memory_str(x: Array) -> str:
         return f'{mem / 1024**3:.2f} Gb'
 
 
-def array_str(x: Array | None) -> str | None:
+def array_str(x: Array | QArray | None) -> str | None:
+    # TODO: implement memory_str for QArray rather than converting to JAX array
+    x = asjaxarray(x)
     return None if x is None else f'Array {x.dtype} {tuple(x.shape)} | {memory_str(x)}'
 
 
 # the Saved object holds quantities saved during the equation integration
 class Saved(eqx.Module):
-    ysave: Array
+    ysave: QArray
     Esave: Array | None
     extra: PyTree | None
 
@@ -45,7 +48,7 @@ class Result(eqx.Module):
     infos: PyTree | None
 
     @property
-    def states(self) -> Array:
+    def states(self) -> QArray:
         return self._saved.ysave
 
     @property
@@ -92,7 +95,7 @@ class SEResult(Result):
     r"""Result of the Schrödinger equation integration.
 
     Attributes:
-        states _(array of shape (..., ntsave, n, 1))_: Saved states.
+        states _(qarray of shape (..., ntsave, n, 1))_: Saved states.
         expects _(array of shape (..., len(exp_ops), ntsave) or None)_: Saved
             expectation values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
@@ -142,7 +145,7 @@ class MEResult(Result):
     """Result of the Lindblad master equation integration.
 
     Attributes:
-        states _(array of shape (..., ntsave, n, n))_: Saved states.
+        states _(qarray of shape (..., ntsave, n, n))_: Saved states.
         expects _(array of shape (..., len(exp_ops), ntsave) or None)_: Saved
             expectation values, if specified by `exp_ops`.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if

--- a/dynamiqs/sesolve/sepropagator.py
+++ b/dynamiqs/sesolve/sepropagator.py
@@ -1,14 +1,14 @@
 import jax
-from jax import Array
 from jaxtyping import Scalar
 
 from ..core.propagator_solver import SEPropagatorSolver
+from ..qarrays import QArray
 
 
 class SEPropagator(SEPropagatorSolver):
     # supports only ConstantTimeArray
     # TODO: support PWCTimeArray
 
-    def forward(self, delta_t: Scalar, y: Array) -> Array:
+    def forward(self, delta_t: Scalar, y: QArray) -> QArray:
         propagator = jax.scipy.linalg.expm(-1j * self.H * delta_t)
         return propagator @ y

--- a/dynamiqs/smesolve/smesolve.py
+++ b/dynamiqs/smesolve/smesolve.py
@@ -6,6 +6,7 @@ from jaxtyping import ArrayLike
 
 from ..gradient import Gradient
 from ..options import Options
+from ..qarrays import QArrayLike
 from ..result import Result
 from ..solver import Solver
 from ..time_array import TimeArray
@@ -14,15 +15,15 @@ __all__ = ['smesolve']
 
 
 def smesolve(
-    H: ArrayLike | TimeArray,
-    jump_ops: list[ArrayLike | TimeArray],
+    H: QArrayLike | TimeArray,
+    jump_ops: list[QArrayLike | TimeArray],
     etas: ArrayLike,
-    rho0: ArrayLike,
+    rho0: QArrayLike,
     tsave: ArrayLike,
     *,
     tmeas: ArrayLike | None = None,
     ntrajs: int = 10,
-    exp_ops: list[ArrayLike] | None = None,
+    exp_ops: list[QArrayLike] | None = None,
     solver: Solver | None = None,
     gradient: Gradient | None = None,
     options: Options = Options(),  # noqa: B008
@@ -99,21 +100,21 @@ def smesolve(
         more details.
 
     Args:
-        H _(array-like or time-array of shape (bH?, n, n))_: Hamiltonian.
-        jump_ops _(list of array-like or time-array, of shape (nL, n, n))_: List of
+        H _(qarray-like or time-array of shape (bH?, n, n))_: Hamiltonian.
+        jump_ops _(list of qarray-like or time-array, of shape (nL, n, n))_: List of
             jump operators.
         etas _(array-like of shape (nL,))_: Measurement efficiencies, must be of the
             same length as `jump_ops` with values between 0 and 1. For a purely
             dissipative loss channel, set the corresponding efficiency to 0. No
             measurement signal will be returned for such channels.
-        rho0 _(array-like of shape (brho?, n, 1) or (brho?, n, n))_: Initial state.
+        rho0 _(qarray-like of shape (brho?, n, 1) or (brho?, n, n))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`, or from `t0` to `tsave[-1]` if `t0` is specified in `options`.
         tmeas _(array-like of shape (ntmeas,), optional)_: Times between which
             measurement signals are averaged and saved. Defaults to `tsave`.
         ntrajs: Number of stochastic trajectories to solve concurrently.
-        exp_ops _(list of array-like, of shape (nE, n, n), optional)_: List of
+        exp_ops _(list of qarray-like, of shape (nE, n, n), optional)_: List of
             operators for which the expectation value is computed.
         solver: Solver for the integration.
         gradient: Algorithm used to compute the gradient.


### PR DESCRIPTION
Quick PR to fix the simple typings here and there. Migrate
- [x] `abstract_solver.py`
- [x] `propagator_solver.py`
- [x] `mepropagator.py`
- [x] `sepropagator.py`
- [x] `result.py`
- [x] `smesolve.py`