### PR TITLE
Improve GIFs creation performance and fix the color quantization bug

### DIFF
--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from pathlib import Path
 
 import jax.numpy as jnp
 import matplotlib
@@ -11,33 +12,36 @@ from sybil.parsers.markdown import PythonCodeBlockParser, SkipParser
 import dynamiqs
 
 
-# doctest fixture
 @pytest.fixture(scope='session', autouse=True)
 def _jax_set_printoptions():
     jnp.set_printoptions(precision=3, suppress=True)
 
 
-# doctest fixture
 @pytest.fixture(scope='session', autouse=True)
-def _mplstyle():
-    dynamiqs.plot.utils.mplstyle()
-
-
-@pytest.fixture(scope='session', autouse=True)
-def _mpl_backend():
+def _mpl_params():
+    dynamiqs.plot.utils.mplstyle(dpi=150)
     # use a non-interactive backend for matplotlib, to avoid opening a display window
     matplotlib.use('Agg')
 
 
-# doctest fixture
 @pytest.fixture
 def renderfig():
     def savefig_docs(figname):
         filename = f'docs/figs_docs/{figname}.png'
-        plt.gcf().savefig(filename, bbox_inches='tight', dpi=300)
+        plt.gcf().savefig(filename, bbox_inches='tight')
         plt.close()
 
     return savefig_docs
+
+
+@pytest.fixture
+def rendergif():
+    def savegif_docs(gif, figname):
+        filename = f'docs/figs_docs/{figname}.gif'
+        with Path(filename).open('wb') as f:
+            f.write(gif.data)
+
+    return savegif_docs
 
 
 # pycon code blocks parser
@@ -59,5 +63,5 @@ class PyconCodeBlockParser(PythonCodeBlockParser):
 pytest_collect_file = Sybil(
     parsers=[PythonCodeBlockParser(), PyconCodeBlockParser(), SkipParser()],
     patterns=['*.md'],
-    fixtures=['_jax_set_printoptions', '_mplstyle', '_mpl_backend', 'renderfig'],
+    fixtures=['_jax_set_printoptions', '_mpl_params', 'renderfig', 'rendergif'],
 ).pytest()

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,12 +1,12 @@
 import re
 
-# The following regex will match any line containing 'renderfig', 'default_mpl_style'
-# or '[...]':
+# The following regex will match any line containing 'renderfig', 'rendergif',
+# 'default_mpl_style' or '[...]':
 # - '^' matches the start of a line
 # - '.*' matches any character (except for line terminators) zero or more times
 # - '$' matches the end of a line
 # - '\n?' optionally matches the newline character at the end of the line
-regex = r'^.*(renderfig|default\_mpl\_style|\[\.\.\.\]).*$\n?'
+regex = r'^.*(renderfig|rendergif|default\_mpl\_style|\[\.\.\.\]).*$\n?'
 # `flags=re.MULTILINE` is necessary to match the start and end of each line
 pattern = re.compile(regex, flags=re.MULTILINE)
 

--- a/dynamiqs/conftest.py
+++ b/dynamiqs/conftest.py
@@ -1,4 +1,5 @@
 from doctest import ELLIPSIS
+from pathlib import Path
 
 import jax
 import jax.numpy as jnp
@@ -21,19 +22,18 @@ def sybil_setup(namespace):
     namespace['jnp'] = jnp
 
 
-# doctest fixture
 @pytest.fixture(scope='session', autouse=True)
 def _jax_set_printoptions():
     jnp.set_printoptions(precision=3, suppress=True)
 
 
-# doctest fixture
 @pytest.fixture(scope='session', autouse=True)
-def _mplstyle():
-    dynamiqs.plot.utils.mplstyle()
+def _mpl_params():
+    dynamiqs.plot.utils.mplstyle(dpi=150)
+    # use a non-interactive backend for matplotlib, to avoid opening a display window
+    matplotlib.use('Agg')
 
 
-# doctest fixture
 @pytest.fixture
 def default_mpl_style():
     def set_default_mpl_style():
@@ -42,21 +42,24 @@ def default_mpl_style():
     return set_default_mpl_style
 
 
-@pytest.fixture(scope='session', autouse=True)
-def _mpl_backend():
-    # use a non-interactive backend for matplotlib, to avoid opening a display window
-    matplotlib.use('Agg')
-
-
-# doctest fixture
 @pytest.fixture
 def renderfig():
     def savefig_code(figname):
         filename = f'docs/figs_code/{figname}.png'
