### PR TITLE
Adapt base integrator, saved and result classes to new solvers structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ print(result)
 
 ```text
 |██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
-==== MEResult ====
+==== MESolveResult ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
 Infos   : 7 steps (7 accepted, 0 rejected)

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ print(result)
 |██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
 ==== MESolveResult ====
 Solver  : Tsit5
-States  : Array complex64 (101, 128, 128) | 12.62 Mb
 Infos   : 7 steps (7 accepted, 0 rejected)
+States  : Array complex64 (101, 128, 128) | 12.62 Mb
 ```
 
 ### Compute gradients with respect to some parameters

--- a/docs/documentation/basics/workflow.md
+++ b/docs/documentation/basics/workflow.md
@@ -83,9 +83,9 @@ print(result)
 
 ==== SESolveResult ====
 Solver  : Dopri5
+Infos   : 56 steps (48 accepted, 8 rejected)
 States  : Array complex64 (101, 2, 1) | 1.58 Kb
 Expects : Array complex64 (1, 101) | 0.79 Kb
-Infos   : 56 steps (48 accepted, 8 rejected)
 ```
 
 ## IV. Analyze the results

--- a/docs/documentation/basics/workflow.md
+++ b/docs/documentation/basics/workflow.md
@@ -62,7 +62,7 @@ solver = dq.solver.Dopri5(rtol=1e-6, atol=1e-8)
 
 ## III. Run the simulation
 
-We can now run the simulation. This is done by calling the [`dq.sesolve()`][dynamiqs.sesolve] function, which returns an instance of the [`SEResult`][dynamiqs.SEResult] class. This object contains the computed states, the observables, and various information about the solver.
+We can now run the simulation. This is done by calling the [`dq.sesolve()`][dynamiqs.sesolve] function, which returns an instance of the [`SESolveResult`][dynamiqs.SESolveResult] class. This object contains the computed states, the observables, and various information about the solver.
 
 ```python
 # run simulation
