### PR TITLE
Add benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,76 @@
+# Benchmarks
+
+This directory contains a set of scripts to benchmark dynamiqs against other libraries (`QuTiP`, `QuTiP-jax` and `QuantumOptics.jl` for now), on a set of representative problems of the simulation of dynamics of closed and open quantum systems.
+
+All scripts have the same structure:
+- Import relevant dependencies
+- Define global options, namely the matrix layout (dense or sparse) and the backend (CPU or GPU) when applicable
+- Define the problem to solve (Hamiltonian, jump operators, initial state, time grid, etc.)
+- Define the solver and its options
+- Run the benchmark using `timeit` for Python or `BenchmarkTools.jl` for Julia
+
+For fair comparisons, all scripts use the default solver of the library (namely `Tsit5` for dynamiqs, `QuTiP-jax` and `QuantumOptics.jl`, and `Adams` for `QuTiP`) with the same tolerances (`atol=1e-8`, `rtol=1e-6`).
+
+## Selected problems
+
+Below, we provide a complete description of each problem considered in these benchmarks. The following table gives a summary of the main characteristics of these problems.
+
+| | Cross-resonance gate | Dissipative cat CNOT | Driven-dissipative Kerr oscillator | Transmon pi-pulse | 1D Ising model |
+|----------------------|----------------------|----------------------|----------------------|----------------------|----------------------|
+| Time-dependence | time-dependent | constant | constant | time-dependent | constant |
+| Nature of system | closed | open | open | open | closed |
+| Hilbert space size | 4 | 1024 | 32 | 3 | 4096 |
+| Number of modes | 2 | 2 | 1 | 1 | 12 |
+| Batching size | 1 | 1 | 20 | 400 | 1 |
+
+### Cross-resonance gate
+
+This problem simulates the dynamics of a cross-resonance gate between two qubits. The Hamiltonian is given by
+$$
+H = \omega_1 \sigma_z^{(1)} + \omega_2 \sigma_z^{(2)} + J (\sigma_+^{(1)} \sigma_-^{(2)} + \mathrm{h.c.}) + \epsilon(t) \sigma_x^{(1)},
+$$
+where $\epsilon(t) = \epsilon_0 \cos(\omega_d t)$ with $\omega_d = \omega_2 - J^2 / (\omega_1 - \omega_2)$. The system is simulated for a duration $T = \frac{\pi |\omega_2 - \omega_1|}{2 J \epsilon_0}$. The state is initialized in $|00\rangle$. The selected system parameters are $\omega_1 = 4$, $\omega_2 = 6$, $J = 0.4$, and $\epsilon_0 = 0.4$.
+
+### Dissipative cat CNOT
+
+This problem simulates the dynamics of a CNOT gate between two dissipative cat qubits, encoded in quantum harmonic oscillators. The Hamiltonian is given by
+$$
+H = g (a_c^\dagger + a_c) (a_t^\dagger a_t - |\alpha|^2)
+$$
+and the unique jump operator reads
+$$
+L = \sqrt{\kappa_2} (a_c^2 - \alpha^2)
+$$
+The system is simulated for a duration $T = \pi / 4 \alpha g$. The state is initialized in $|\mathcal{C}_\alpha^+ \rangle |\mathcal{C}_\alpha^+ \rangle$ where $|\mathcal{C}_\alpha^+ \rangle$ is the even cat state. The selected system parameters are $\kappa_2 = 1$, $g = 0.3$, $\alpha^2 = 4$, and $N = 32$ for each mode.
+
+### Driven-dissipative Kerr oscillator
+
+This problem simulates the dynamics of an idling driven-dissipative Kerr oscillator, where the drive strength is sweeped. The Hamiltonian is given by
+$$
+H = K a^{\dagger 2} a^2 + \epsilon (a + a^\dagger)
+$$
+and the unique jump operator reads
+$$
+L = \sqrt{\kappa} a
+$$
+The system is simulated for a duration $T = \pi / K$. The state is initialized in a coherent state $|\alpha\rangle$. The selected system parameters are $K = 1$, $\kappa = 0.1$, $\alpha = 2$, $N = 32$ and $\epsilon$ is batched from $0$ to $0.5$ over $n_{batch} = 20$ parameters.
+
+### Transmon pi-pulse
+
+This problem simulates the dynamics of a 3-level transmon qubit under a gaussian-shaped $\pi$-pulse, where two parameters of the drive are batched over. The Hamiltonian is given by
+$$
+H = K a^{\dagger 2} a^2 + \Omega(t) (a + a^\dagger)
+$$
+where
+$$
+\Omega(t) = \Omega_0 \left[\exp\left(-\frac{(t - T/2)^2}{2\sigma^2}\right) - \exp\left(-\frac{T^2}{8\sigma^2}\right) \right]^2
+$$
+The system is simulated for a fixed duration $T$. The state is initialized in the transmon ground state $|g\rangle$. The selected system parameters are $K = 2$, $\kappa = 0.1$, $T = 20$, $\Omega_0$ is batched from $0$ to $0.3$ over $n_{batch, 1} = 20$ parameters, and $\sigma$ is batched from $0.5$ to $10$ over $n_{batch, 2} = 20$ parameters.
+
+### 1D Ising model
+
+This problem simulates the dynamics of a 1D chain of 12 spins under the Ising model Hamiltonian. The Hamiltonian is given by
+$$
+H = -J \sum_{i} \sigma_z^{(i)} \sigma_z^{(i+1)}
+$$
+with $J < 0$ (anti-ferromagnetic). The system is simulated for a duration $T = 1 / J$. The state is initialized in the ground state of each individual spin, $\otimes_i \vert\!\downarrow\rangle^{(i)}$. The selected system parameters are $J = -1$ and $n_{mode} = 12$ spins.

