### PR TITLE
make dq.stack general for SparseDIAQArray

### DIFF
--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -55,15 +55,26 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
         data = jnp.stack([q.data for q in qarrays], axis=axis)
         return DenseQArray(dims, data)
     elif all(isinstance(q, SparseDIAQArray) for q in qarrays):
-        offsets = qarrays[0].offsets
-        if not all(q.offsets == offsets for q in qarrays):
-            # TODO: implement stacking with different offsets
-            raise ValueError(
-                'Argument `qarrays` with elements of type `SparseDIAQArray` must have'
-                ' identical `offsets` attribute.'
+        unique_offsets = set()
+        for qarray in qarrays:
+            unique_offsets.update(qarray.offsets)
+        unique_offsets = tuple(sorted(unique_offsets))
+
+        offset_to_index = {offset: idx for idx, offset in enumerate(unique_offsets)}
+        diag_list = []
+        for qarray in qarrays:
+            add_diags_shape = qarray.diags.shape[:-2] + (
+                len(unique_offsets),
+                qarray.diags.shape[-1],
             )
-        diags = jnp.stack([q.diags for q in qarrays], axis=axis)
-        return SparseDIAQArray(dims, offsets, diags)
+            updated_diags = jnp.zeros(add_diags_shape)
+            for i, offset in enumerate(qarray.offsets):
+                idx = offset_to_index[offset]
+                updated_diags = updated_diags.at[..., idx, :].set(
+                    qarray.diags[..., i, :]
+                )
+            diag_list.append(updated_diags)
+        return SparseDIAQArray(dims, unique_offsets, jnp.stack(diag_list))
     else:
         raise NotImplementedError(
             'Stacking qarrays with different types is not implemented.'


### PR DESCRIPTION
This PR changes the code for `dq.qarray` to accept `SparseDIAQArray` objects that do not share the same offsets and works for batched versions of the sparse objects.

```
diags = [
    jnp.array([[0,1,2], [0,0,3]]),
    jnp.array([[0,4,5], [0,0,6]]),
    jnp.array([[0,7,8], [0,0,9]]),
    
]
offsets = (1,2)
x = SparseDIAQArray(dims, offsets, diags)

diags = [
    jnp.array([[1,2,3], [0,1,2], [0,0,4]]),
    jnp.array([[4,5,6], [0,1,2], [0,0,7]]), 
    jnp.array([[8,9,10], [0,1,2], [0,0,11]]), 
]
offsets = (0,1,2)
y = SparseDIAQArray(dims, offsets, diags)

stacked_z = stack([x,y]) #stacked_z.shape = (2,3,3,3)
```