@@ -77,11 +77,11 @@ print(result)
 
 ```text title="Output"
 |██████████| 100.0% ◆ elapsed 3.25ms ◆ remaining 0.00ms
-`result` is of type <class 'dynamiqs.result.SEResult'>.
+`result` is of type <class 'dynamiqs.result.SESolveResult'>.
 `result` has the following attributes:
 ['Esave', '_abc_impl', 'expects', 'gradient', 'options', 'solver', 'states', 'to_numpy', 'to_qutip', 'tsave', 'ysave']
 
-==== SEResult ====
+==== SESolveResult ====
 Solver  : Dopri5
 States  : Array complex64 (101, 2, 1) | 1.58 Kb
 Expects : Array complex64 (1, 101) | 0.79 Kb

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -32,8 +32,8 @@ print(result)
 |██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
 ==== MESolveResult ====
 Solver  : Tsit5
-States  : Array complex64 (101, 128, 128) | 12.62 Mb
 Infos   : 7 steps (7 accepted, 0 rejected)
+States  : Array complex64 (101, 128, 128) | 12.62 Mb
 ```
 
 ## Compute gradients with respect to some parameters

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -30,7 +30,7 @@ print(result)
 
 ```text title="Output"
 |██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
-==== MEResult ====
+==== MESolveResult ====
 Solver  : Tsit5
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
 Infos   : 7 steps (7 accepted, 0 rejected)

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -161,9 +161,7 @@ def _mepropagator(
 
     # === init integrator
     y0 = eye(H.shape[-1] ** 2)
-    integrator = integrator_class(
-        tsave, y0, H, None, solver, gradient, options, jump_ops
-    )
+    integrator = integrator_class(tsave, y0, H, solver, gradient, options, jump_ops)
 
     # === run integrator
     result = integrator.run()

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -117,9 +117,9 @@ def mesolve(
         options: Generic options, see [`dq.Options`][dynamiqs.Options].
 
     Returns:
-        [`dq.MESolveResult`][dynamiqs.MESolveResult] object holding the result of the Lindblad
-            master  equation integration. Use the attributes `states` and `expects`
-            to access saved quantities, more details in
+        [`dq.MESolveResult`][dynamiqs.MESolveResult] object holding the result of the
+            Lindblad master equation integration. Use the attributes `states` and
+            `expects` to access saved quantities, more details in
             [`dq.MESolveResult`][dynamiqs.MESolveResult].
     """  # noqa: E501
     # === convert arguments

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -226,6 +226,7 @@ def _mesolve(
     integrator = integrator_class(
         tsave, rho0, H, solver, gradient, options, jump_ops, exp_ops
     )
+
     # === run integrator
     result = integrator.run()
 

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -12,7 +12,7 @@ from ..._checks import check_shape, check_times
 from ..._utils import cdtype
 from ...gradient import Gradient
 from ...options import Options
-from ...result import MEResult
+from ...result import MESolveResult
 from ...solver import (
     Dopri5,
     Dopri8,
@@ -55,7 +55,7 @@ def mesolve(
     solver: Solver = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
     options: Options = Options(),  # noqa: B008
-) -> MEResult:
+) -> MESolveResult:
     r"""Solve the Lindblad master equation.
 
     This function computes the evolution of the density matrix $\rho(t)$ at time $t$,
@@ -117,10 +117,10 @@ def mesolve(
         options: Generic options, see [`dq.Options`][dynamiqs.Options].
 
     Returns:
-        [`dq.MEResult`][dynamiqs.MEResult] object holding the result of the Lindblad
+        [`dq.MESolveResult`][dynamiqs.MESolveResult] object holding the result of the Lindblad
             master  equation integration. Use the attributes `states` and `expects`
             to access saved quantities, more details in
-            [`dq.MEResult`][dynamiqs.MEResult].
+            [`dq.MESolveResult`][dynamiqs.MESolveResult].
     """  # noqa: E501
     # === convert arguments
     H = _astimearray(H)
@@ -154,14 +154,14 @@ def _vectorized_mesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> MEResult:
+) -> MESolveResult:
     # === vectorize function
     # we vectorize over H, jump_ops and rho0, all other arguments are not vectorized
     # `n_batch` is a pytree. Each leaf of this pytree gives the number of times
     # this leaf should be vmapped on.
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = MEResult(False, False, False, False, 0, 0)
+    out_axes = MESolveResult(False, False, False, False, 0, 0)
 
     if not options.cartesian_batching:
         broadcast_shape = jnp.broadcast_shapes(
@@ -205,7 +205,7 @@ def _mesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> MEResult:
+) -> MESolveResult:
     # === select integrator class
     integrators = {
         Euler: MESolveEulerIntegrator,
@@ -224,9 +224,8 @@ def _mesolve(
 
     # === init integrator
     integrator = integrator_class(
-        tsave, rho0, H, exp_ops, solver, gradient, options, jump_ops
+        tsave, rho0, H, solver, gradient, options, jump_ops, exp_ops
     )
-
     # === run integrator
     result = integrator.run()
 

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -155,7 +155,7 @@ def _sepropagator(
 
     # === init integrator
     y0 = eye(H.shape[-1])
-    integrator = integrator_class(tsave, y0, H, None, solver, gradient, options)
+    integrator = integrator_class(tsave, y0, H, solver, gradient, options)
 
     # === run integrator
     result = integrator.run()

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -11,7 +11,7 @@ from ..._checks import check_shape, check_times
 from ..._utils import cdtype
 from ...gradient import Gradient
 from ...options import Options
-from ...result import SEResult
+from ...result import SESolveResult
 from ...solver import Dopri5, Dopri8, Euler, Expm, Kvaerno3, Kvaerno5, Solver, Tsit5
 from ...time_array import Shape, TimeArray
 from .._utils import (
@@ -41,7 +41,7 @@ def sesolve(
     solver: Solver = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
     options: Options = Options(),  # noqa: B008
-) -> SEResult:
+) -> SESolveResult:
     r"""Solve the Schrödinger equation.
 
     This function computes the evolution of the state vector $\ket{\psi(t)}$ at time
@@ -91,10 +91,10 @@ def sesolve(
         options: Generic options, see [`dq.Options`][dynamiqs.Options].
 
     Returns:
-        [`dq.SEResult`][dynamiqs.SEResult] object holding the result of the
+        [`dq.SESolveResult`][dynamiqs.SESolveResult] object holding the result of the
             Schrödinger equation integration. Use the attributes `states` and `expects`
             to access saved quantities, more details in
-            [`dq.SEResult`][dynamiqs.SEResult].
+            [`dq.SESolveResult`][dynamiqs.SESolveResult].
     """  # noqa: E501
     # === convert arguments
     H = _astimearray(H)
@@ -121,7 +121,7 @@ def _vectorized_sesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> SEResult:
+) -> SESolveResult:
     # === vectorize function
     # we vectorize over H and psi0, all other arguments are not vectorized
 
@@ -143,7 +143,7 @@ def _vectorized_sesolve(
     )
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = SEResult(False, False, False, False, 0, 0)
+    out_axes = SESolveResult(False, False, False, False, 0, 0)
 
     # compute vectorized function with given batching strategy
     if options.cartesian_batching:
@@ -163,7 +163,7 @@ def _sesolve(
     solver: Solver,
     gradient: Gradient | None,
     options: Options,
-) -> SEResult:
+) -> SESolveResult:
     # === select integrator class
     integrators = {
         Euler: SESolveEulerIntegrator,
@@ -180,7 +180,7 @@ def _sesolve(
     solver.assert_supports_gradient(gradient)
 
     # === init integrator
-    integrator = integrator_class(tsave, psi0, H, exp_ops, solver, gradient, options)
+    integrator = integrator_class(tsave, psi0, H, solver, gradient, options, exp_ops)
 
     # === run integrator
     result = integrator.run()

--- a/dynamiqs/integrators/core/abstract_integrator.py
+++ b/dynamiqs/integrators/core/abstract_integrator.py
@@ -72,6 +72,7 @@ class SolveIntegrator(BaseIntegrator):
 
     def save(self, y: PyTree) -> Saved:
         ysave, Esave, extra = None, None, None
+
         if self.options.save_states:
             ysave = y
         if self.Es is not None and len(self.Es) > 0:
@@ -83,19 +84,19 @@ class SolveIntegrator(BaseIntegrator):
 
     def collect_saved(self, saved: Saved, ylast: Array) -> Saved:
         saved = super().collect_saved(saved, ylast)
+
+        # reorder Esave after jax.lax.scan stacking (ntsave, nE) -> (nE, ntsave)
         Esave = saved.Esave
         if Esave is not None:
             Esave = Esave.swapaxes(-1, -2)
             saved = eqx.tree_at(lambda x: x.Esave, saved, Esave)
+
         return saved
 
 
 class PropagatorIntegrator(BaseIntegrator):
     def save(self, y: PyTree) -> Saved:
-        ysave = None
-        if self.options.save_states:
-            ysave = y
-
+        ysave = y if self.options.save_states else None
         return PropagatorSaved(ysave)
 
 

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -11,7 +11,7 @@ from jaxtyping import PyTree
 
 from ...gradient import Autograd, CheckpointAutograd
 from ...utils.quantum_utils.general import dag
-from .abstract_integrator import BaseIntegrator
+from .abstract_integrator import BaseIntegrator, MEIntegrator
 
 
 class DiffraxIntegrator(BaseIntegrator):
@@ -179,7 +179,7 @@ class SEDiffraxIntegrator(DiffraxIntegrator):
         return dx.ODETerm(vector_field)
 
 
-class MEDiffraxIntegrator(DiffraxIntegrator):
+class MEDiffraxIntegrator(DiffraxIntegrator, MEIntegrator):
     @property
     def terms(self) -> dx.AbstractTerm:
         # define Lindblad term drho/dt

--- a/dynamiqs/integrators/core/expm_integrator.py
+++ b/dynamiqs/integrators/core/expm_integrator.py
@@ -7,12 +7,17 @@ from jax import Array
 from jaxtyping import PyTree
 
 from dynamiqs._utils import _concatenate_sort
-from dynamiqs.result import Saved
+from dynamiqs.result import PropagatorSaved, Saved, SolveSaved
 
 from ...utils.quantum_utils.general import expm
 from ...utils.vectorization import slindbladian
 from .._utils import ispwc
-from .abstract_integrator import BaseIntegrator, MEIntegrator
+from .abstract_integrator import (
+    BaseIntegrator,
+    MEIntegrator,
+    PropagatorIntegrator,
+    SolveIntegrator,
+)
 
 
 class ExpmIntegrator(BaseIntegrator):
@@ -56,16 +61,10 @@ class ExpmIntegrator(BaseIntegrator):
     def _generator(self, t: float) -> Array:
         raise NotImplementedError
 
-    def collect_saved(self, saved: Saved, ylast: Array, times: Array) -> Saved:
-        # === extract the states and expects or the propagators at the save times ts
-        t_idxs = jnp.searchsorted(times[1:], self.ts)  # (nts,)
-        saved = Saved(
-            saved.ysave[t_idxs] if self.options.save_states else saved.ysave,
-            saved.Esave[t_idxs] if saved.Esave is not None else None,
-            saved.extra[t_idxs] if saved.extra is not None else None,
-        )
-
-        return super().collect_saved(saved, ylast)
+    def _find_time_idxs(self, times: Array) -> Array:
+        # === useful for extracting states, propagators and/or expects at the save
+        # times ts
+        return jnp.searchsorted(times[1:], self.ts)  # (nts,)
 
     def run(self) -> PyTree:
         # === find all times at which to stop in [t0, t1]
@@ -97,6 +96,30 @@ class ExpmIntegrator(BaseIntegrator):
         nsteps = (delta_ts != 0).sum()
         saved = self.collect_saved(saved, ylast, times)
         return self.result(saved, infos=self.Infos(nsteps))
+
+
+class PropagatorExpmIntegrator(ExpmIntegrator, PropagatorIntegrator):
+    def collect_saved(self, saved: Saved, ylast: Array, times: Array) -> Saved:
+        t_idxs = self._find_time_idxs(times)
+        saved = PropagatorSaved(
+            saved.ysave[t_idxs] if self.options.save_states else saved.ysave
+        )
+        saved = super().collect_saved(saved, ylast)
+
+        return saved  # noqa: RET504
+
+
+class SolveExpmIntegrator(ExpmIntegrator, SolveIntegrator):
+    def collect_saved(self, saved: Saved, ylast: Array, times: Array) -> Saved:
+        t_idxs = self._find_time_idxs(times)
+        saved = SolveSaved(
+            saved.ysave[t_idxs] if self.options.save_states else saved.ysave,
+            saved.Esave[t_idxs] if saved.Esave is not None else None,
+            saved.extra[t_idxs] if saved.extra is not None else None,
+        )
+        saved = super().collect_saved(saved, ylast)
+
+        return saved  # noqa: RET504
 
 
 class SEExpmIntegrator(ExpmIntegrator):

--- a/dynamiqs/integrators/mepropagator/expm_integrator.py
+++ b/dynamiqs/integrators/mepropagator/expm_integrator.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from ..core.abstract_integrator import MEPropagatorIntegrator
-from ..core.expm_integrator import MEExpmIntegrator
+from ..core.expm_integrator import MEExpmIntegrator, PropagatorExpmIntegrator
 
 
-class MEPropagatorExpmIntegrator(MEExpmIntegrator, MEPropagatorIntegrator):
+class MEPropagatorExpmIntegrator(
+    PropagatorExpmIntegrator, MEExpmIntegrator, MEPropagatorIntegrator
+):
     pass

--- a/dynamiqs/integrators/mesolve/expm_integrator.py
+++ b/dynamiqs/integrators/mesolve/expm_integrator.py
@@ -3,10 +3,10 @@ from jax import Array
 from ...result import Saved
 from ...utils.vectorization import operator_to_vector, vector_to_operator
 from ..core.abstract_integrator import MESolveIntegrator
-from ..core.expm_integrator import MEExpmIntegrator
+from ..core.expm_integrator import MEExpmIntegrator, SolveExpmIntegrator
 
 
-class MESolveExpmIntegrator(MEExpmIntegrator, MESolveIntegrator):
+class MESolveExpmIntegrator(SolveExpmIntegrator, MEExpmIntegrator, MESolveIntegrator):
     def __init__(self, *args):
         super().__init__(*args)
 

--- a/dynamiqs/integrators/sepropagator/expm_integrator.py
+++ b/dynamiqs/integrators/sepropagator/expm_integrator.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 from ..core.abstract_integrator import SEPropagatorIntegrator
-from ..core.expm_integrator import SEExpmIntegrator
+from ..core.expm_integrator import PropagatorExpmIntegrator, SEExpmIntegrator
 
 
-class SEPropagatorExpmIntegrator(SEExpmIntegrator, SEPropagatorIntegrator):
+class SEPropagatorExpmIntegrator(
+    PropagatorExpmIntegrator, SEExpmIntegrator, SEPropagatorIntegrator
+):
     pass

--- a/dynamiqs/integrators/sesolve/expm_integrator.py
+++ b/dynamiqs/integrators/sesolve/expm_integrator.py
@@ -1,6 +1,6 @@
 from ..core.abstract_integrator import SESolveIntegrator
-from ..core.expm_integrator import SEExpmIntegrator
+from ..core.expm_integrator import SEExpmIntegrator, SolveExpmIntegrator
 
 
-class SESolveExpmIntegrator(SEExpmIntegrator, SESolveIntegrator):
+class SESolveExpmIntegrator(SolveExpmIntegrator, SEExpmIntegrator, SESolveIntegrator):
     pass

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -34,7 +34,8 @@ class Options(eqx.Module):
             This can be used to save additional arbitrary data during the
             integration. The additional data is accessible in the `extra` attribute of
             the result object returned by the solvers (see
-            [`SEResult`][dynamiqs.SEResult] or [`MEResult`][dynamiqs.MEResult]).
+            [`SESolveResult`][dynamiqs.SESolveResult] or
+            [`MESolveResult`][dynamiqs.MESolveResult]).
     """
 
     save_states: bool = True

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -166,8 +166,8 @@ nav:
               - CheckpointAutograd: python_api/gradient/CheckpointAutograd.md
           - Options: python_api/options/Options.md
           - Results:
-              - SEResult: python_api/result/SEResult.md
-              - MEResult: python_api/result/MEResult.md
+              - SESolveResult: python_api/result/SESolveResult.md
+              - MESolveResult: python_api/result/MESolveResult.md
               - SEPropagatorResult: python_api/result/SEPropagatorResult.md
               - MEPropagatorResult: python_api/result/MEPropagatorResult.md
       - Utilities:


### PR DESCRIPTION
Closes DYN-238.

In light of new `sepropagator` and `meproagator` methods the `Result` internal classes are updated to avoid having meaningless `None`s. 

Related to this, a few new internal classes are introduced to avoid code duplication. For instance new integrators are added `SolveIntegrator`, `PropagatorIntegrator`, `SolveExpmIntegrator` and `PropagatorExpmIntegrator` which e.g. for `SolveIntegrator` contain methods relevant for both `sesolve` and `mesolve` regardless of the integration scheme (whether expm or diffrax).