### PR TITLE
fix bad `raise`

### DIFF
--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -184,7 +184,7 @@ class SparseDIAQArray(QArray):
         return self.to_dense().to_jax()
 
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
-        raise self.to_dense().__array__(dtype=dtype, copy=copy)
+        return self.to_dense().__array__(dtype=dtype, copy=copy)
 
     def __repr__(self) -> str:
         # === array representation with dots instead of zeros


### PR DESCRIPTION
There is a `raise` where there should be a `return`. This PR introduces a proposition of fix for this by replacing the `raise` by a `return`. 