### PR TITLE
Refactor integrators

### DIFF
--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -21,6 +21,7 @@ from .._utils import (
     catch_xla_runtime_error,
     get_integrator_class,
 )
+from ..core.abstract_integrator import MEPropagatorIntegrator
 from ..mepropagator.expm_integrator import MEPropagatorExpmIntegrator
 
 
@@ -156,14 +157,22 @@ def _mepropagator(
 ) -> MEPropagatorResult:
     # === select integrator class
     integrators = {Expm: MEPropagatorExpmIntegrator}
-    integrator_class = get_integrator_class(integrators, solver)
+    integrator_class: MEPropagatorIntegrator = get_integrator_class(integrators, solver)
 
     # === check gradient is supported
     solver.assert_supports_gradient(gradient)
 
     # === init integrator
     y0 = eye(H.shape[-1] ** 2)
-    integrator = integrator_class(tsave, y0, H, solver, gradient, options, jump_ops)
+    integrator = integrator_class(
+        ts=tsave,
+        y0=y0,
+        solver=solver,
+        gradient=gradient,
+        options=options,
+        H=H,
+        Ls=jump_ops,
+    )
 
     # === run integrator
     result = integrator.run()

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -33,6 +33,7 @@ from .._utils import (
     catch_xla_runtime_error,
     get_integrator_class,
 )