--- a/benchmarks/cat-cnot/dynamiqs-bench.py
+++ b/benchmarks/cat-cnot/dynamiqs-bench.py
@@ -1,0 +1,40 @@
+import dynamiqs as dq
+import jax.numpy as jnp
+
+# global settings
+dq.set_layout('dia') # 'dense' or 'dia'
+dq.set_device('cpu') # 'cpu' or 'gpu'
+
+# parameters
+kappa_2 = 1.0
+g_cnot = 0.3
+nbar = 4.0
+num_tsave = 100
+N = 32
+
+# save times
+alpha = jnp.sqrt(nbar)
+gate_time = jnp.pi / (4 * alpha * g_cnot)
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# operators
+ac = dq.tensor(dq.destroy(N), dq.eye(N))
+nt = dq.tensor(dq.eye(N), dq.number(N))
+i = dq.tensor(dq.eye(N), dq.eye(N))
+H = g_cnot * (ac + dq.dag(ac)) @ (nt - nbar * i)
+jump_ops = [jnp.sqrt(kappa_2) * (ac @ ac - nbar * i)]
+
+# initial state
+plus = dq.unit(dq.coherent(N, alpha) + dq.coherent(N, -alpha))
+psi0 = dq.tensor(plus, plus)
+
+# options
+options = dq.Options(progress_meter=None)
+solver = dq.solver.Tsit5(atol=1e-8, rtol=1e-6)
+
+# run benchmark
+def blocked_mesolve(*args, **kwargs):
+    return dq.mesolve(*args, **kwargs).states.data.block_until_ready()
+
+blocked_mesolve(H, jump_ops, psi0, tsave, options=options, solver=solver)
+%timeit -r1 blocked_mesolve(H, jump_ops, psi0, tsave, options=options, solver=solver)

--- a/benchmarks/cat-cnot/quantumoptics-bench.jl
+++ b/benchmarks/cat-cnot/quantumoptics-bench.jl
@@ -1,0 +1,33 @@
+using QuantumOptics
+using BenchmarkTools
+
+# global options
+layout == "sparse" # "sparse" or "dense"
+
+# parameters
+kappa_2 = 1.0
+g_cnot = 0.3
+nbar = 4.0
+num_tsave = 100
+N = 32
+
+# save times
+alpha = sqrt(nbar)
+gate_time = pi / (4 * alpha * g_cnot)
+tspan = LinRange(0, gate_time, num_tsave)
+
+# operators
+basis = FockBasis(N - 1)
+a = layout == "sparse" ? destroy(basis) : dense(destroy(basis))
+adag = layout == "sparse" ? create(basis) : dense(create(basis))
+n = layout == "sparse" ? number(basis) : dense(number(basis))
+i = layout == "sparse" ? identityoperator(basis) : dense(identityoperator(basis))
+H = g_cnot * tensor(a + adag, n - nbar * i)
+J = [sqrt(kappa_2) * tensor(a^2 - nbar * i, i)]
+
+# initial state
+plus = normalize(coherentstate(basis, alpha) + coherentstate(basis, -alpha))
+psi0 = tensor(plus, plus)
+
+# run benchmark
+@btime timeevolution.master(tspan, psi0, H, J; abstol=1e-8, reltol=1e-6);

--- a/benchmarks/cat-cnot/qutip-bench.py
+++ b/benchmarks/cat-cnot/qutip-bench.py
@@ -1,0 +1,35 @@
+import qutip as qt
+import numpy as np
+
+# global options
+qt.settings.core['default_dtype'] = 'Dia' # 'Dia' or 'Dense'
+
+# parameters
+kappa_2 = 1.0
+g_cnot = 0.3
+nbar = 4.0
+num_tsave = 100
+N = 32
+
+# save times
+alpha = np.sqrt(nbar)
+gate_time = np.pi / (4 * alpha * g_cnot)
+tsave = np.linspace(0.0, gate_time, num_tsave)
+
+# operators
+ac = qt.tensor(qt.destroy(N), qt.qeye(N))
+nt = qt.tensor(qt.qeye(N), qt.num(N))
+i = qt.tensor(qt.qeye(N), qt.qeye(N))
+H = g_cnot * (ac + ac.dag()) @ (nt - nbar * i)
+c_ops = [np.sqrt(kappa_2) * (ac @ ac - nbar * i)]
+
+# initial state
+with qt.CoreOptions(default_dtype='Dense'):
+    plus = (qt.coherent(N, alpha) + qt.coherent(N, -alpha)).unit()
+    psi0 = qt.tensor(plus, plus)
+
+# options
+options = {'method': 'adams', 'normalize_output': False}
+
+# run benchmark
+%timeit -r1 qt.mesolve(H, psi0, tsave, c_ops=c_ops, options=options)

