### PR TITLE
Sparse dia `__repr__` and fix associated doctest

### DIFF
--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -35,11 +35,13 @@ def constant(array: QArrayLike) -> ConstantTimeArray:
     Examples:
         >>> H = dq.constant(dq.sigmaz())
         >>> H(0.0)
-        Array([[ 1.+0.j,  0.+0.j],
-               [ 0.+0.j, -1.+0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[ 1.+0.j    ⋅   ]
+         [   ⋅    -1.+0.j]]
         >>> H(1.0)
-        Array([[ 1.+0.j,  0.+0.j],
-               [ 0.+0.j, -1.+0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[ 1.+0.j    ⋅   ]
+         [   ⋅    -1.+0.j]]
     """
     array = asqarray(array)
     check_shape(array, 'array', '(..., n, n)')
@@ -82,17 +84,21 @@ def pwc(times: ArrayLike, values: ArrayLike, array: QArrayLike) -> PWCTimeArray:
         >>> array = dq.sigmaz()
         >>> H = dq.pwc(times, values, array)
         >>> H(-0.5)
-        Array([[ 0.+0.j,  0.+0.j],
-               [ 0.+0.j, -0.+0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[  ⋅      ⋅   ]
+         [  ⋅      ⋅   ]]
         >>> H(0.0)
-        Array([[ 3.+0.j,  0.+0.j],
-               [ 0.+0.j, -3.+0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[ 3.+0.j    ⋅   ]
+         [   ⋅    -3.+0.j]]
         >>> H(0.5)
-        Array([[ 3.+0.j,  0.+0.j],
-               [ 0.+0.j, -3.+0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[ 3.+0.j    ⋅   ]
+         [   ⋅    -3.+0.j]]
         >>> H(1.0)
-        Array([[-2.+0.j, -0.+0.j],
-               [-0.+0.j,  2.-0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[-2.+0.j    ⋅   ]
+         [   ⋅     2.+0.j]]
     """
     # times
     times = jnp.asarray(times)
@@ -142,11 +148,13 @@ def modulated(
         >>> f = lambda t: jnp.cos(2.0 * jnp.pi * t)
         >>> H = dq.modulated(f, dq.sigmax())
         >>> H(0.5)
-        Array([[-0.+0.j, -1.+0.j],
-               [-1.+0.j, -0.+0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=2
+        [[   ⋅    -1.+0.j]
+         [-1.+0.j    ⋅   ]]
         >>> H(1.0)
-        Array([[0.+0.j, 1.+0.j],
-               [1.+0.j, 0.+0.j]], dtype=complex64)
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=2
+        [[  ⋅    1.+0.j]
+         [1.+0.j   ⋅   ]]
     """
     # check f is callable
     if not callable(f):

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -85,7 +85,9 @@ def eye_dense(*dims: int) -> QArray:
 @register_format_handler('eye', MatrixFormatEnum.SPARSE_DIA)
 def eye_sparse_dia(*dims: int) -> QArray:
     dim = prod(dims)
-    return SparseDIAQArray(diags=jnp.ones((1, dim)), offsets=(0,), dims=dims)
+    return SparseDIAQArray(
+        diags=jnp.ones((1, dim), dtype=cdtype()), offsets=(0,), dims=dims
+    )
 
 
 @dispatch_matrix_format
@@ -135,7 +137,9 @@ def zero_dense(*dims: int) -> QArray:
 
 @register_format_handler('zero', MatrixFormatEnum.SPARSE_DIA)
 def zero_sparse_dia(*dims: int) -> QArray:
-    return SparseDIAQArray(diags=jnp.zeros((0, np.prod(dims))), offsets=(), dims=dims)
+    return SparseDIAQArray(
+        diags=jnp.zeros((0, np.prod(dims)), dtype=cdtype()), offsets=(), dims=dims
+    )
 
 
 @dispatch_matrix_format

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -57,21 +57,21 @@ def eye(*dims: int, matrix_format: MatrixFormat = None) -> QArray:
     Examples:
         Single-mode $I_4$:
         >>> dq.eye(4)
-        DenseQArray: shape=(4, 4), dims=(4,), dtype=complex64
-        [[1.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 1.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 1.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 1.+0.j]]
+        SparseDIAQArray: shape=(4, 4), dims=(4,), dtype=complex64, ndiags=1
+        [[1.+0.j   ⋅      ⋅      ⋅   ]
+         [  ⋅    1.+0.j   ⋅      ⋅   ]
+         [  ⋅      ⋅    1.+0.j   ⋅   ]
+         [  ⋅      ⋅      ⋅    1.+0.j]]
 
         Multi-mode $I_2 \otimes I_3$:
         >>> dq.eye(2, 3)
-        DenseQArray: shape=(6, 6), dims=(2, 3), dtype=complex64
-        [[1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j]]
+        SparseDIAQArray: shape=(6, 6), dims=(2, 3), dtype=complex64, ndiags=1
+        [[1.+0.j   ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅    1.+0.j   ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅    1.+0.j   ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅    1.+0.j   ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅    1.+0.j   ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅    1.+0.j]]
     """
 
 
@@ -110,21 +110,21 @@ def zero(*dims: int, matrix_format: MatrixFormat = None) -> QArray:
     Examples:
         Single-mode $0_4$:
         >>> dq.zero(4)
-        DenseQArray: shape=(4, 4), dims=(4,), dtype=complex64
-        [[0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
+        SparseDIAQArray: shape=(4, 4), dims=(4,), dtype=complex64, ndiags=0
+        [[  ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅   ]]
 
         Multi-mode $0_2 \otimes 0_3$:
         >>> dq.zero(2, 3)
-        DenseQArray: shape=(6, 6), dims=(2, 3), dtype=complex64
-        [[0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
+        SparseDIAQArray: shape=(6, 6), dims=(2, 3), dtype=complex64, ndiags=0
+        [[  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]]
     """
 
 
@@ -168,30 +168,30 @@ def destroy(
     Examples:
         Single-mode $a$:
         >>> dq.destroy(4)
-        DenseQArray: shape=(4, 4), dims=(4,), dtype=complex64
-        [[0.   +0.j 1.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 1.414+0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 1.732+0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]]
+        SparseDIAQArray: shape=(4, 4), dims=(4,), dtype=complex64, ndiags=1
+        [[    ⋅     1.   +0.j     ⋅         ⋅    ]
+         [    ⋅         ⋅     1.414+0.j     ⋅    ]
+         [    ⋅         ⋅         ⋅     1.732+0.j]
+         [    ⋅         ⋅         ⋅         ⋅    ]]
 
         Mult-mode $a\otimes I_3$ and $I_2\otimes b$:
         >>> a, b = dq.destroy(2, 3)
         >>> a
-        DenseQArray: shape=(6, 6), dims=(2, 3), dtype=complex64
-        [[0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 1.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]]
+        SparseDIAQArray: shape=(6, 6), dims=(2, 3), dtype=complex64, ndiags=1
+        [[  ⋅      ⋅      ⋅    1.+0.j   ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅    1.+0.j   ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅    1.+0.j]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]]
         >>> b
-        DenseQArray: shape=(6, 6), dims=(2, 3), dtype=complex64
-        [[0.   +0.j 1.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 1.414+0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 1.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 1.414+0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]]
+        SparseDIAQArray: shape=(6, 6), dims=(2, 3), dtype=complex64, ndiags=1
+        [[    ⋅     1.   +0.j     ⋅         ⋅         ⋅         ⋅    ]
+         [    ⋅         ⋅     1.414+0.j     ⋅         ⋅         ⋅    ]
+         [    ⋅         ⋅         ⋅         ⋅         ⋅         ⋅    ]
+         [    ⋅         ⋅         ⋅         ⋅     1.   +0.j     ⋅    ]
+         [    ⋅         ⋅         ⋅         ⋅         ⋅     1.414+0.j]
+         [    ⋅         ⋅         ⋅         ⋅         ⋅         ⋅    ]]
     """
 
 
@@ -260,30 +260,30 @@ def create(
     Examples:
         Single-mode $a^\dag$:
         >>> dq.create(4)
-        DenseQArray: shape=(4, 4), dims=(4,), dtype=complex64
-        [[0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [1.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 1.414+0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 1.732+0.j 0.   +0.j]]
+        SparseDIAQArray: shape=(4, 4), dims=(4,), dtype=complex64, ndiags=1
+        [[    ⋅         ⋅         ⋅         ⋅    ]
+         [1.   +0.j     ⋅         ⋅         ⋅    ]
+         [    ⋅     1.414+0.j     ⋅         ⋅    ]
+         [    ⋅         ⋅     1.732+0.j     ⋅    ]]
 
         Mult-mode $a^\dag\otimes I_3$ and $I_2\otimes b^\dag$:
         >>> adag, bdag = dq.create(2, 3)
         >>> adag
-        DenseQArray: shape=(6, 6), dims=(2, 3), dtype=complex64
-        [[0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 1.+0.j 0.+0.j 0.+0.j 0.+0.j]]
+        SparseDIAQArray: shape=(6, 6), dims=(2, 3), dtype=complex64, ndiags=1
+        [[  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [1.+0.j   ⋅      ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅    1.+0.j   ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅      ⋅    1.+0.j   ⋅      ⋅      ⋅   ]]
         >>> bdag
-        DenseQArray: shape=(6, 6), dims=(2, 3), dtype=complex64
-        [[0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [1.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 1.414+0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 1.   +0.j 0.   +0.j 0.   +0.j]
-         [0.   +0.j 0.   +0.j 0.   +0.j 0.   +0.j 1.414+0.j 0.   +0.j]]
+        SparseDIAQArray: shape=(6, 6), dims=(2, 3), dtype=complex64, ndiags=1
+        [[    ⋅         ⋅         ⋅         ⋅         ⋅         ⋅    ]
+         [1.   +0.j     ⋅         ⋅         ⋅         ⋅         ⋅    ]
+         [    ⋅     1.414+0.j     ⋅         ⋅         ⋅         ⋅    ]
+         [    ⋅         ⋅         ⋅         ⋅         ⋅         ⋅    ]
+         [    ⋅         ⋅         ⋅     1.   +0.j     ⋅         ⋅    ]
+         [    ⋅         ⋅         ⋅         ⋅     1.414+0.j     ⋅    ]]
     """
 
 
@@ -343,11 +343,11 @@ def number(dim: int | None = None, *, matrix_format: MatrixFormat = None) -> QAr
 
     Examples:
         >>> dq.number(4)
-        DenseQArray: shape=(4, 4), dims=(4,), dtype=complex64
-        [[0.+0.j 0.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 1.+0.j 0.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 2.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j 0.+0.j 3.+0.j]]
+        SparseDIAQArray: shape=(4, 4), dims=(4,), dtype=complex64, ndiags=1
+        [[  ⋅      ⋅      ⋅      ⋅   ]
+         [  ⋅    1.+0.j   ⋅      ⋅   ]
+         [  ⋅      ⋅    2.+0.j   ⋅   ]
+         [  ⋅      ⋅      ⋅    3.+0.j]]
     """
 
 
@@ -379,11 +379,11 @@ def parity(dim: int, *, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.parity(4)
-        DenseQArray: shape=(4, 4), dims=(4,), dtype=complex64
-        [[ 1.+0.j  0.+0.j  0.+0.j  0.+0.j]
-         [ 0.+0.j -1.+0.j  0.+0.j  0.+0.j]
-         [ 0.+0.j  0.+0.j  1.+0.j  0.+0.j]
-         [ 0.+0.j  0.+0.j  0.+0.j -1.+0.j]]
+        SparseDIAQArray: shape=(4, 4), dims=(4,), dtype=complex64, ndiags=1
+        [[ 1.+0.j    ⋅       ⋅       ⋅   ]
+         [   ⋅    -1.+0.j    ⋅       ⋅   ]
+         [   ⋅       ⋅     1.+0.j    ⋅   ]
+         [   ⋅       ⋅       ⋅    -1.+0.j]]
     """
 
 
@@ -487,15 +487,15 @@ def quadrature(dim: int, phi: float, *, matrix_format: MatrixFormat = None) -> Q
 
     Examples:
         >>> dq.quadrature(3, 0.0)
-        DenseQArray: shape=(3, 3), dims=(3,), dtype=complex64
-        [[0.   +0.j 0.5  +0.j 0.   +0.j]
-         [0.5  +0.j 0.   +0.j 0.707+0.j]
-         [0.   +0.j 0.707+0.j 0.   +0.j]]
+        SparseDIAQArray: shape=(3, 3), dims=(3,), dtype=complex64, ndiags=2
+        [[    ⋅     0.5  +0.j     ⋅    ]
+         [0.5  +0.j     ⋅     0.707+0.j]
+         [    ⋅     0.707+0.j     ⋅    ]]
         >>> dq.quadrature(3, jnp.pi / 2)
-        DenseQArray: shape=(3, 3), dims=(3,), dtype=complex64
-        [[ 0.+0.j    -0.-0.5j    0.+0.j   ]
-         [-0.+0.5j    0.+0.j    -0.-0.707j]
-         [ 0.+0.j    -0.+0.707j  0.+0.j   ]]
+        SparseDIAQArray: shape=(3, 3), dims=(3,), dtype=complex64, ndiags=2
+        [[   ⋅       -0.-0.5j      ⋅      ]
+         [-0.+0.5j      ⋅       -0.-0.707j]
+         [   ⋅       -0.+0.707j    ⋅      ]]
     """
     a = destroy(dim, matrix_format=matrix_format)
     return 0.5 * (jnp.exp(1.0j * phi) * a.dag() + jnp.exp(-1.0j * phi) * a)
@@ -513,10 +513,10 @@ def position(dim: int, *, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.position(3)
-        DenseQArray: shape=(3, 3), dims=(3,), dtype=complex64
-        [[0.   +0.j 0.5  +0.j 0.   +0.j]
-         [0.5  +0.j 0.   +0.j 0.707+0.j]
-         [0.   +0.j 0.707+0.j 0.   +0.j]]
+        SparseDIAQArray: shape=(3, 3), dims=(3,), dtype=complex64, ndiags=2
+        [[    ⋅     0.5  +0.j     ⋅    ]
+         [0.5  +0.j     ⋅     0.707+0.j]
+         [    ⋅     0.707+0.j     ⋅    ]]
     """
     a = destroy(dim, matrix_format=matrix_format)
     return 0.5 * (a + a.dag())
@@ -534,10 +534,10 @@ def momentum(dim: int, *, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.momentum(3)
-        DenseQArray: shape=(3, 3), dims=(3,), dtype=complex64
-        [[ 0.+0.j    -0.-0.5j    0.+0.j   ]
-         [ 0.+0.5j    0.+0.j    -0.-0.707j]
-         [ 0.+0.j     0.+0.707j  0.+0.j   ]]
+        SparseDIAQArray: shape=(3, 3), dims=(3,), dtype=complex64, ndiags=2
+        [[  ⋅       0.-0.5j     ⋅      ]
+         [0.+0.5j     ⋅       0.-0.707j]
+         [  ⋅       0.+0.707j   ⋅      ]]
     """
     a = destroy(dim, matrix_format=matrix_format)
     return 0.5j * (a.dag() - a)
@@ -554,9 +554,9 @@ def sigmax(*, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.sigmax()
-        DenseQArray: shape=(2, 2), dims=(2,), dtype=complex64
-        [[0.+0.j 1.+0.j]
-         [1.+0.j 0.+0.j]]
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=2
+        [[  ⋅    1.+0.j]
+         [1.+0.j   ⋅   ]]
     """
 
 
@@ -583,9 +583,9 @@ def sigmay(*, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.sigmay()
-        DenseQArray: shape=(2, 2), dims=(2,), dtype=complex64
-        [[ 0.+0.j -0.-1.j]
-         [ 0.+1.j  0.+0.j]]
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=2
+        [[  ⋅    0.-1.j]
+         [0.+1.j   ⋅   ]]
     """
 
 
@@ -612,9 +612,9 @@ def sigmaz(*, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.sigmaz()
-        DenseQArray: shape=(2, 2), dims=(2,), dtype=complex64
-        [[ 1.+0.j  0.+0.j]
-         [ 0.+0.j -1.+0.j]]
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[ 1.+0.j    ⋅   ]
+         [   ⋅    -1.+0.j]]
     """
 
 
@@ -641,9 +641,9 @@ def sigmap(*, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.sigmap()
-        DenseQArray: shape=(2, 2), dims=(2,), dtype=complex64
-        [[0.+0.j 1.+0.j]
-         [0.+0.j 0.+0.j]]
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[  ⋅    1.+0.j]
+         [  ⋅      ⋅   ]]
     """
 
 
@@ -670,9 +670,9 @@ def sigmam(*, matrix_format: MatrixFormat = None) -> QArray:
 
     Examples:
         >>> dq.sigmam()
-        DenseQArray: shape=(2, 2), dims=(2,), dtype=complex64
-        [[0.+0.j 0.+0.j]
-         [1.+0.j 0.+0.j]]
+        SparseDIAQArray: shape=(2, 2), dims=(2,), dtype=complex64, ndiags=1
+        [[  ⋅      ⋅   ]
+         [1.+0.j   ⋅   ]]
     """
 
 

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -436,7 +436,7 @@ def displace(dim: int, alpha: ArrayLike) -> DenseQArray:
     return (alpha * a.dag() - alpha.conj() * a).expm()
 
 
-def squeeze(dim: int, z: ArrayLike) -> QArray:
+def squeeze(dim: int, z: ArrayLike) -> DenseQArray:
     r"""Returns the squeezing operator of complex squeezing amplitude $z$.
 
     It is defined by


### PR DESCRIPTION
On top of #675.

Very satisfying 😋
```python
>>> import dynamiqs as dq
>>> import jax.numpy as jnp
>>> jnp.set_printoptions(precision=3)
>>> a = dq.destroy(6)
>>> a.dag() @ a + a @ a @ a + a.dag()
SparseDIAQArray: shape=(6, 6), dims=(6,), dtype=complex64, ndiags=3
[[    ⋅         ⋅         ⋅     2.449+0.j     ⋅         ⋅    ]
 [1.   +0.j 1.   +0.j     ⋅         ⋅     4.899+0.j     ⋅    ]
 [    ⋅     1.414+0.j 2.   +0.j     ⋅         ⋅     7.746+0.j]
 [    ⋅         ⋅     1.732+0.j 3.   +0.j     ⋅         ⋅    ]
 [    ⋅         ⋅         ⋅     2.   +0.j 4.   +0.j     ⋅    ]
 [    ⋅         ⋅         ⋅         ⋅     2.236+0.j 5.   +0.j]]
```

The way `__repr__` is written is quite robust to any chosen `jnp.set_printoptions` parameter, e.g. `precision`, but it introduces a subtle bug which we have to fix. The symbol `∙` is supposed to mean "not stored", not "0". With the proposed `__repr__` implementation, when a stored diagonal contains a `0` it is replaced by mistake with a `⋅`, e.g.
```python
>>> dq.number(4)
SparseDIAQArray: shape=(4, 4), dims=(4,), dtype=complex64, ndiags=1
[[  ⋅      ⋅      ⋅      ⋅   ]
 [  ⋅    1.+0.j   ⋅      ⋅   ]
 [  ⋅      ⋅    2.+0.j   ⋅   ]
 [  ⋅      ⋅      ⋅    3.+0.j]]
```
(the first item should be 0.+0.j)

Happy for any better `__repr__` implementation suggestions!