+from ..core.abstract_integrator import MESolveIntegrator
 from ..mesolve.diffrax_integrator import (
     MESolveDopri5Integrator,
     MESolveDopri8Integrator,
@@ -220,14 +221,21 @@ def _mesolve(
         Kvaerno5: MESolveKvaerno5Integrator,
         Expm: MESolveExpmIntegrator,
     }
-    integrator_class = get_integrator_class(integrators, solver)
+    integrator_class: MESolveIntegrator = get_integrator_class(integrators, solver)
 
     # === check gradient is supported
     solver.assert_supports_gradient(gradient)
 
     # === init integrator
     integrator = integrator_class(
-        tsave, rho0, H, solver, gradient, options, jump_ops, exp_ops
+        ts=tsave,
+        y0=rho0,
+        solver=solver,
+        gradient=gradient,
+        options=options,
+        H=H,
+        Ls=jump_ops,
+        Es=exp_ops,
     )
 
     # === run integrator

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -20,6 +20,7 @@ from .._utils import (
     get_integrator_class,
     ispwc,
 )
+from ..core.abstract_integrator import SEPropagatorIntegrator
 from ..sepropagator.diffrax_integrator import (
     SEPropagatorDopri5Integrator,
     SEPropagatorDopri8Integrator,
@@ -150,14 +151,16 @@ def _sepropagator(
         Kvaerno3: SEPropagatorKvaerno3Integrator,
         Kvaerno5: SEPropagatorKvaerno5Integrator,
     }
-    integrator_class = get_integrator_class(integrators, solver)
+    integrator_class: SEPropagatorIntegrator = get_integrator_class(integrators, solver)
 
     # === check gradient is supported
     solver.assert_supports_gradient(gradient)
 
     # === init integrator
     y0 = eye(H.shape[-1])
-    integrator = integrator_class(tsave, y0, H, solver, gradient, options)
+    integrator = integrator_class(
+        ts=tsave, y0=y0, solver=solver, gradient=gradient, options=options, H=H
+    )
 
     # === run integrator
     result = integrator.run()

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -21,6 +21,7 @@ from .._utils import (
     catch_xla_runtime_error,
     get_integrator_class,
 )
+from ..core.abstract_integrator import SESolveIntegrator
 from ..sesolve.diffrax_integrator import (
     SESolveDopri5Integrator,
     SESolveDopri8Integrator,
@@ -177,13 +178,21 @@ def _sesolve(
         Kvaerno5: SESolveKvaerno5Integrator,
         Expm: SESolveExpmIntegrator,
     }
-    integrator_class = get_integrator_class(integrators, solver)
+    integrator_class: SESolveIntegrator = get_integrator_class(integrators, solver)
 
     # === check gradient is supported
     solver.assert_supports_gradient(gradient)
 
     # === init integrator
-    integrator = integrator_class(tsave, psi0, H, solver, gradient, options, exp_ops)
+    integrator = integrator_class(
+        ts=tsave,
+        y0=psi0,
+        solver=solver,
+        gradient=gradient,
+        options=options,
+        H=H,
+        Es=exp_ops,
+    )
 
     # === run integrator
     result = integrator.run()

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -10,26 +10,44 @@ from jax import Array
 from jaxtyping import PyTree
 
 from ...gradient import Autograd, CheckpointAutograd
+from ...result import Result
 from ...utils.quantum_utils.general import dag
-from .abstract_integrator import BaseIntegrator, MEIntegrator
+from .abstract_integrator import BaseIntegrator, MEInterface, SEIntegrator
+from .save_mixin import SaveMixin
 
 
-class DiffraxIntegrator(BaseIntegrator):
-    # Subclasses should implement:
-    # - the attributes: stepsize_controller, dt0, max_steps, diffrax_solver, terms
-    # - the methods: result, infos
+class DiffraxIntegrator(BaseIntegrator, SaveMixin):
+    """Integrator using the Diffrax library."""
 
-    stepsize_controller: dx.AbstractVar[dx.AbstractStepSizeController]
-    dt0: dx.AbstractVar[float | None]
-    max_steps: dx.AbstractVar[int]
-    diffrax_solver: dx.AbstractVar[dx.AbstractSolver]
-    terms: dx.AbstractVar[dx.AbstractTerm]
+    # subclasses should implement: stepsize_controller, dt0, max_steps, diffrax_solver,
+    # terms, discontinuity_ts, infos()
 
-    def __init__(self, *args):
-        # pass all init arguments to `BaseIntegrator`
-        super().__init__(*args)
+    @property
+    @abstractmethod
+    def stepsize_controller(self) -> dx.AbstractStepSizeController:
+        pass
 
-    def run(self) -> PyTree:
+    @property
+    @abstractmethod
+    def dt0(self) -> float | None:
+        pass
+
+    @property
+    @abstractmethod
+    def max_steps(self) -> int:
+        pass
+
+    @property
+    @abstractmethod
+    def diffrax_solver(self) -> dx.AbstractSolver:
+        pass
+
+    @property
+    @abstractmethod
+    def terms(self) -> dx.AbstractTerm:
+        pass
+
+    def run(self) -> Result:
         with warnings.catch_warnings():
             # TODO: remove once complex support is stabilized in diffrax
             warnings.simplefilter('ignore', UserWarning)
@@ -74,10 +92,10 @@ class DiffraxIntegrator(BaseIntegrator):
         pass
 
 
-class FixedStepIntegrator(DiffraxIntegrator):
-    # Subclasses should implement:
-    # - the attributes: diffrax_solver, terms
-    # - the methods: result
+class FixedStepDiffraxIntegrator(DiffraxIntegrator):
+    """Integrator using a fixed step Diffrax solver."""
+
+    # subclasses should implement: diffrax_solver, terms, discontinuity_ts
 
     class Infos(eqx.Module):
         nsteps: Array
@@ -90,25 +108,26 @@ class FixedStepIntegrator(DiffraxIntegrator):
                 )
             return f'{self.nsteps} steps'
 
-    stepsize_controller: dx.AbstractStepSizeController = dx.ConstantStepSize()
-    max_steps: int = 100_000  # TODO: fix hard-coded max_steps
-
-    @property
-    def dt0(self) -> float:
-        return self.solver.dt
-
     def infos(self, stats: dict[str, Array]) -> PyTree:
         return self.Infos(stats['num_steps'])
 
+    @property
+    def stepsize_controller(self) -> dx.AbstractStepSizeController:
+        return dx.ConstantStepSize()
 
-class EulerIntegrator(FixedStepIntegrator):
-    diffrax_solver: dx.AbstractSolver = dx.Euler()
+    @property
+    def dt0(self) -> float | None:
+        return self.solver.dt
+
+    @property
+    def max_steps(self) -> int:
+        return 100_000  # TODO: fix hard-coded max_steps
 
 
-class AdaptiveStepIntegrator(DiffraxIntegrator):
-    # Subclasses should implement:
-    # - the attributes: diffrax_solver, terms
-    # - the methods: result
+class AdaptiveStepDiffraxIntegrator(DiffraxIntegrator):
+    """Integrator using an adaptive step Diffrax solver."""
+
+    # subclasses should implement: diffrax_solver, terms, discontinuity_ts
 
     class Infos(eqx.Module):
         nsteps: Array
@@ -127,7 +146,10 @@ class AdaptiveStepIntegrator(DiffraxIntegrator):
                 f' {self.nrejected} rejected)'
             )
 
-    dt0 = None
+    def infos(self, stats: dict[str, Array]) -> PyTree:
+        return self.Infos(
+            stats['num_steps'], stats['num_accepted_steps'], stats['num_rejected_steps']
+        )
 
     @property
     def stepsize_controller(self) -> dx.AbstractStepSizeController:
@@ -141,36 +163,30 @@ class AdaptiveStepIntegrator(DiffraxIntegrator):
         )
 
     @property