--- a/benchmarks/cat-cnot/qutip-jax-bench.py
+++ b/benchmarks/cat-cnot/qutip-jax-bench.py
@@ -1,0 +1,40 @@
+import qutip_jax as qjax
+import qutip as qt
+import jax.numpy as jnp
+
+# global options
+qt.settings.core['default_dtype'] = 'jaxdia' # 'jaxdia' or 'jax'
+
+# parameters
+kappa_2 = 1.0
+g_cnot = 0.3
+nbar = 4.0
+num_tsave = 100
+N = 32
+
+# save times
+alpha = jnp.sqrt(nbar)
+gate_time = jnp.pi / (4 * alpha * g_cnot)
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# operators
+ac = qt.tensor(qt.destroy(N), qt.qeye(N))
+nt = qt.tensor(qt.qeye(N), qt.num(N))
+i = qt.tensor(qt.qeye(N), qt.qeye(N))
+H = g_cnot * (ac + ac.dag()) @ (nt - nbar * i)
+c_ops = [jnp.sqrt(kappa_2) * (ac @ ac - nbar * i)]
+
+# initial state
+with qt.CoreOptions(default_dtype='jax'):
+    plus = (qt.coherent(N, alpha) + qt.coherent(N, -alpha)).unit()
+    psi0 = qt.tensor(plus, plus)
+
+# options
+options = {'method': 'diffrax', 'normalize_output': False}
+
+# function to benchmark
+def blocked_mesolve(*args, **kwargs):
+    return qt.mesolve(*args, **kwargs).final_state.data._jxa.block_until_ready()
+
+blocked_mesolve(H, psi0, tsave, c_ops=c_ops, options=options)
+%timeit -r1 blocked_mesolve(H, psi0, tsave, c_ops=c_ops, options=options)

--- a/benchmarks/cr-gate/dynamiqs-bench.py
+++ b/benchmarks/cr-gate/dynamiqs-bench.py
@@ -1,0 +1,44 @@
+import dynamiqs as dq
+import jax.numpy as jnp
+
+# global settings
+dq.set_layout('dia') # 'dense' or 'dia'
+dq.set_device('cpu') # 'cpu' or 'gpu'
+
+# parameters
+omega_1 = 4.0
+omega_2 = 6.0
+J = 0.4
+eps = 0.4
+num_tsave = 100
+
+# save times
+gate_time = 0.5 * jnp.pi * abs(omega_2 - omega_1) / (J * eps)
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# operators
+sz1 = dq.tensor(dq.sigmaz(), dq.eye(2))
+sz2 = dq.tensor(dq.eye(2), dq.sigmaz())
+sp1 = dq.tensor(dq.sigmap(), dq.eye(2))
+sp2 = dq.tensor(dq.eye(2), dq.sigmap())
+sm1 = dq.tensor(dq.sigmam(), dq.eye(2))
+sm2 = dq.tensor(dq.eye(2), dq.sigmam())
+omega_d = omega_2 - J**2 / (omega_1 - omega_2)
+H0 = 0.5 * omega_1 * sz1 + 0.5 * omega_2 * sz2 + J * (sp1 @ sm2 + sm1 @ sp2)
+Hd = eps * (sp1 + sm1)
+fd = lambda t: jnp.cos(omega_d * t)  # noqa: E731
+H = H0 + dq.modulated(fd, Hd)
+
+# initial state
+psi0 = dq.tensor(dq.basis(2, 1), dq.basis(2, 1))
+
+# options
+options = dq.Options(progress_meter=None)
+solver = dq.solver.Tsit5(atol=1e-8, rtol=1e-6)
+
+# run benchmark
+def blocked_sesolve(*args, **kwargs):
+    return dq.sesolve(*args, **kwargs).states.data.block_until_ready()
+
+blocked_sesolve(H, psi0, tsave, options=options, solver=solver)
+%timeit blocked_sesolve(H, psi0, tsave, options=options, solver=solver)