-        plt.gcf().savefig(filename, bbox_inches='tight', dpi=300)
+        plt.gcf().savefig(filename, bbox_inches='tight')
         plt.close()
 
     return savefig_code
+
+
+@pytest.fixture
+def rendergif():
+    def savegif_code(gif, figname):
+        filename = f'docs/figs_code/{figname}.gif'
+        with Path(filename).open('wb') as f:
+            f.write(gif.data)
+
+    return savegif_code
 
 
 # sybil configuration
@@ -66,9 +69,9 @@ pytest_collect_file = Sybil(
     setup=sybil_setup,
     fixtures=[
         '_jax_set_printoptions',
-        '_mplstyle',
+        '_mpl_params',
         'default_mpl_style',
-        '_mpl_backend',
         'renderfig',
+        'rendergif',
     ],
 ).pytest()

--- a/dynamiqs/plot/utils.py
+++ b/dynamiqs/plot/utils.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-import pathlib
-import shutil
 from collections.abc import Iterable, Sequence
 from functools import wraps
+from io import BytesIO
 from math import ceil
 from typing import TypeVar
 
-import imageio as iio
-import IPython.display as ipy
 import matplotlib
 import matplotlib as mpl
 import numpy as np
 from cycler import cycler
-from jax.typing import ArrayLike
+from IPython.display import Image
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.axis import Axis
@@ -21,6 +18,7 @@ from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
 from matplotlib.ticker import FixedLocator, MaxNLocator, MultipleLocator, NullLocator
 from mpl_toolkits.axes_grid1 import make_axes_locatable
+from PIL import Image as PILImage
 from tqdm import tqdm
 
 __all__ = ['gifit', 'grid', 'mplstyle']
@@ -155,7 +153,7 @@ colors = {
 }
 
 
-def mplstyle(*, usetex: bool = False):
+def mplstyle(*, usetex: bool = False, dpi: int = 72):
     r"""Set custom Matplotlib style.
 
     Warning:
@@ -180,7 +178,7 @@ def mplstyle(*, usetex: bool = False):
 
         After (Dynamiqs Matplotlib style):
 
-        >>> dq.plot.mplstyle()
+        >>> dq.plot.mplstyle(dpi=150)
         >>> fig, ax = plt.subplots(1, 1)
         >>> for y in ys:
         ...     ax.plot(x, y)
@@ -223,7 +221,7 @@ def mplstyle(*, usetex: bool = False):
             'legend.fontsize': 12,
             # figure
             'figure.facecolor': 'white',
-            'figure.dpi': 72,
+            'figure.dpi': dpi,
             'figure.figsize': (7, 7 / 1.6),
             # other
             'savefig.facecolor': 'white',
@@ -295,109 +293,102 @@ def add_colorbar(
 T = TypeVar('T')
 
 
+def gif_indices(nitems: int, nframes: int) -> np.ndarray:
+    # generate indices for GIF frames
+    if nframes < nitems:
+        return np.linspace(0, nitems - 1, nframes, dtype=int)
+    else:
+        return np.arange(nitems)
+
+
 def gifit(
     plot_function: callable[[T, ...], None],
-    gif_duration: float = 5.0,
-    fps: int = 10,
-    filename: str = '.tmp/dynamiqs/gifit.gif',
-    dpi: int = 72,
-    display: bool = True,
-) -> callable[[Sequence[T], ...], None]:
-    """Transform a plot function into a function that creates an animated GIF.
+) -> callable[[Sequence[T], ...], Image]:
+    """Transform a plot function into a new function that returns an animated GIF.
 
     This function takes a plot function that normally operates on a single input and
-    returns a function that creates a GIF from a sequence of inputs.
+    returns a new function that creates a GIF from a sequence of inputs. The new
+    function accepts two extra keyword arguments:
 
-    Warning:
-        This function creates files in the current working directory under
-        `.tmp/dynamiqs` to store the GIF frames. The directory is automatically deleted
-        when the function ends. Specify the argument `filename` to save the GIF
-        on your disk.
+    - **gif_duration** _(float)_ -- GIF duration in seconds.
+    - **fps** _(int)_ -- GIF frames per seconds.
 
-    Note:
-        By default, the GIF is displayed in Jupyter notebook environments.
+    The new function returns an object of type `IPython.core.display.Image`,
+    which automatically displays the GIF in Jupyter notebook environments (when the
+    `Image` object is the last expression in a cell).
+
+    ??? "Save GIF to a file"
+        The returned GIF can be saved to a file with:
+
+        ```
+        with open('/path/to/file.gif').open('wb') as f:
+            f.write(gif.data)
+        ```
 
     Args:
         plot_function: Plot function which must take as first positional argument the
             input that will be sequenced over by the new function. It must create a
             matplotlib `Figure` object and not close it.
-        gif_duration: GIF duration in seconds.
-        fps: GIF frames per seconds.
-        filename: Save path of the GIF file.
-        dpi: GIF resolution.
-        display: If `True`, the GIF is displayed in Jupyter notebook environments.
 
     Returns:
         A new function with the same signature as `plot_function` which accepts a
-            sequence of inputs and creates a GIF by applying the original
+            sequence of inputs and returns a GIF by applying the original
             `plot_function` to each element in the sequence.
 
     Examples:
         >>> def plot_cos(phi):
         ...     x = np.linspace(0, 1.0, 501)
         ...     y = np.cos(2 * np.pi * x + phi)
+        ...     plt.figure(constrained_layout=True)
         ...     plt.plot(x, y)
         >>> phis = np.linspace(0, 2 * np.pi, 101)
-        >>> filename = 'docs/figs_code/cos.gif'
-        >>> plot_cos_gif = dq.plot.gifit(
-        ...     plot_cos, fps=25, filename=filename, dpi=150, display=False
-        ... )
-        >>> plot_cos_gif(phis)
+        >>> gif = dq.plot.gifit(plot_cos)(phis, fps=25)
+        >>> gif
+        <IPython.core.display.Image object>
+        >>> rendergif(gif, 'cos')
 
         ![plot_cos](/figs_code/cos.gif){.fig}
 
         >>> alphas = jnp.linspace(0.0, 3.0, 51)
         >>> states = dq.coherent(24, alphas)
-        >>> filename = 'docs/figs_code/coherent_evolution.gif'
-        >>> plot_fock_gif = dq.plot.gifit(
-        ...     dq.plot.fock, fps=25, filename=filename, dpi=150, display=False
-        ... )
-        >>> plot_fock_gif(states)
+        >>> gif = dq.plot.gifit(dq.plot.fock)(states, fps=25)
+        >>> rendergif(gif, 'coherent_evolution')
 
         ![plot_coherent_evolution](/figs_code/coherent_evolution.gif){.fig}
     """
 
     @wraps(plot_function)