+    def dt0(self) -> float | None:
+        return None
+
+    @property
     def max_steps(self) -> int:
         return self.solver.max_steps
 
-    def infos(self, stats: dict[str, Array]) -> PyTree:
-        return self.Infos(
-            stats['num_steps'], stats['num_accepted_steps'], stats['num_rejected_steps']
-        )
+
+# fmt: off
+# ruff: noqa
+class EulerIntegrator(FixedStepDiffraxIntegrator): diffrax_solver = dx.Euler()
+class Dopri5Integrator(AdaptiveStepDiffraxIntegrator): diffrax_solver = dx.Dopri5()
+class Dopri8Integrator(AdaptiveStepDiffraxIntegrator): diffrax_solver = dx.Dopri8()
+class Tsit5Integrator(AdaptiveStepDiffraxIntegrator): diffrax_solver = dx.Tsit5()
+class Kvaerno3Integrator(AdaptiveStepDiffraxIntegrator): diffrax_solver = dx.Kvaerno3()
+class Kvaerno5Integrator(AdaptiveStepDiffraxIntegrator): diffrax_solver = dx.Kvaerno5()
+# fmt: on
 
 
-class Dopri5Integrator(AdaptiveStepIntegrator):
-    diffrax_solver = dx.Dopri5()
+class SEDiffraxIntegrator(DiffraxIntegrator, SEIntegrator):
+    """Integrator solving the Schrödinger equation with Diffrax."""
 
+    # subclasses should implement: diffrax_solver
 
-class Dopri8Integrator(AdaptiveStepIntegrator):
-    diffrax_solver = dx.Dopri8()
-
-
-class Tsit5Integrator(AdaptiveStepIntegrator):
-    diffrax_solver = dx.Tsit5()
-
-
-class Kvaerno3Integrator(AdaptiveStepIntegrator):
-    diffrax_solver = dx.Kvaerno3()
-
-
-class Kvaerno5Integrator(AdaptiveStepIntegrator):
-    diffrax_solver = dx.Kvaerno5()
-
-
-class SEDiffraxIntegrator(DiffraxIntegrator):
     @property
     def terms(self) -> dx.AbstractTerm:
         # define Schrödinger term d|psi>/dt = - i H |psi>
@@ -178,7 +194,11 @@ class SEDiffraxIntegrator(DiffraxIntegrator):
         return dx.ODETerm(vector_field)
 
 
-class MEDiffraxIntegrator(DiffraxIntegrator, MEIntegrator):
+class MEDiffraxIntegrator(DiffraxIntegrator, MEInterface):
+    """Integrator solving the Lindblad master equation with Diffrax."""
+
+    # subclasses should implement: diffrax_solver
+
     @property
     def terms(self) -> dx.AbstractTerm:
         # define Lindblad term drho/dt

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -12,8 +12,9 @@ from jaxtyping import PyTree
 from ...gradient import Autograd, CheckpointAutograd
 from ...result import Result
 from ...utils.quantum_utils.general import dag
