### PR TITLE
Fix JAX version compatibility with latest equinox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,8 @@ dependencies = [
     "numpy",
     "matplotlib",
     "tqdm",
-    "jax<0.4.32",  # todo: fix
-    "jaxlib<0.4.32",  # todo: fix
+    "jax",
+    "jaxlib",
     "jaxtyping",
     "diffrax>=0.5.1",  # for complex support (0.5.0) and progress meter (0.5.1)
     "equinox",


### PR DESCRIPTION
Closes DYN-246.

The bug has been fixed in the latest equinox release yesterday https://github.com/patrick-kidger/equinox/releases/tag/v0.11.7.