### PR TITLE
Add .block_until_ready() method to Result

### DIFF
--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -57,6 +57,10 @@ class Result(eqx.Module):
     def to_numpy(self) -> Result:
         raise NotImplementedError
 
+    def block_until_ready(self) -> Result:
+        _ = self._saved.ysave.block_until_ready()
+        return self
+
     def _str_parts(self) -> dict[str, str | None]:
         return {
             'Solver': type(self.solver).__name__,


### PR DESCRIPTION
Nice helper for benchmarks.

Implementation is the same as https://github.com/google/jax/blob/201d3ff8f1bbcce6bebf90d2c1a5e5d6dec4fd5e/jax/_src/earray.py#L41-L43.