### PR TITLE
Partial support for QuTiP >= 5.0

### DIFF
--- a/dynamiqs/utils/jax_utils.py
+++ b/dynamiqs/utils/jax_utils.py
@@ -35,7 +35,7 @@ def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Q
                [1.+0.j],
                [0.+0.j]], dtype=complex64)
         >>> dq.to_qutip(psi)
-        Quantum object: dims = [[3], [1]], shape = (3, 1), type = ket
+        Quantum object: dims=[[3], [1]], shape=(3, 1), type='ket', dtype=Dense
         Qobj data =
         [[0.]
          [1.]
@@ -52,7 +52,7 @@ def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Q
         specified with the `dims` argument:
         >>> I = dq.eye(3, 2)
         >>> dq.to_qutip(I)
-        Quantum object: dims = [[6], [6]], shape = (6, 6), type = oper, isherm = True
+        Quantum object: dims=[[6], [6]], shape=(6, 6), type='oper', dtype=Dense, isherm=True
         Qobj data =
         [[1. 0. 0. 0. 0. 0.]
          [0. 1. 0. 0. 0. 0.]
@@ -61,7 +61,7 @@ def to_qutip(x: ArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Q
          [0. 0. 0. 0. 1. 0.]
          [0. 0. 0. 0. 0. 1.]]
         >>> dq.to_qutip(I, (3, 2))
-        Quantum object: dims = [[3, 2], [3, 2]], shape = (6, 6), type = oper, isherm = True
+        Quantum object: dims=[[3, 2], [3, 2]], shape=(6, 6), type='oper', dtype=Dense, isherm=True
         Qobj data =
         [[1. 0. 0. 0. 0. 0.]
          [0. 1. 0. 0. 0. 0.]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-    "qutip>=4.7.5,<5.0",
+    "qutip>=4.7.5",
     "scipy",
     "numpy",
     "matplotlib",

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -2,9 +2,18 @@ import jax
 import jax.numpy as jnp
 import pytest
 import qutip as qt
+from jax import Array
 
 import dynamiqs as dq
 from dynamiqs._utils import cdtype
+
+
+def qobj_to_array(x: qt.Qobj) -> Array:
+    # todo: support QuTiP >= 5.0, remove once https://github.com/qutip/qutip/pull/2533
+    # is merged, and use `jnp.asarray` instead
+    if isinstance(x, list):
+        return jnp.asarray([qobj_to_array(y) for y in x])
+    return jnp.asarray(x.full())
 
 
 def test_ket_fidelity_correctness():
@@ -16,8 +25,8 @@ def test_ket_fidelity_correctness():
     qt_fid = qt.fidelity(psi, phi) ** 2
 
     # Dynamiqs
-    psi = jnp.asarray(psi)
-    phi = jnp.asarray(phi)
+    psi = qobj_to_array(psi)
+    phi = qobj_to_array(phi)
     dq_fid = dq.fidelity(psi, phi).item()
 
     # compare
@@ -28,8 +37,8 @@ def test_ket_fidelity_batching():
     b1, b2, n = 3, 5, 8
     psi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
     phi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
-    psi = jnp.asarray(psi)
-    phi = jnp.asarray(phi)
+    psi = qobj_to_array(psi)
+    phi = qobj_to_array(phi)
     assert dq.fidelity(psi, phi).shape == (b1, b2)
 
 
@@ -42,8 +51,8 @@ def test_dm_fidelity_correctness():
     qt_fid = qt.fidelity(rho, sigma) ** 2
 
     # Dynamiqs
-    rho = jnp.asarray(rho)
-    sigma = jnp.asarray(sigma)
+    rho = qobj_to_array(rho)
+    sigma = qobj_to_array(sigma)
     dq_fid = dq.fidelity(rho, sigma).item()
 
     # compare
@@ -54,8 +63,8 @@ def test_dm_fidelity_batching():
     b1, b2, n = 3, 5, 8
     rho = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
     sigma = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
-    rho = jnp.asarray(rho)
-    sigma = jnp.asarray(sigma)
+    rho = qobj_to_array(rho)
+    sigma = qobj_to_array(sigma)
     assert dq.fidelity(rho, sigma).shape == (b1, b2)
 
 
@@ -68,8 +77,8 @@ def test_ket_dm_fidelity_correctness():
     qt_fid = qt.fidelity(psi, rho) ** 2
 
     # Dynamiqs
-    psi = jnp.asarray(psi)
-    rho = jnp.asarray(rho)
+    psi = qobj_to_array(psi)
+    rho = qobj_to_array(rho)
     dq_fid_ket_dm = dq.fidelity(psi, rho).item()
     dq_fid_dm_ket = dq.fidelity(rho, psi).item()
 
@@ -82,8 +91,8 @@ def test_ket_dm_fidelity_batching():
     b1, b2, n = 3, 5, 8
     psi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n)
     rho = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
-    psi = jnp.asarray(psi)
-    rho = jnp.asarray(rho)
+    psi = qobj_to_array(psi)
+    rho = qobj_to_array(rho)
     assert dq.fidelity(rho, psi).shape == (b1, b2)
     assert dq.fidelity(psi, rho).shape == (b1, b2)
 


### PR DESCRIPTION
Before this PR, we enforced the dependency on QuTiP < 5.0 because `qt.QObj` in versions > 5.0 does not have a native conversion to NumPy or JAX arrays, unlike in versions < 5.0. This limitation prevents `qt.QObj` objects from being used directly in all Dynamiqs functions. This PR lifts the dependency constraint because it breaks the installation with `uv`, although the original problem remains unresolved.

For native conversion support in QuTiP > 5.0, see https://github.com/qutip/qutip/pull/2533.

Related to https://linear.app/dynamiqs/issue/DYN-191/fix-compatibility-with-qutip-50.