### PR TITLE
Refactor how `final_state` and `final_propagator` are saved

### DIFF
--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -111,7 +111,7 @@ def _vectorized_mepropagator(
     # `n_batch` is a pytree. Each leaf of this pytree gives the number of times
     # this leaf should be vmapped on.
 
-    # the result is vectorized over `_saved` `final_state` and `infos`
+    # the result is vectorized over `_saved` `infos` and `final_state`
     out_axes = MEPropagatorResult(False, False, False, False, 0, 0, 0)
 
     if not options.cartesian_batching:

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -111,8 +111,8 @@ def _vectorized_mepropagator(
     # `n_batch` is a pytree. Each leaf of this pytree gives the number of times
     # this leaf should be vmapped on.
 
-    # the result is vectorized over `_saved` and `infos`
-    out_axes = MEPropagatorResult(False, False, False, False, 0, 0)
+    # the result is vectorized over `_saved` `final_state` and `infos`
+    out_axes = MEPropagatorResult(False, False, False, False, 0, 0, 0)
 
     if not options.cartesian_batching:
         broadcast_shape = jnp.broadcast_shapes(

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -160,8 +160,8 @@ def _vectorized_mesolve(
     # `n_batch` is a pytree. Each leaf of this pytree gives the number of times
     # this leaf should be vmapped on.
 
-    # the result is vectorized over `_saved` and `infos`
-    out_axes = MESolveResult(False, False, False, False, 0, 0)
+    # the result is vectorized over `_saved` `final_state` and `infos`
+    out_axes = MESolveResult(False, False, False, False, 0, 0, 0)
 
     if not options.cartesian_batching:
         broadcast_shape = jnp.broadcast_shapes(

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -160,7 +160,7 @@ def _vectorized_mesolve(
     # `n_batch` is a pytree. Each leaf of this pytree gives the number of times
     # this leaf should be vmapped on.
 
-    # the result is vectorized over `_saved` `final_state` and `infos`
+    # the result is vectorized over `_saved` `infos` and `final_state`
     out_axes = MESolveResult(False, False, False, False, 0, 0, 0)
 
     if not options.cartesian_batching:

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -118,8 +118,8 @@ def _vectorized_sepropagator(
     # we vectorize over H, all other arguments are not vectorized
     n_batch = (H.in_axes, Shape(), Shape(), Shape(), Shape())
 
-    # the result is vectorized over `_saved` and `infos`
-    out_axes = SEPropagatorResult(False, False, False, False, 0, 0)
+    # the result is vectorized over `_saved` `final_state` and `infos`
+    out_axes = SEPropagatorResult(False, False, False, False, 0, 0, 0)
 
     # compute vectorized function
     f = _cartesian_vectorize(_sepropagator, n_batch, out_axes)

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -118,7 +118,7 @@ def _vectorized_sepropagator(
     # we vectorize over H, all other arguments are not vectorized
     n_batch = (H.in_axes, Shape(), Shape(), Shape(), Shape())
 
-    # the result is vectorized over `_saved` `final_state` and `infos`
+    # the result is vectorized over `_saved` `infos` and `final_state`
     out_axes = SEPropagatorResult(False, False, False, False, 0, 0, 0)
 
     # compute vectorized function

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -142,7 +142,7 @@ def _vectorized_sesolve(
         Shape(),
     )
 
-    # the result is vectorized over `_saved` `final_state` and `infos`
+    # the result is vectorized over `_saved` `infos` and `final_state`
     out_axes = SESolveResult(False, False, False, False, 0, 0, 0)
 
     # compute vectorized function with given batching strategy

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -142,8 +142,8 @@ def _vectorized_sesolve(
         Shape(),
     )
 
-    # the result is vectorized over `_saved` and `infos`
-    out_axes = SESolveResult(False, False, False, False, 0, 0)
+    # the result is vectorized over `_saved` `final_state` and `infos`
+    out_axes = SESolveResult(False, False, False, False, 0, 0, 0)
 
     # compute vectorized function with given batching strategy
     if options.cartesian_batching:

--- a/dynamiqs/integrators/core/abstract_integrator.py
+++ b/dynamiqs/integrators/core/abstract_integrator.py
@@ -51,7 +51,7 @@ class BaseIntegrator(AbstractIntegrator):
         return self.H.discontinuity_ts
 
     @abstractmethod
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
+    def result(self, saved: Saved, ylast: Array, infos: PyTree | None = None) -> Result:
         pass
 
     def collect_saved(self, saved: Saved, ylast: Array) -> Saved:
@@ -110,28 +110,28 @@ class MEIntegrator(BaseIntegrator):
 
 
 class SESolveIntegrator(SolveIntegrator):
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
+    def result(self, saved: Saved, ylast: Array, infos: PyTree | None = None) -> Result:
         return SESolveResult(
-            self.ts, self.solver, self.gradient, self.options, saved, infos
+            self.ts, self.solver, self.gradient, self.options, saved, infos, ylast
         )
 
 
 class MESolveIntegrator(SolveIntegrator, MEIntegrator):
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
+    def result(self, saved: Saved, ylast: Array, infos: PyTree | None = None) -> Result:
         return MESolveResult(
-            self.ts, self.solver, self.gradient, self.options, saved, infos
+            self.ts, self.solver, self.gradient, self.options, saved, infos, ylast
         )
 
 
 class SEPropagatorIntegrator(PropagatorIntegrator):
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
+    def result(self, saved: Saved, ylast: Array, infos: PyTree | None = None) -> Result:
         return SEPropagatorResult(
-            self.ts, self.solver, self.gradient, self.options, saved, infos
+            self.ts, self.solver, self.gradient, self.options, saved, infos, ylast
         )
 
 
 class MEPropagatorIntegrator(PropagatorIntegrator, MEIntegrator):
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
+    def result(self, saved: Saved, ylast: Array, infos: PyTree | None = None) -> Result:
         return MEPropagatorResult(
-            self.ts, self.solver, self.gradient, self.options, saved, infos
+            self.ts, self.solver, self.gradient, self.options, saved, infos, ylast
         )

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -68,7 +68,7 @@ class DiffraxIntegrator(BaseIntegrator):
         # === collect and return results
         save_a, save_b = solution.ys
         saved = self.collect_saved(save_a, save_b[0])
-        return self.result(saved, infos=self.infos(solution.stats))
+        return self.result(saved, save_b[0], infos=self.infos(solution.stats))
 
     @abstractmethod
     def infos(self, stats: dict[str, Array]) -> PyTree:

--- a/dynamiqs/integrators/core/expm_integrator.py
+++ b/dynamiqs/integrators/core/expm_integrator.py
@@ -90,7 +90,7 @@ class ExpmIntegrator(BaseIntegrator):
         # === save the propagators
         nsteps = (delta_ts != 0).sum()
         saved = self.collect_saved(saved, ylast, times)
-        return self.result(saved, infos=self.Infos(nsteps))
+        return self.result(saved, ylast, infos=self.Infos(nsteps))
 
 
 class PropagatorExpmIntegrator(ExpmIntegrator, PropagatorIntegrator):

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -79,16 +79,11 @@ class Result(eqx.Module):
 
 
 class SolveResult(Result):
+    final_state: Array
+
     @property
     def states(self) -> Array:
         return self._saved.ysave
-
-    @property
-    def final_state(self) -> Array:
-        if self.options.save_states:
-            return self.states[..., -1, :, :]
-        else:
-            return self.states
 
     @property
     def expects(self) -> Array | None:
@@ -101,29 +96,28 @@ class SolveResult(Result):
     def _str_parts(self) -> dict[str, str | None]:
         d = super()._str_parts()
         return d | {
-            'States  ': array_str(self.states),
-            'Expects ': array_str(self.expects),
-            'Extra   ': (
+            'States     ': array_str(self.states),
+            'Final state': array_str(self.final_state),
+            'Expects    ': array_str(self.expects),
+            'Extra      ': (
                 eqx.tree_pformat(self.extra) if self.extra is not None else None
             ),
         }
 
 
 class PropagatorResult(Result):
+    final_propagator: Array
+
     @property
     def propagators(self) -> Array:
         return self._saved.ysave
 
-    @property
-    def final_propagator(self) -> Array:
-        if self.options.save_states:
-            return self.propagators[..., -1, :, :]
-        else:
-            return self.propagators
-
     def _str_parts(self) -> dict[str, str | None]:
         d = super()._str_parts()
-        return d | {'Propagators': array_str(self.propagators)}
+        return d | {
+            'Propagators     ': array_str(self.propagators),
+            'Final propagator': array_str(self.final_propagator),
+        }
 
 
 class SESolveResult(SolveResult):


### PR DESCRIPTION
I've experienced issues trying to use functions like `jax.lax.cond` where in the functions passed to `cond` I reference a `result.final_state`, which goes through a conditional check on `options.save_states`. It is nicer to save the `final_state` directly after the integration and not have the ugly conditional logic that we have now. 