### PR TITLE
Update qutip dependency to support `>= 5.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qutip>=4.7.5,<5.0",
+    "qutip>=4.7.5",
     "scipy",
     "numpy",
     "matplotlib",


### PR DESCRIPTION
This is mostly to fix `uv` install. Dynamiqs is not yet fully compatible with the newest QuTiP version.