### PR TITLE
Add pow, powm and tests

### DIFF
--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -115,8 +115,14 @@ class SparseDIAQArray(QArray):
         raise NotImplementedError
 
     def powm(self, n: int) -> QArray:
-        # todo: implement dia specific method or raise warning for dense conversion
-        return to_dense(self).powm(n)
+        if n == 0:
+            eye = jnp.eye(self.shape[-1], dtype=self.dtype)
+            batched_eye = jnp.broadcast_to(eye, self.shape)
+            return SparseDIAQArray(self.dims, self.offsets, batched_eye)
+        if n == 1:
+            return self
+        else:
+            return self @ self.powm(n - 1)
 
     def expm(self, *, max_squarings: int = 16) -> QArray:
         # todo: implement dia specific method or raise warning for dense conversion
@@ -394,8 +400,8 @@ class SparseDIAQArray(QArray):
         out_offsets, out_diags = _compress_dia(out_offsets, out_diags)
         return SparseDIAQArray(dims=out_dims, offsets=out_offsets, diags=out_diags)
 
-    def _pow(self, power: int) -> QArray:  # noqa: ARG002
-        return NotImplemented
+    def _pow(self, power: int) -> QArray:
+        return SparseDIAQArray(self.dims, self.offsets, self.diags**power)
 
     def __getitem__(self, key: int | slice) -> QArray:
         full = slice(None, None, None)

--- a/tests/qarrays/test_sparse_dia_qarray.py
+++ b/tests/qarrays/test_sparse_dia_qarray.py
@@ -158,3 +158,21 @@ class TestSparseDIAQArray:
         error_str = 'must contain zeros outside the matrix bounds'
         with pytest.raises(ValueError, match=error_str):
             dq.SparseDIAQArray(diags=diags, offsets=offsets, dims=(N,))
+
+    @pytest.mark.parametrize('k', ['simple', 'batch', 'batch_broadcast'])
+    def test_pow(self, k, rtol=1e-05, atol=1e-08):
+        d, s = self.denseA[k], self.sparseA[k]
+
+        out_dense = (d**3).to_jax()
+        out_dia = dq.to_dense(s**3).to_jax()
+
+        assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)
+
+    @pytest.mark.parametrize('k', ['simple', 'batch', 'batch_broadcast'])
+    def test_powm(self, k, rtol=1e-05, atol=1e-08):
+        d, s = self.denseA[k], self.sparseA[k]
+
+        out_dense = d.powm(3).to_jax()
+        out_dia = s.powm(3).to_jax()
+
+        assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)


### PR DESCRIPTION
Replaces https://github.com/dynamiqs/dynamiqs/pull/632.

For `powm`, we cannot use a `jax.lax.scan` since the input and output pytree structures of the scan function change from one power to the next (i.e. different offsets). 