-from .abstract_integrator import BaseIntegrator, MEInterface, SEIntegrator
+from .abstract_integrator import BaseIntegrator
 from .save_mixin import SaveMixin
+from .interfaces import SEInterface, MEInterface
 
 
 class DiffraxIntegrator(BaseIntegrator, SaveMixin):
@@ -182,10 +183,10 @@ class Kvaerno5Integrator(AdaptiveStepDiffraxIntegrator): diffrax_solver = dx.Kva
 # fmt: on
 
 
-class SEDiffraxIntegrator(DiffraxIntegrator, SEIntegrator):
+class SEDiffraxIntegrator(DiffraxIntegrator, SEInterface):
     """Integrator solving the Schrödinger equation with Diffrax."""
 
-    # subclasses should implement: diffrax_solver
+    # subclasses should implement: diffrax_solver, discontinuity_ts
 
     @property
     def terms(self) -> dx.AbstractTerm:
@@ -197,7 +198,7 @@ class SEDiffraxIntegrator(DiffraxIntegrator, SEIntegrator):
 class MEDiffraxIntegrator(DiffraxIntegrator, MEInterface):
     """Integrator solving the Lindblad master equation with Diffrax."""
 
-    # subclasses should implement: diffrax_solver
+    # subclasses should implement: diffrax_solver, discontinuity_ts
 
     @property
     def terms(self) -> dx.AbstractTerm:

--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -1,0 +1,26 @@
+import equinox as eqx
+from jax import Array
+
+from ...options import Options
+from ...time_array import TimeArray
+
+
+class OptionsInterface(eqx.Module):
+    options: Options
+
+
+class SEInterface(eqx.Module):
+    """Interface for the Schrödinger equation."""
+
+    H: TimeArray
+
+
+class MEInterface(eqx.Module):
+    """Interface for the Lindblad master equation."""
+
+    H: TimeArray
+    Ls: list[TimeArray]
+
+
+class SolveInterface(eqx.Module):
+    Es: Array

--- a/dynamiqs/integrators/core/save_mixin.py
+++ b/dynamiqs/integrators/core/save_mixin.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import equinox as eqx
+from jaxtyping import PyTree
+
+from ...result import PropagatorSaved, Saved, SolveSaved
+from ...utils.quantum_utils import expect
+from .abstract_integrator import OptionsInterface, SolveInterface
+
+
+class SaveMixin(OptionsInterface):
+    """Mixin to assist integrators with data saving."""
+
+    def save(self, y: PyTree) -> Saved:
+        ysave = y if self.options.save_states else None
+        extra = self.options.save_extra(y) if self.options.save_extra else None
+        return Saved(ysave, extra)
+
+    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+        # if save_states is False save only last state
+        if not self.options.save_states:
+            saved = eqx.tree_at(
+                lambda x: x.ysave, saved, ylast, is_leaf=lambda x: x is None
+            )
+        return saved
+
+
+class PropagatorSaveMixin(SaveMixin):
+    """Mixin to assist integrators computing propagators with data saving."""
+
+    def save(self, y: PyTree) -> Saved:
+        saved = super().save(y)
+        return PropagatorSaved(saved.ysave, saved.extra)
+
+
+class SolveSaveMixin(SaveMixin, SolveInterface):
+    """Mixin to assist integrators computing time evolution with data saving."""
+
+    def save(self, y: PyTree) -> Saved:
+        saved = super().save(y)
+        Esave = expect(self.Es, y) if self.Es is not None else None
+        return SolveSaved(saved.ysave, saved.extra, Esave)
+
+    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+        saved = super().postprocess_saved(saved, ylast)
+        # reorder Esave after jax.lax.scan stacking (ntsave, nE) -> (nE, ntsave)
+        if saved.Esave is not None:
+            saved = eqx.tree_at(lambda x: x.Esave, saved, saved.Esave.swapaxes(-1, -2))
+        return saved