-    def wrapper(items: ArrayLike, *args, **kwargs) -> None:
+    def wrapper(
+        items: Sequence[T], *args, gif_duration: float = 5.0, fps: int = 10, **kwargs
+    ) -> Image:
         nframes = int(gif_duration * fps)
+        indices = gif_indices(len(items), nframes)
 
-        nitems = len(items)
-        if nframes >= nitems:
-            indices = np.arange(nitems)
-        else:
-            indices = np.round(np.linspace(0, nitems - 1, nframes)).astype(int)
+        frames = []
+        for idx in tqdm(indices):
+            plt.close()
+            plot_function(items[idx], *args, **kwargs)  # plot frame
+            canvas = plt.gcf().canvas
+            canvas.draw()  # ensure the figure is drawn
+            frame = np.array(canvas.buffer_rgba())  # capture the RGBA buffer
+            frames.append(frame)
 
-        try:
-            # create temporary directory
-            tmpdir = pathlib.Path('./.tmp/dynamiqs')
-            tmpdir.mkdir(parents=True, exist_ok=True)
+        plt.close()
 
-            frames = []
-            for i, idx in enumerate(tqdm(indices)):
-                # ensure previous plot is closed
-                plt.close()
+        # create a BytesIO object to save the GIF in memory
+        gif_buffer = BytesIO()
+        # duration per frame in ms, rescaled to account for eventual duplicate frames
+        duration = int(1000 / fps * nframes / len(indices))
+        pil_frames = [PILImage.fromarray(frame).convert('RGB') for frame in frames]
+        pil_frames[0].save(
+            gif_buffer,
+            format='GIF',
+            save_all=True,
+            append_images=pil_frames[1:],
+            duration=duration,
+            loop=0,
+        )
 
