### PR TITLE
Implement `dq.stack` for QArrays and fix mesolve `vector_field` consequently

### DIFF
--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -21,6 +21,7 @@ PATHS_TO_PARSE = [
     ('dynamiqs/solvers.py', 'dq'),
     ('dynamiqs/result.py', 'dq'),
     ('dynamiqs/options.py', 'dq'),
+    ('dynamiqs/qarrays/utils.py', 'dq'),
     # directories
     ('dynamiqs/plots', 'dq'),
     ('dynamiqs/utils/utils', 'dq'),

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -78,6 +78,12 @@ The **dynamiqs** Python API features two main types of functions: solvers of dif
     options:
         table: true
 
+### QArray utilities
+
+::: dynamiqs.qarrays.utils
+    options:
+        table: true
+
 ### JAX-related utilities
 
 ::: dynamiqs.utils.jax_utils

--- a/dynamiqs/mesolve/mediffrax.py
+++ b/dynamiqs/mesolve/mediffrax.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import diffrax as dx
-import jax.numpy as jnp
 
 from ..core.abstract_solver import MESolver
 from ..core.diffrax_solver import (
@@ -11,6 +10,7 @@ from ..core.diffrax_solver import (
     EulerSolver,
     Tsit5Solver,
 )
+from ..qarrays.utils import stack
 from ..utils.utils import dag
 
 
@@ -37,7 +37,7 @@ class MEDiffraxSolver(DiffraxSolver, MESolver):
         # induced on the dynamics.
 
         def vector_field(t, y, _):  # noqa: ANN001, ANN202
-            Ls = jnp.stack([L(t) for L in self.Ls])
+            Ls = stack([L(t) for L in self.Ls])
             Lsd = dag(Ls)
             LdL = (Lsd @ Ls).sum(0)
             tmp = (-1j * self.H(t) - 0.5 * LdL) @ y + 0.5 * (Ls @ y @ Lsd).sum(0)

--- a/dynamiqs/qarrays/__init__.py
+++ b/dynamiqs/qarrays/__init__.py
@@ -1,1 +1,2 @@
 from .types import *
+from .utils import *

--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -16,6 +16,8 @@ from qutip import Qobj
 from .dense_qarray import DenseQArray
 from .qarray import QArray, QArrayLike
 
+__all__ = ['SparseDIAQArray', 'to_dense', 'to_sparse_dia']
+
 
 class SparseDIAQArray(QArray):
     offsets: tuple[int, ...] = eqx.field(static=True)

--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -14,7 +14,7 @@ from jaxtyping import Array, ArrayLike, Scalar, ScalarLike
 from qutip import Qobj
 
 from .dense_qarray import DenseQArray
-from .qarray import QArray, QArrayLike
+from .types import QArray, QArrayLike
 
 __all__ = ['SparseDIAQArray', 'to_dense', 'to_sparse_dia']
 

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import jax.numpy as jnp
+
+from .dense_qarray import DenseQArray
+from .sparse_dia_qarray import SparseDIAQArray
+from .types import QArray
+
+__all__ = ['stack']
+
+
+def stack(qarrays: QArray | Sequence[QArray], axis: int = 0) -> QArray:
+    """Join a sequence of QArrays along a new axis.
+
+    Args:
+        qarrays: The QArrays to be stacked.
+        axis: The axis in the result along which the input QArrays are stacked.
+
+    Returns:
+        QArray: The stacked QArray.
+    """
+    if isinstance(qarrays, QArray):
+        return qarrays
+
+    # check validity of input
+    if len(qarrays) == 0:
+        raise ValueError('At least one QArray must be provided.')
+    if not all(isinstance(q, QArray) for q in qarrays):
+        raise ValueError('All elements must be of type QArray.')
+    if not all(qarray.dims == qarrays[0].dims for qarray in qarrays):
+        raise ValueError('All elements must have the same dims.')
+
+    # stack inputs depending on type
+    dims = qarrays[0].dims
+    if all(isinstance(qarray, DenseQArray) for qarray in qarrays):
+        data = jnp.stack([qarray.data for qarray in qarrays], axis=axis)
+        return DenseQArray(dims, data)
+    elif all(isinstance(qarray, SparseDIAQArray) for qarray in qarrays):
+        if not all(qarray.offsets == qarrays[0].offsets for qarray in qarrays):
+            # todo: implement stacking with different offsets
+            raise NotImplementedError(
+                'All SparseDIAQArrays to be stacked must have the same offsets.'
+            )
+        diags = jnp.stack([x.diags for x in qarrays], axis=axis)
+        offsets = qarrays[0].offsets
+        return SparseDIAQArray(dims, diags, offsets)
+    else:
+        raise NotImplementedError(
+            'Stacking different types of QArrays is not implemented.'
+        )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,6 +218,8 @@ nav:
               - fidelity: python_api/utils/utils/fidelity.md
               - entropy_vn: python_api/utils/utils/entropy_vn.md
               - wigner: python_api/utils/utils/wigner.md
+          - QArray utilities:
+              - stack: python_api/qarrays/utils/stack.md
           - JAX-related utilities:
               - to_qutip: python_api/utils/jax_utils/to_qutip.md
               - set_device: python_api/utils/jax_utils/set_device.md


### PR DESCRIPTION
Replaces https://github.com/dynamiqs/dynamiqs/pull/630.

The following snippet now passes:
```python
import dynamiqs as dq
import jax.numpy as jnp

H = dq.number(8)
jump_ops = [dq.destroy(8)]
tlist = jnp.linspace(0.0, 1.0, 10)
psi0 = dq.basis(8, 0)
result = dq.mesolve(H, jump_ops, psi0, tlist)
```