--- a/dynamiqs/integrators/core/save_mixin.py
+++ b/dynamiqs/integrators/core/save_mixin.py
@@ -5,7 +5,7 @@ from jaxtyping import PyTree
 
 from ...result import PropagatorSaved, Saved, SolveSaved
 from ...utils.quantum_utils import expect
-from .abstract_integrator import OptionsInterface, SolveInterface
+from .interfaces import OptionsInterface, SolveInterface
 
 
 class SaveMixin(OptionsInterface):

--- a/dynamiqs/integrators/mepropagator/expm_integrator.py
+++ b/dynamiqs/integrators/mepropagator/expm_integrator.py
@@ -5,4 +5,6 @@ from ..core.expm_integrator import MEExpmIntegrator
 
 
 class MEPropagatorExpmIntegrator(MEExpmIntegrator, MEPropagatorIntegrator):
-    pass
+    """Integrator computing the propagator of the Lindblad master equation by
+    explicitly exponentiating the propagator.
+    """

--- a/dynamiqs/integrators/mesolve/diffrax_integrator.py
+++ b/dynamiqs/integrators/mesolve/diffrax_integrator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ..core.save_mixin import SolveSaveMixin
+
 from ..core.abstract_integrator import MESolveIntegrator
 from ..core.diffrax_integrator import (
     Dopri5Integrator,
@@ -12,29 +14,17 @@ from ..core.diffrax_integrator import (
 )
 
 
-class MESolveDiffraxIntegrator(MEDiffraxIntegrator, MESolveIntegrator):
-    pass
+class MESolveDiffraxIntegrator(MEDiffraxIntegrator, MESolveIntegrator, SolveSaveMixin):
+    """Integrator computing the time evolution of the Lindblad master equation using the
+    Diffrax library."""
 
 
-class MESolveEulerIntegrator(MESolveDiffraxIntegrator, EulerIntegrator):
-    pass
-
-
-class MESolveDopri5Integrator(MESolveDiffraxIntegrator, Dopri5Integrator):
-    pass
-
-
-class MESolveDopri8Integrator(MESolveDiffraxIntegrator, Dopri8Integrator):
-    pass
-
-
-class MESolveTsit5Integrator(MESolveDiffraxIntegrator, Tsit5Integrator):
-    pass
-
-
-class MESolveKvaerno3Integrator(MESolveDiffraxIntegrator, Kvaerno3Integrator):
-    pass
-
-
-class MESolveKvaerno5Integrator(MESolveDiffraxIntegrator, Kvaerno5Integrator):
-    pass
+# fmt: off
+# ruff: noqa
+class MESolveEulerIntegrator(MESolveDiffraxIntegrator, EulerIntegrator): pass
+class MESolveDopri5Integrator(MESolveDiffraxIntegrator, Dopri5Integrator): pass
+class MESolveDopri8Integrator(MESolveDiffraxIntegrator, Dopri8Integrator): pass
+class MESolveTsit5Integrator(MESolveDiffraxIntegrator, Tsit5Integrator): pass
+class MESolveKvaerno3Integrator(MESolveDiffraxIntegrator, Kvaerno3Integrator): pass
+class MESolveKvaerno5Integrator(MESolveDiffraxIntegrator, Kvaerno5Integrator): pass
+# fmt: on

--- a/dynamiqs/integrators/mesolve/expm_integrator.py
+++ b/dynamiqs/integrators/mesolve/expm_integrator.py
@@ -4,12 +4,15 @@ from ...result import Saved
 from ...utils.vectorization import operator_to_vector, vector_to_operator
 from ..core.abstract_integrator import MESolveIntegrator
 from ..core.expm_integrator import MEExpmIntegrator
+from ..core.save_mixin import SolveSaveMixin
 
 
-class MESolveExpmIntegrator(MEExpmIntegrator, MESolveIntegrator):
-    def __init__(self, *args):
-        super().__init__(*args)
+class MESolveExpmIntegrator(MEExpmIntegrator, MESolveIntegrator, SolveSaveMixin):
+    """Integrator computing the time evolution of the Lindblad master equation by
+    explicitly exponentiating the propagator.
+    """
 
+    def __post_init__(self):
         # convert to vectorized form
         self.y0 = operator_to_vector(self.y0)  # (n^2, 1)
 

--- a/dynamiqs/integrators/mesolve/rouchon_integrator.py
+++ b/dynamiqs/integrators/mesolve/rouchon_integrator.py
@@ -11,7 +11,8 @@ from jax import Array
 
 from ...utils.quantum_utils.general import dag
 from ..core.abstract_integrator import MESolveIntegrator
-from ..core.diffrax_integrator import FixedStepIntegrator
+from ..core.diffrax_integrator import FixedStepDiffraxIntegrator
+from ..core.save_mixin import SolveSaveMixin
 
 
 class AbstractRouchonTerm(dx.AbstractTerm):
@@ -53,8 +54,14 @@ class Rouchon1DXSolver(RouchonDXSolver):
         return 1
 
 
-class MESolveRouchon1Integrator(FixedStepIntegrator, MESolveIntegrator):
-    diffrax_solver: dx.AbstractSolver = Rouchon1DXSolver()
+class MESolveRouchon1Integrator(
+    FixedStepDiffraxIntegrator, MESolveIntegrator, SolveSaveMixin
+):
+    """Integrator computing the time evolution of the Lindblad master equation using the
+    Rouchon 1 solver.
+    """
+
+    diffrax_solver = Rouchon1DXSolver()
 
     @property
     def Id(self) -> Array:

--- a/dynamiqs/integrators/sepropagator/diffrax_integrator.py
+++ b/dynamiqs/integrators/sepropagator/diffrax_integrator.py
@@ -13,28 +13,16 @@ from ..core.diffrax_integrator import (
 
 
 class SEPropagatorDiffraxIntegrator(SEDiffraxIntegrator, SEPropagatorIntegrator):
-    pass
+    """Integrator computing the propagator of the Schrödinger equation using the Diffrax
+    library."""
 
 
-class SEPropagatorEulerIntegrator(SEPropagatorDiffraxIntegrator, EulerIntegrator):
-    pass
-
-
-class SEPropagatorDopri5Integrator(SEPropagatorDiffraxIntegrator, Dopri5Integrator):
-    pass
-
-
-class SEPropagatorDopri8Integrator(SEPropagatorDiffraxIntegrator, Dopri8Integrator):
-    pass
-
-
-class SEPropagatorTsit5Integrator(SEPropagatorDiffraxIntegrator, Tsit5Integrator):
-    pass
-
-
-class SEPropagatorKvaerno3Integrator(SEPropagatorDiffraxIntegrator, Kvaerno3Integrator):
-    pass
-
-
-class SEPropagatorKvaerno5Integrator(SEPropagatorDiffraxIntegrator, Kvaerno5Integrator):
-    pass
+# fmt: off
+# ruff: noqa
+class SEPropagatorEulerIntegrator(SEPropagatorDiffraxIntegrator, EulerIntegrator): pass
+class SEPropagatorDopri5Integrator(SEPropagatorDiffraxIntegrator, Dopri5Integrator): pass
+class SEPropagatorDopri8Integrator(SEPropagatorDiffraxIntegrator, Dopri8Integrator): pass
+class SEPropagatorTsit5Integrator(SEPropagatorDiffraxIntegrator, Tsit5Integrator): pass
+class SEPropagatorKvaerno3Integrator(SEPropagatorDiffraxIntegrator, Kvaerno3Integrator): pass
+class SEPropagatorKvaerno5Integrator(SEPropagatorDiffraxIntegrator, Kvaerno5Integrator): pass
+# fmt: on

--- a/dynamiqs/integrators/sepropagator/expm_integrator.py
+++ b/dynamiqs/integrators/sepropagator/expm_integrator.py
@@ -5,4 +5,6 @@ from ..core.expm_integrator import SEExpmIntegrator
 
 
 class SEPropagatorExpmIntegrator(SEExpmIntegrator, SEPropagatorIntegrator):
-    pass
+    """Integrator computing the propagator of the Lindblad master equation by
+    explicitly exponentiating the propagator.
+    """

--- a/dynamiqs/integrators/sesolve/diffrax_integrator.py
+++ b/dynamiqs/integrators/sesolve/diffrax_integrator.py
@@ -10,31 +10,20 @@ from ..core.diffrax_integrator import (
     SEDiffraxIntegrator,
     Tsit5Integrator,
 )
+from ..core.save_mixin import SolveSaveMixin
 
 
-class SESolveDiffraxIntegrator(SEDiffraxIntegrator, SESolveIntegrator):
-    pass
+class SESolveDiffraxIntegrator(SEDiffraxIntegrator, SESolveIntegrator, SolveSaveMixin):
+    """Integrator computing the time evolution of the Schrödinger equation using the
+    Diffrax library."""
 
 
-class SESolveEulerIntegrator(SESolveDiffraxIntegrator, EulerIntegrator):
-    pass
-
-
-class SESolveDopri5Integrator(SESolveDiffraxIntegrator, Dopri5Integrator):
-    pass
-
-
-class SESolveDopri8Integrator(SESolveDiffraxIntegrator, Dopri8Integrator):
-    pass
-
-
-class SESolveTsit5Integrator(SESolveDiffraxIntegrator, Tsit5Integrator):
-    pass
-
-
-class SESolveKvaerno3Integrator(SESolveDiffraxIntegrator, Kvaerno3Integrator):
-    pass
-
-
-class SESolveKvaerno5Integrator(SESolveDiffraxIntegrator, Kvaerno5Integrator):
-    pass
+# fmt: off
+# ruff: noqa
+class SESolveEulerIntegrator(SESolveDiffraxIntegrator, EulerIntegrator): pass
+class SESolveDopri5Integrator(SESolveDiffraxIntegrator, Dopri5Integrator): pass
+class SESolveDopri8Integrator(SESolveDiffraxIntegrator, Dopri8Integrator): pass
+class SESolveTsit5Integrator(SESolveDiffraxIntegrator, Tsit5Integrator): pass
+class SESolveKvaerno3Integrator(SESolveDiffraxIntegrator, Kvaerno3Integrator): pass
+class SESolveKvaerno5Integrator(SESolveDiffraxIntegrator, Kvaerno5Integrator): pass
+# fmt: on

--- a/dynamiqs/integrators/sesolve/expm_integrator.py
+++ b/dynamiqs/integrators/sesolve/expm_integrator.py
@@ -1,6 +1,9 @@
 from ..core.abstract_integrator import SESolveIntegrator
 from ..core.expm_integrator import SEExpmIntegrator
+from ..core.save_mixin import SolveSaveMixin
 
 
-class SESolveExpmIntegrator(SEExpmIntegrator, SESolveIntegrator):
-    pass
+class SESolveExpmIntegrator(SEExpmIntegrator, SESolveIntegrator, SolveSaveMixin):
+    """Integrator computing the time evolution of the Schrödinger equation by
+    explicitly exponentiating the propagator.
+    """


### PR DESCRIPTION
This PR tries to clean the mess of integrators, by
- adding docstrings to every solver
- splitting objects between abstract classes, interfaces and mixins
- removing a bug introduced by messing with Python MRO in `DiffraxIntegrator`

It doesn't change the logic anywhere. Now almost all classes only inherit from a single abstract class (+ some interface and/or mixins).

Essentially, any class attributes can now be defined using the typical `eqx.Module` attribute syntax, and we can trust Python MRO to distribute the attributes to the correct class when using multiple inheritance. The `__init__` should be called with `kwargs` for clarity and to avoid having to guess the correct arguments order.

Minor things:
- use `__check_init__` and `__post_init__` from equinox

Now writing your custom solver is a bit like doing your groceries: pick the base classes you need, replace the ones you want, and everything should work fine.