-                # plot frame
-                plot_function(items[idx], *args, **kwargs)
-
-                # save frame in temporary file
-                frame_filename = tmpdir / f'tmp-{i}.png'
-                plt.gcf().savefig(frame_filename, bbox_inches='tight', dpi=dpi)
-                plt.close()
-
-                # read frame with imageio
-                frame = iio.v3.imread(frame_filename)
-                frames.append(frame)
-
-            # duration: duration per frame in ms
-            # loop=0: loop the GIF forever
-            # rescale duration to account for eventual duplicate frames
-            duration = int(1000 / fps * nframes / len(indices))
-            iio.v3.imwrite(filename, frames, format='GIF', duration=duration, loop=0)
-            if display:
-                ipy.display(ipy.Image(filename))
-        finally:
-            if tmpdir.exists():
-                shutil.rmtree(tmpdir, ignore_errors=True)
+        return Image(data=gif_buffer.getvalue(), format='gif')
 
     return wrapper

--- a/dynamiqs/plot/wigner.py
+++ b/dynamiqs/plot/wigner.py
@@ -1,21 +1,15 @@
 from __future__ import annotations
 
-import pathlib
-import shutil
-
-import imageio as iio
-import IPython.display as ipy
 import jax.numpy as jnp
 import numpy as np
+from IPython.display import Image
 from jax.typing import ArrayLike
-from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.colors import Normalize
-from tqdm import tqdm
 
 from .._checks import check_shape
 from ..utils import wigner as compute_wigner
-from .utils import add_colorbar, colors, figax, grid, optional_ax
+from .utils import add_colorbar, colors, gif_indices, gifit, grid, optional_ax
 
 __all__ = ['wigner', 'wigner_mosaic', 'wigner_gif']
 
@@ -241,7 +235,6 @@ def wigner_gif(
     gif_duration: float = 5.0,
     fps: int = 10,
     w: float = 5.0,
-    h: float | None = None,
     xmax: float = 5.0,
     ymax: float | None = None,
     vmax: float = 2 / jnp.pi,
@@ -250,23 +243,14 @@ def wigner_gif(
     interpolation: str = 'bilinear',
     cross: bool = False,
     clear: bool = False,
-    filename: str = '.tmp/dynamiqs/wigner.gif',
-    dpi: int = 72,
-    display: bool = True,
-):
+) -> Image:
     r"""Plot a GIF of the Wigner function of multiple states.
 
     Warning:
         Documentation redaction in progress.
 
-    Warning:
-        This function creates files in the current working directory under
-        `.tmp/dynamiqs`.
-
-    Note:
-        By default, the GIF is displayed in Jupyter notebook environments.
-
-    See [`dq.plot.wigner()`][dynamiqs.plot.wigner] for more details.
+    See [`dq.plot.wigner()`][dynamiqs.plot.wigner] and
+    [`dq.plot.gifit()`][dynamiqs.plot.gifit] for more details.
 
     Examples:
         >>> n = 16
@@ -276,15 +260,8 @@ def wigner_gif(
         >>> psi0 = dq.coherent(n, 0)
         >>> tsave = jnp.linspace(0, 1.0, 1001)
         >>> result = dq.mesolve(H, jump_ops, psi0, tsave)
-        >>> dq.plot.wigner_gif(
-        ...     result.states,
-        ...     fps=25,  # 25 frames per second
-        ...     xmax=4.0,
-        ...     ymax=2.0,
-        ...     filename='docs/figs_code/wigner-cat.gif',
-        ...     dpi=150,
-        ...     display=False,
-        ... )
+        >>> gif = dq.plot.wigner_gif(result.states, fps=25, xmax=4.0, ymax=2.0)
+        >>> rendergif(gif, 'wigner-cat')
 
         ![plot_wigner_gif_cat](/figs_code/wigner-cat.gif){.fig}
 
@@ -294,16 +271,10 @@ def wigner_gif(
         >>> psi0 = dq.coherent(n, 2)
         >>> tsave = jnp.linspace(0, jnp.pi, 1001)
         >>> result = dq.sesolve(H, psi0, tsave)
-        >>> dq.plot.wigner_gif(
-        ...     result.states,
-        ...     gif_duration=10.0,  # 10 seconds GIF
-        ...     fps=25,
-        ...     xmax=4.0,
-        ...     clear=True,
-        ...     filename='docs/figs_code/wigner-kerr.gif',
-        ...     dpi=150,
-        ...     display=False,
+        >>> gif = dq.plot.wigner_gif(
+        ...     result.states, gif_duration=10.0, fps=25, xmax=4.0, clear=True
         ... )
+        >>> rendergif(gif, 'wigner-kerr')
 
         ![plot_wigner_gif_kerr](/figs_code/wigner-kerr.gif){.fig-half}
     """
