### PR TITLE
Fix performance of `mesolve` with QArrays

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -72,8 +72,8 @@ class DenseQArray(QArray):
     def trace(self) -> Array:
         return self.data.trace(axis1=-1, axis2=-2)
 
-    def sum(self, axis: int | tuple[int, ...] | None = None) -> Array:
-        return self.data.sum(axis=axis)
+    def sum(self, axis: int | tuple[int, ...] | None = None) -> Array | QArray:
+        return DenseQArray(self.dims, self.data.sum(axis=axis))
 
     def squeeze(self, axis: int | tuple[int, ...] | None = None) -> Array:
         return self.data.squeeze(axis=axis)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -15,7 +15,7 @@ from qutip import Qobj
 if TYPE_CHECKING:  # avoid circular import by importing only during type checking
     from .types import QArrayLike
 
-__all__ = ["QArray"]
+__all__ = ['QArray']
 
 
 class QArray(eqx.Module):
@@ -46,7 +46,7 @@ class QArray(eqx.Module):
             isinstance(d, int) for d in self.dims
         ):
             raise TypeError(
-                f"Argument `dims` must be a tuple of ints, but is {self.dims}."
+                f'Argument `dims` must be a tuple of ints, but is {self.dims}.'
             )
 
         # === ensure dims is compatible with the shape
@@ -55,8 +55,8 @@ class QArray(eqx.Module):
         allowed_shapes = (prod(self.dims), prod(self.dims) ** 2)
         if not (self.shape[-1] in allowed_shapes or self.shape[-2] in allowed_shapes):
             raise ValueError(
-                "Argument `dims` must be compatible with the shape of the QArray, but "
-                f"got dims {self.dims} and shape {self.shape}."
+                'Argument `dims` must be compatible with the shape of the QArray, but '
+                f'got dims {self.dims} and shape {self.shape}.'
             )
 
     @property
@@ -312,7 +312,7 @@ class QArray(eqx.Module):
         try:
             return self.shape[0]
         except IndexError as err:
-            raise TypeError("len() of unsized object") from err
+            raise TypeError('len() of unsized object') from err
 
     @abstractmethod
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
@@ -328,8 +328,8 @@ class QArray(eqx.Module):
 
     def __repr__(self) -> str:
         return (
-            f"{type(self).__name__}: shape={self.shape}, dims={self.dims}, "
-            f"dtype={self.dtype}"
+            f'{type(self).__name__}: shape={self.shape}, dims={self.dims}, '
+            f'dtype={self.dtype}'
         )
 
     def __neg__(self) -> QArray:
@@ -343,9 +343,9 @@ class QArray(eqx.Module):
 
         if not _is_batched_scalar(y):
             logging.warning(
-                "Using the `*` operator between two arrays performs element-wise "
-                "multiplication. For matrix multiplication, use the `@` operator "
-                "instead."
+                'Using the `*` operator between two arrays performs element-wise '
+                'multiplication. For matrix multiplication, use the `@` operator '
+                'instead.'
             )
 
         if isinstance(y, QArray):
@@ -373,9 +373,9 @@ class QArray(eqx.Module):
 
         if _is_batched_scalar(y):
             logging.warning(
-                "Using the `+` or `-` operator between an array and a scalar performs "
-                "element-wise addition or subtraction. For addition with a scaled "
-                "identity matrix, use e.g. `x + 2 * x.I` instead."
+                'Using the `+` or `-` operator between an array and a scalar performs '
+                'element-wise addition or subtraction. For addition with a scaled '
+                'identity matrix, use e.g. `x + 2 * x.I` instead.'
             )
 
         if isinstance(y, QArray):
@@ -413,8 +413,8 @@ class QArray(eqx.Module):
             return _Metaω.__rpow__(power, self)
         else:
             logging.warning(
-                "Using the `**` operator performs element-wise power. For matrix "
-                "power, use `x @ x @ ... @ x` or `dq.powm(x, power)` instead."
+                'Using the `**` operator performs element-wise power. For matrix '
+                'power, use `x @ x @ ... @ x` or `dq.powm(x, power)` instead.'
             )
             return self._pow(power)
 
@@ -430,7 +430,7 @@ class QArray(eqx.Module):
 def _check_compatible_dims(dims1: tuple[int, ...], dims2: tuple[int, ...]):
     if dims1 != dims2:
         raise ValueError(
-            f"QArrays have incompatible dimensions. Got {dims1} and {dims2}."
+            f'QArrays have incompatible dimensions. Got {dims1} and {dims2}.'
         )
 
 

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -15,7 +15,7 @@ from qutip import Qobj
 if TYPE_CHECKING:  # avoid circular import by importing only during type checking
     from .types import QArrayLike
 
-__all__ = ['QArray']
+__all__ = ["QArray"]
 
 
 class QArray(eqx.Module):
@@ -46,7 +46,7 @@ class QArray(eqx.Module):
             isinstance(d, int) for d in self.dims
         ):
             raise TypeError(
-                f'Argument `dims` must be a tuple of ints, but is {self.dims}.'
+                f"Argument `dims` must be a tuple of ints, but is {self.dims}."
             )
 
         # === ensure dims is compatible with the shape