--- a/benchmarks/cr-gate/quantumoptics-bench.jl
+++ b/benchmarks/cr-gate/quantumoptics-bench.jl
@@ -1,0 +1,33 @@
+using QuantumOptics
+using BenchmarkTools
+
+# global options
+layout == "sparse" # "sparse" or "dense"
+
+# parameters
+omega_1 = 4.0
+omega_2 = 6.0
+J = 0.4
+eps = 0.4
+num_tsave = 100
+
+# save times
+gate_time = 0.5 * pi * abs(omega_2 - omega_1) / (J * eps)
+tspan = LinRange(0, gate_time, num_tsave)
+
+# operators
+basis = SpinBasis(1//2)
+sz = layout == "sparse" ? sigmaz(basis) : dense(sigmaz(basis))
+sp = layout == "sparse" ? sigmap(basis) : dense(sigmap(basis))
+sm = layout == "sparse" ? sigmam(basis) : dense(sigmam(basis))
+i = layout == "sparse" ? identityoperator(basis) : dense(identityoperator(basis))
+omega_d = omega_2 - J^2 / (omega_1 - omega_2)
+H0 = 0.5 * omega_1 * tensor(sz, i) + 0.5 * omega_2 * tensor(i, sz) + J * (tensor(sp, sm) + tensor(sm, sp))
+Hd = eps * (tensor(sp, i) + tensor(sm, i))
+H(t, psi) = H0 + cos(omega_d * t) * Hd
+
+# initial state
+psi0 = tensor(spindown(basis), spindown(basis))
+
+# run benchmark
+@benchmark timeevolution.schroedinger_dynamic(tspan, psi0, H; abstol=1e-8, reltol=1e-6)

--- a/benchmarks/cr-gate/qutip-bench.py
+++ b/benchmarks/cr-gate/qutip-bench.py
@@ -1,0 +1,39 @@
+import qutip as qt
+import numpy as np
+
+# global options
+qt.settings.core['default_dtype'] = 'Dia' # 'Dia' or 'Dense'
+
+# parameters
+omega_1 = 4.0
+omega_2 = 6.0
+J = 0.4
+eps = 0.4
+num_tsave = 100
+
+# save times
+gate_time = 0.5 * np.pi * abs(omega_2 - omega_1) / (J * eps)
+tsave = np.linspace(0.0, gate_time, num_tsave)
+
+# operators
+sz1 = qt.tensor(qt.sigmaz(), qt.qeye(2))
+sz2 = qt.tensor(qt.qeye(2), qt.sigmaz())
+sp1 = qt.tensor(qt.sigmap(), qt.qeye(2))
+sp2 = qt.tensor(qt.qeye(2), qt.sigmap())
+sm1 = qt.tensor(qt.sigmam(), qt.qeye(2))
+sm2 = qt.tensor(qt.qeye(2), qt.sigmam())
+omega_d = omega_2 - J**2 / (omega_1 - omega_2)
+H0 = 0.5 * omega_1 * sz1 + 0.5 * omega_2 * sz2 + J * (sp1 * sm2 + sm1 * sp2)
+Hd = eps * (sp1 + sm1)
+fd = lambda t: np.cos(omega_d * t)
+H = [H0, [Hd, fd]]
+
+# initial state
+with qt.CoreOptions(default_dtype='Dense'):
+    psi0 = qt.tensor(qt.basis(2, 1), qt.basis(2, 1))
+
+# options
+options = {'method': 'adams', 'normalize_output': False}
+
+# run benchmark
+%timeit qt.sesolve(H, psi0, tsave, options=options)

--- a/benchmarks/cr-gate/qutip-jax-bench.py
+++ b/benchmarks/cr-gate/qutip-jax-bench.py
@@ -1,0 +1,45 @@
+import qutip_jax
+import qutip as qt
+import jax.numpy as jnp
+import jax
+
+# global options
+qt.settings.core['default_dtype'] = 'jaxdia' # 'jaxdia' or 'jax'
+
+# parameters
+omega_1 = 4.0
+omega_2 = 6.0
+J = 0.4
+eps = 0.4
+num_tsave = 100
+
+# save times
+gate_time = 0.5 * jnp.pi * abs(omega_2 - omega_1) / (J * eps)
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# operators
+sz1 = qt.tensor(qt.sigmaz(), qt.qeye(2))
+sz2 = qt.tensor(qt.qeye(2), qt.sigmaz())
+sp1 = qt.tensor(qt.sigmap(), qt.qeye(2))
+sp2 = qt.tensor(qt.qeye(2), qt.sigmap())
+sm1 = qt.tensor(qt.sigmam(), qt.qeye(2))
+sm2 = qt.tensor(qt.qeye(2), qt.sigmam())
+omega_d = omega_2 - J**2 / (omega_1 - omega_2)
+H0 = 0.5 * omega_1 * sz1 + 0.5 * omega_2 * sz2 + J * (sp1 * sm2 + sm1 * sp2)
+Hd = eps * (sp1 + sm1)
+fd = jax.jit(lambda t: jnp.cos(omega_d * t))
+H = [H0, [Hd, fd]]
+
+# initial state
+with qt.CoreOptions(default_dtype='jax'):
+    psi0 = qt.tensor(qt.basis(2, 1), qt.basis(2, 1))
+
+# options
+options = {'method': 'diffrax', 'normalize_output': False}
+
+# function to benchmark
+def blocked_sesolve(*args, **kwargs):
+    return qt.sesolve(*args, **kwargs).final_state.data._jxa.block_until_ready()
+
+blocked_sesolve(H, psi0, tsave, options=options)
+%timeit blocked_sesolve(H, psi0, tsave, options=options)

--- a/benchmarks/ising-model/dynamiqs-bench.py
+++ b/benchmarks/ising-model/dynamiqs-bench.py
@@ -1,0 +1,37 @@
+import dynamiqs as dq
+import jax.numpy as jnp
+
+# global settings
+dq.set_layout('dia') # 'dense' or 'dia'
+dq.set_device('cpu') # 'cpu' or 'gpu'
+
+# parameters
+num_modes = 12
+num_tsave = 100
+J = 1.0
+
+# save times
+gate_time = 1 / J
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# operators
+sigmazs = [
+    dq.tensor(*[dq.eye(2) if j != m else dq.sigmaz() for j in range(num_modes)])
+    for m in range(num_modes)
+]
+identity = dq.tensor(*[dq.eye(2) for _ in range(num_modes)])
+H = J * sum([sigmazs[m] @ sigmazs[m + 1] for m in range(num_modes - 1)], 0 * identity)
+
+# initial state
+psi0 = dq.tensor(*[dq.basis(2, 0) for _ in range(num_modes)])
+
+# options
+options = dq.Options(progress_meter=None)
+solver = dq.solver.Tsit5(atol=1e-8, rtol=1e-6)
+
+# run benchmark
+def blocked_sesolve(*args, **kwargs):
+    return dq.sesolve(*args, **kwargs).states.data.block_until_ready()
+
+blocked_sesolve(H, psi0, tsave, options=options, solver=solver)
+%timeit blocked_sesolve(H, psi0, tsave, options=options, solver=solver)

--- a/benchmarks/ising-model/quantumoptics-bench.jl
+++ b/benchmarks/ising-model/quantumoptics-bench.jl
@@ -1,0 +1,28 @@
+using QuantumOptics
+using BenchmarkTools
+
+# global options
+layout == "sparse" # "sparse" or "dense"
+
+# parameters
+num_modes = 12
+num_tsave = 100
+J = 1.0
+
+# save times
+gate_time = 1 / J
+tspan = LinRange(0, gate_time, num_tsave)
+
+# operators
+b = SpinBasis(1//2)
+sz = layout == "sparse" ? sigmaz(b) : dense(sigmaz(b))
+id = layout == "sparse" ? identityoperator(b) : dense(identityoperator(b))
+sigmazs = [tensor([j != m ? id : sz for j in 1:num_modes]...) for m in 1:num_modes]
+identity = tensor([id for j in 1:num_modes]...)
+H = J * sum([sigmazs[m] * sigmazs[m + 1] for m in 1:num_modes - 1])
+
+# initial state
+psi0 = tensor([spindown(b) for j in 1:num_modes]...)
+
+# run benchmark
+@benchmark timeevolution.schroedinger(tspan, psi0, H; abstol=1e-8, reltol=1e-6)

--- a/benchmarks/ising-model/qutip-bench.py
+++ b/benchmarks/ising-model/qutip-bench.py
@@ -1,0 +1,29 @@
+import qutip as qt
+import numpy as np
+
+# global options
+qt.settings.core['default_dtype'] = 'Dia' # 'Dia' or 'Dense'
+
+# parameters
+num_modes = 12
+num_tsave = 100
+J = 1.0
+
+# save times
+gate_time = 1 / J
+tsave = np.linspace(0.0, gate_time, num_tsave)
+
+# operators
+sigmazs = [qt.tensor(*[qt.qeye(2) if j != m else qt.sigmaz() for j in range(num_modes)]) for m in range(num_modes)]
+identity = qt.tensor(*[qt.qeye(2) for _ in range(num_modes)])
+H = J * sum([sigmazs[m] @ sigmazs[m + 1] for m in range(num_modes - 1)], 0 * identity)
+
+# initial state
+with qt.CoreOptions(default_dtype='Dense'):
+    psi0 = qt.tensor(*[qt.basis(2, 0) for _ in range(num_modes)])
+
+# options
+options = {'method': 'adams', 'normalize_output': False}
+
+# run benchmark
+%timeit qt.sesolve(H, psi0, tsave, options=options)

--- a/benchmarks/ising-model/qutip-jax-bench.py
+++ b/benchmarks/ising-model/qutip-jax-bench.py
@@ -1,0 +1,34 @@
+import qutip_jax as qjax
+import qutip as qt
+import jax.numpy as jnp
+
+# global options
+qt.settings.core['default_dtype'] = 'jaxdia' # 'jaxdia' or 'jax'
+
+# parameters
+num_modes = 12
+num_tsave = 100
+J = 1.0
+
+# save times
+gate_time = 1 / J
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# operators
+sigmazs = [qt.tensor(*[qt.qeye(2) if j != m else qt.sigmaz() for j in range(num_modes)]) for m in range(num_modes)]
+identity = qt.tensor(*[qt.qeye(2) for _ in range(num_modes)])
+H = J * sum([sigmazs[m] @ sigmazs[m + 1] for m in range(num_modes - 1)], 0 * identity)
+
+# initial state
+with qt.CoreOptions(default_dtype='jax'):
+    psi0 = qt.tensor(*[qt.basis(2, 0) for _ in range(num_modes)])
+
+# options
+options = {'method': 'diffrax', 'normalize_output': False}
+
+# function to benchmark
+def blocked_sesolve(*args, **kwargs):
+    return qt.sesolve(*args, **kwargs).final_state.data._jxa.block_until_ready()
+
+blocked_sesolve(H, psi0, tsave, options=options)
+%timeit blocked_sesolve(H, psi0, tsave, options=options)

--- a/benchmarks/kerr-oscillator/dynamiqs-bench.py
+++ b/benchmarks/kerr-oscillator/dynamiqs-bench.py
@@ -1,0 +1,37 @@
+import dynamiqs as dq
+import jax.numpy as jnp
+
+# global settings
+dq.set_layout('dia') # 'dense' or 'dia'
+dq.set_device('cpu') # 'cpu' or 'gpu'
+
+# parameters
+K = 1.0
+epsilons = jnp.linspace(0.0, 0.5, 20)
+kappa = 0.1
+alpha = 2.0
+num_tsave = 100
+N = 32
+
+# save times
+gate_time = jnp.pi / K
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# operators
+a, adag = dq.destroy(N), dq.create(N)
+Hs = K * adag @ adag @ a @ a + epsilons[:, None, None] * (a + adag)
+jump_ops = [jnp.sqrt(kappa) * a]
+
+# initial state
+psi0 = dq.coherent(N, alpha)
+
+# options
+options = dq.Options(progress_meter=None)
+solver = dq.solver.Tsit5(atol=1e-8, rtol=1e-6)
+
+# run benchmark
+def blocked_mesolve(*args, **kwargs):
+    return dq.mesolve(*args, **kwargs).states.data.block_until_ready()
+
+blocked_mesolve(Hs, jump_ops, psi0, tsave, options=options, solver=solver)
+%timeit blocked_mesolve(Hs, jump_ops, psi0, tsave, options=options, solver=solver)

--- a/benchmarks/kerr-oscillator/quantumoptics-bench.jl
+++ b/benchmarks/kerr-oscillator/quantumoptics-bench.jl
@@ -1,0 +1,30 @@
+using QuantumOptics
+using BenchmarkTools
+
+# global options
+layout = "sparse" # "dense" or "sparse"
+
+# parameters
+K = 1.0
+epsilons = LinRange(0.0, 0.5, 20)
+kappa = 0.1
+alpha = 2.0
+num_tsave = 100
+N = 32
+
+# save times
+gate_time = pi / K
+tspan = LinRange(0, gate_time, num_tsave)
+
+# operators
+basis = FockBasis(N - 1)
+a = layout == "sparse" ? destroy(basis) : dense(destroy(basis))
+adag = layout == "sparse" ? create(basis) : dense(create(basis))
+Hs = [K * adag^2 * a^2 + eps * (adag + a) for eps in epsilons]
+J = [sqrt(kappa) * a]
+
+# initial state
+psi0 = coherentstate(basis, alpha)
+
+# run benchmark
+@btime [timeevolution.master(tspan, psi0, H, J; abstol=1e-8, reltol=1e-6) for H in Hs];

--- a/benchmarks/kerr-oscillator/qutip-bench.py
+++ b/benchmarks/kerr-oscillator/qutip-bench.py
@@ -1,0 +1,32 @@
+import qutip as qt
+import numpy as np
+
+# global options
+qt.settings.core['default_dtype'] = 'Dia' # 'Dia' or 'Dense'
+
+# parameters
+K = 1.0
+epsilons = np.linspace(0.0, 0.5, 20)
+kappa = 0.1
+alpha = 2.0
+num_tsave = 100
+N = 32
+
+# save times
+gate_time = np.pi / K
+tsave = np.linspace(0.0, gate_time, num_tsave)
+
+# operators
+a, adag = qt.destroy(N), qt.create(N)
+Hs = [K * adag @ adag @ a @ a + eps * (a + adag) for eps in epsilons]
+c_ops = [np.sqrt(kappa) * a]
+
+# initial state
+with qt.CoreOptions(default_dtype='Dense'):
+    psi0 = qt.coherent(N, alpha)
+
+# options
+options = {'method': 'adams', 'normalize_output': False}
+
+# run benchmark
+%timeit [qt.mesolve(H, psi0, tsave, c_ops=c_ops, options=options) for H in Hs]

--- a/benchmarks/kerr-oscillator/qutip-jax-bench.py
+++ b/benchmarks/kerr-oscillator/qutip-jax-bench.py
@@ -1,0 +1,39 @@
+import qutip_jax
+import qutip as qt
+import jax.numpy as jnp
+
+# global options
+qt.settings.core['default_dtype'] = 'jaxdia' # 'jaxdia' or 'jax'
+
+# parameters
+K = 1.0
+epsilons = np.linspace(0.0, 0.5, 20)
+kappa = 0.1
+alpha = 2.0
+num_tsave = 100
+N = 32
+
+# save times
+gate_time = np.pi / K
+tsave = np.linspace(0.0, gate_time, num_tsave)
+
+# operators
+a, adag = qt.destroy(N), qt.create(N)
+Hs = [K * adag @ adag @ a @ a + eps * (a + adag) for eps in epsilons]
+c_ops = [np.sqrt(kappa) * a]
+
+# initial state
+with qt.CoreOptions(default_dtype='jax'):
+    psi0 = qt.coherent(N, alpha)
+
+# options
+options = {'method': 'diffrax', 'normalize_output': False}
+
+# function to benchmark
+def blocked_mesolve(Hs, *args, **kwargs):
+    # `qt.mesolve` does not support `jax.jit`/`jax.vmap` yet: using a for loop instead
+    result_list = [qt.mesolve(H, *args, **kwargs).final_state.data._jxa for H in Hs]
+    return jnp.asarray(result_list).block_until_ready()
+
+blocked_mesolve(Hs, psi0, tsave, c_ops=c_ops, options=options)
+%timeit blocked_mesolve(Hs, psi0, tsave, c_ops=c_ops, options=options)

--- a/benchmarks/transmon-pi/dynamiqs-bench.py
+++ b/benchmarks/transmon-pi/dynamiqs-bench.py
@@ -1,0 +1,48 @@
+from functools import partial
+
+import dynamiqs as dq
+import jax.numpy as jnp
+
+# global settings
+dq.set_layout('dia') # 'dense' or 'dia'
+dq.set_device('cpu') # 'cpu' or 'gpu'
+
+# parameters
+K = 2.0
+kappa = 0.1
+amps = jnp.linspace(0.0, 0.3, 20)
+sigmas = jnp.linspace(0.5, 10.0, 20)
+gate_time = 20.0
+num_tsave = 100
+
+# save times
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# pulse helper functions
+def gaussian(t, T, sigma):
+    return jnp.exp(-((t - 0.5 * T)**2 / (2 * sigma**2)))
+
+def pulse(t, T, amp, sigma):
+    return amp * (gaussian(t, T, sigma) - gaussian(0, T, sigma))**2
+
+# operators
+a, adag = dq.destroy(3), dq.create(3)
+H0 = K * adag @ adag @ a @ a
+Hd = a + adag
+fd = partial(pulse, T=gate_time, amp=amps[:, None], sigma=sigmas[None, :])
+Hs = H0 + dq.modulated(fd, Hd)
+jump_ops = [jnp.sqrt(kappa) * a]
+
+# initial state
+psi0 = dq.basis(3, 0)
+
+# options
+options = dq.Options(progress_meter=None)
+solver = dq.solver.Tsit5(atol=1e-8, rtol=1e-6)
+
+# run benchmark
+def blocked_mesolve(*args, **kwargs):
+    return dq.mesolve(*args, **kwargs).states.data.block_until_ready()
+
+blocked_mesolve(Hs, jump_ops, psi0, tsave, options=options, solver=solver)
+%timeit blocked_mesolve(Hs, jump_ops, psi0, tsave, options=options, solver=solver)

--- a/benchmarks/transmon-pi/quantumoptics-bench.jl
+++ b/benchmarks/transmon-pi/quantumoptics-bench.jl
@@ -1,0 +1,41 @@
+using QuantumOptics
+using BenchmarkTools
+
+# global options
+layout = "sparse" # "dense" or "sparse"
+
+# parameters
+K = 2.0
+kappa = 0.1
+amps = LinRange(0.0, 0.3, 20)
+sigmas = LinRange(0.5, 10.0, 20)
+gate_time = 20.0
+num_tsave = 100
+
+# save times
+tspan = LinRange(0, gate_time, num_tsave)
+
+# pulse helper functions
+function gaussian(t, T, sigma)
+    return exp(-((t - 0.5 * T)^2 / (2 * sigma^2)))
+end
+
+function pulse(t, T, amp, sigma)
+    return amp * (gaussian(t, T, sigma) - gaussian(0, T, sigma))^2
+end
+
+# operators
+basis = FockBasis(2)
+a = layout == "sparse" ? destroy(basis) : dense(destroy(basis))
+adag = layout == "sparse" ? create(basis) : dense(create(basis))
+H0 = K * adag^2 * a^2
+Hd = a + adag
+J = [sqrt(kappa) * a]
+Jdagger = [sqrt(kappa) * adag]
+fs = [(t, rho) -> (H0 + pulse(t, gate_time, amp, sigma) * Hd, J, Jdagger) for amp in amps for sigma in sigmas]
+
+# initial state
+psi0 = fockstate(basis, 0)
+
+# run benchmark
+@benchmark [timeevolution.master_dynamic(tspan, psi0, f; abstol=1e-8, reltol=1e-6) for f in fs]

--- a/benchmarks/transmon-pi/qutip-bench.py
+++ b/benchmarks/transmon-pi/qutip-bench.py
@@ -1,0 +1,41 @@
+import qutip as qt
+import numpy as np
+
+# global options
+qt.settings.core['default_dtype'] = 'Dia' # 'Dia' or 'Dense'
+
+# parameters
+K = 2.0
+kappa = 0.1
+amps = np.linspace(0.0, 0.3, 20)
+sigmas = np.linspace(0.5, 10.0, 20)
+gate_time = 20.0
+num_tsave = 100
+
+# save times
+tsave = np.linspace(0.0, gate_time, num_tsave)
+
+# pulse helper functions
+def gaussian(t, T, sigma):
+    return np.exp(-((t - 0.5 * T)**2 / (2 * sigma**2)))
+
+def pulse(t, T, amp, sigma):
+    return amp * (gaussian(t, T, sigma) - gaussian(0, T, sigma))**2
+
+# operators
+a, adag = qt.destroy(3), qt.create(3)
+H0 = K * adag @ adag @ a @ a
+Hd = a + adag
+fds = [partial(pulse, T=gate_time, amp=amp, sigma=sigma) for amp in amps for sigma in sigmas]
+Hs = [[H0, [Hd, fd]] for fd in fds]
+c_ops = [np.sqrt(kappa) * a]
+
+# initial state
+with qt.CoreOptions(default_dtype='Dense'):
+    psi0 = qt.basis(3, 0)
+
+# options
+options = {'method': 'adams', 'normalize_output': False}
+
+# run benchmark
+%timeit [qt.mesolve(H, psi0, tsave, c_ops=c_ops, options=options) for H in Hs]

--- a/benchmarks/transmon-pi/qutip-jax-bench.py
+++ b/benchmarks/transmon-pi/qutip-jax-bench.py
@@ -1,0 +1,53 @@
+import jax
+import jax.numpy as jnp
+import qutip as qt
+import qutip_jax
+
+# global options
+qt.settings.core['default_dtype'] = 'jaxdia' # 'jaxdia' or 'jax'
+
+# parameters
+K = 2.0
+kappa = 0.1
+amps = jnp.linspace(0.0, 0.3, 20)
+sigmas = jnp.linspace(0.5, 10.0, 20)
+gate_time = 20.0
+num_tsave = 100
+
+# save times
+tsave = jnp.linspace(0.0, gate_time, num_tsave)
+
+# pulse helper functions
+def gaussian(t, T, sigma):
+    return jnp.exp(-((t - 0.5 * T)**2 / (2 * sigma**2)))
+
+def pulse(t, T, amp, sigma):
+    return amp * (gaussian(t, T, sigma) - gaussian(0, T, sigma))**2
+
+# operators
+a, adag = qt.destroy(3), qt.create(3)
+H0 = K * adag @ adag @ a @ a
+Hd = a + adag
+fds = [
+    jax.jit(partial(pulse, T=gate_time, amp=amp, sigma=sigma))
+    for amp in amps
+    for sigma in sigmas
+]
+Hs = [[H0, [Hd, fd]] for fd in fds]
+c_ops = [jnp.sqrt(kappa) * a]
+
+# initial state
+with qt.CoreOptions(default_dtype='jax'):
+    psi0 = qt.basis(3, 0)
+
+# options
+options = {'method': 'diffrax', 'normalize_output': False}
+
+# function to benchmark
+def blocked_mesolve(Hs, *args, **kwargs):
+    # `qt.mesolve` does not support `jax.jit`/`jax.vmap` yet: using a for loop instead
+    result_list = [qt.mesolve(H, *args, **kwargs).final_state.data._jxa for H in Hs]
+    return jnp.asarray(result_list).block_until_ready()
+
+blocked_mesolve(Hs, psi0, tsave, c_ops=c_ops, options=options)
+%timeit blocked_mesolve(Hs, psi0, tsave, c_ops=c_ops, options=options)


### PR DESCRIPTION
This PR adds scripts that can be used to benchmark a selected set of problems using `dynamiqs`, `QuTiP`, `QuTiP-JAX` or `QuantumOptics.jl`.

There's a lot of copy-pasted code, but it's actually quite difficult to find a unique structure that fits all libraries.

I'm not sure this is the final version of the public benchmarks we want to have, but I wanted to have this public for conferences where I show benchmarks so anyone can eventually check the validity of these benchmarks for themselves.