@@ -312,44 +283,21 @@ def wigner_gif(
 
     ymax = xmax if ymax is None else ymax
     nframes = int(gif_duration * fps)
-    selected_indexes = np.linspace(0, len(states), nframes, dtype=int)
-    _, _, wig = compute_wigner(states[selected_indexes], xmax, ymax, npixels)
+    indices = gif_indices(len(states), nframes)
+    _, _, wig = compute_wigner(states[indices], xmax, ymax, npixels)
 
-    try:
-        # create temporary directory
-        tmpdir = pathlib.Path('./.tmp/dynamiqs')
-        tmpdir.mkdir(parents=True, exist_ok=True)
-
-        frames = []
-        for i in tqdm(range(nframes)):
-            fig, ax = figax(w=w, h=h)
-
-            plot_wigner_data(
-                wig[i],
-                ax=ax,
-                xmax=xmax,
-                ymax=ymax,
-                vmax=vmax,
-                cmap=cmap,
-                interpolation=interpolation,
-                colorbar=False,
-                cross=cross,
-                clear=clear,
-            )
-
-            frame_filename = tmpdir / f'tmp-{i}.png'
-            fig.savefig(frame_filename, bbox_inches='tight', dpi=dpi)
-            plt.close()
-            frame = iio.v3.imread(frame_filename)
-            frames.append(frame)
-
-        # loop=0: loop the GIF forever
-        frame_duration_ms = 1000 * 1 / fps
-        iio.v3.imwrite(
-            filename, frames, format='GIF', duration=frame_duration_ms, loop=0
-        )
-        if display:
-            ipy.display(ipy.Image(filename))
-    finally:
-        if tmpdir.exists():
-            shutil.rmtree(tmpdir, ignore_errors=True)
+    return gifit(plot_wigner_data)(
+        wig,
+        w=w,
+        h=ymax / xmax * w,
+        xmax=xmax,
+        ymax=ymax,
+        vmax=vmax,
+        cmap=cmap,
+        interpolation=interpolation,
+        colorbar=False,
+        cross=cross,
+        clear=clear,
+        gif_duration=gif_duration,
+        fps=fps,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "jaxtyping",
     "diffrax>=0.5.1",  # for complex support (0.5.0) and progress meter (0.5.1)
     "equinox",
-    "imageio",
+    "pillow",
     "cmasher>=1.8.0",  # avoid matplotlib colormaps deprecation warning
     "ipython",
     "tqdm",
@@ -134,11 +134,11 @@ cmd = 'echo "\n>>> pytest -n=auto tests" && pytest -n=auto tests'
 help = "run the unit tests suite (pytest)"
 
 [tool.taskipy.tasks.doctest-code]
-cmd = 'echo "\n>>> pytest dynamiqs" && rm -f docs/figs_code/*.png && pytest dynamiqs'
+cmd = 'echo "\n>>> pytest dynamiqs" && rm -f docs/figs_code/*.{png,gif} && pytest dynamiqs'
 help = "check code docstrings examples (doctest)"
 
 [tool.taskipy.tasks.doctest-docs]
-cmd = 'echo "\n>>> pytest docs" && rm -f docs/figs_docs/*.png && pytest docs'
+cmd = 'echo "\n>>> pytest docs" && rm -f docs/figs_docs/*.{png,gif} && pytest docs'
 help = "check documentation examples (doctest)"
 
 [tool.taskipy.tasks.doctest]


### PR DESCRIPTION
This PR revamps the way we create GIFs. The main idea is to write frames on an in-memory `BytesIO()` object (a file-like interface for working with bytes data in memory), instead of on disk.

<p align="center">
    <img width="500" src="https://github.com/user-attachments/assets/3282f706-b15d-466e-9025-dcebe6fcb8ea">
</p>

Main features:
- ~3x faster (e.g. cat inflation or Kerr oscillator example: 23s → 8s)
- fix GIF colors quantization
- avoid writing temporary directory and files when creating GIFs
- simplify the API of `dq.plot.gifit` and `dq.plot.wigner_gif`

Small things:
- replace the `imageio` dependency with the smaller `pillow`
- use `dq.plot.gifit` in the implementation of `dq.plot.wigner_gif`, instead of duplicating code
- `dq.plot.gifit` old keywords arguments `gif_duration` and `fps` should now be passed to the returned function
- `dpi` is now controlled as for all other figures using default Matplotlib parameters
- group doctest fixtures related to Matplotlib
- change default dpi for all documentation plots to `150`
- add a `rendergif` doctest fixture (similar to `renderfig`)
- add a `dpi` keyword argument to `dq.plot.mplstyle()`

Closes DYN-173. Related to DYN-230.