@@ -55,8 +55,8 @@ class QArray(eqx.Module):
         allowed_shapes = (prod(self.dims), prod(self.dims) ** 2)
         if not (self.shape[-1] in allowed_shapes or self.shape[-2] in allowed_shapes):
             raise ValueError(
-                'Argument `dims` must be compatible with the shape of the QArray, but '
-                f'got dims {self.dims} and shape {self.shape}.'
+                "Argument `dims` must be compatible with the shape of the QArray, but "
+                f"got dims {self.dims} and shape {self.shape}."
             )
 
     @property
@@ -312,7 +312,7 @@ class QArray(eqx.Module):
         try:
             return self.shape[0]
         except IndexError as err:
-            raise TypeError('len() of unsized object') from err
+            raise TypeError("len() of unsized object") from err
 
     @abstractmethod
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
@@ -328,8 +328,8 @@ class QArray(eqx.Module):
 
     def __repr__(self) -> str:
         return (
-            f'{type(self).__name__}: shape={self.shape}, dims={self.dims}, '
-            f'dtype={self.dtype}'
+            f"{type(self).__name__}: shape={self.shape}, dims={self.dims}, "
+            f"dtype={self.dtype}"
         )
 
     def __neg__(self) -> QArray:
@@ -343,9 +343,9 @@ class QArray(eqx.Module):
 
         if not _is_batched_scalar(y):
             logging.warning(
-                'Using the `*` operator between two arrays performs element-wise '
-                'multiplication. For matrix multiplication, use the `@` operator '
-                'instead.'
+                "Using the `*` operator between two arrays performs element-wise "
+                "multiplication. For matrix multiplication, use the `@` operator "
+                "instead."
             )
 
         if isinstance(y, QArray):
@@ -373,9 +373,9 @@ class QArray(eqx.Module):
 
         if _is_batched_scalar(y):
             logging.warning(
-                'Using the `+` or `-` operator between an array and a scalar performs '
-                'element-wise addition or subtraction. For addition with a scaled '
-                'identity matrix, use e.g. `x + 2 * x.I` instead.'
+                "Using the `+` or `-` operator between an array and a scalar performs "
+                "element-wise addition or subtraction. For addition with a scaled "
+                "identity matrix, use e.g. `x + 2 * x.I` instead."
             )
 
         if isinstance(y, QArray):
@@ -413,8 +413,8 @@ class QArray(eqx.Module):
             return _Metaω.__rpow__(power, self)
         else:
             logging.warning(
-                'Using the `**` operator performs element-wise power. For matrix '
-                'power, use `x @ x @ ... @ x` or `dq.powm(x, power)` instead.'
+                "Using the `**` operator performs element-wise power. For matrix "
+                "power, use `x @ x @ ... @ x` or `dq.powm(x, power)` instead."
             )
             return self._pow(power)
 
@@ -430,10 +430,17 @@ class QArray(eqx.Module):
 def _check_compatible_dims(dims1: tuple[int, ...], dims2: tuple[int, ...]):
     if dims1 != dims2:
         raise ValueError(
-            f'QArrays have incompatible dimensions. Got {dims1} and {dims2}.'
+            f"QArrays have incompatible dimensions. Got {dims1} and {dims2}."
         )
 
 
 def _in_last_two_dims(axis: int | tuple[int, ...] | None, ndim: int) -> bool:
     axis = (axis,) if isinstance(axis, int) else axis
     return axis is None or any(a % ndim in [ndim - 1, ndim - 2] for a in axis)
+
+
+def _include_last_two_dims(axis: int | tuple[int, ...] | None, ndim: int) -> bool:
+    axis = (axis,) if isinstance(axis, int) else axis
+    return axis is None or (
+        ndim - 1 in [a % ndim for a in axis] and ndim - 2 in [a % ndim for a in axis]
+    )


### PR DESCRIPTION
Fixes the ~20% performance loss with the new `vector_field` introduced with QArrays.

For now, only the dense format is supported. In a following commit, I plan to introduce a `StackedQArray` class to handle stacks of SparseDIA and/or Dense arrays, when relevant. 

<details>
<summary>Benchmark code</summary>

```python
import timeit
import dynamiqs as dq
import jax.numpy as jnp

dq.set_device('cpu')
dq.set_layout(dq.dense)

# parameters
kappa_2 = 1.0
eps_z = 0.1
nbar = 4.0
num_tsave = 100
N = 24

# time evolution
alpha = jnp.sqrt(nbar)
gate_time = jnp.pi / (4 * alpha * eps_z)
tsave = jnp.linspace(0.0, gate_time, num_tsave)

# operators
a = dq.destroy(N)
i = dq.eye(N)

# Hamiltonian
H = eps_z * (a + dq.dag(a))

# jump operators
jump_ops = [jnp.sqrt(kappa_2) * (a @ a - nbar * i)]

# initial state
psi0 = dq.unit(dq.coherent(N, alpha) + dq.coherent(N, -alpha))

# options
options = dq.Options(progress_meter=None)

# run
dq.mesolve(H, jump_ops, psi0, tsave, options=options).states.data.block_until_ready()
%timeit -n10 -r7 dq.mesolve(H, jump_ops, psi0, tsave, options=options).states.data.block_until_ready()
```

Before: 147 ms ± 14.1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
After: 111 ms ± 632 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
</details>