### PR TITLE
Move ptrace tuple args to *args

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -54,7 +54,7 @@ class DenseQArray(QArray):
         data = jnp.broadcast_to(self.data, shape)
         return DenseQArray(self.dims, data)
 
-    def ptrace(self, *keep: tuple[int, ...]) -> QArray:
+    def ptrace(self, *keep: int) -> QArray:
         from ..utils.quantum_utils.general import ptrace
 
         dims = tuple(self.dims[dim] for dim in keep)

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -54,7 +54,7 @@ class DenseQArray(QArray):
         data = jnp.broadcast_to(self.data, shape)
         return DenseQArray(self.dims, data)
 
-    def ptrace(self, keep: tuple[int, ...]) -> QArray:
+    def ptrace(self, *keep: tuple[int, ...]) -> QArray:
         from ..utils.quantum_utils.general import ptrace
 
         dims = tuple(self.dims[dim] for dim in keep)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -134,7 +134,7 @@ class QArray(eqx.Module):
         """
 
     @abstractmethod
-    def ptrace(self, keep: tuple[int, ...]) -> QArray:
+    def ptrace(self, *keep: tuple[int, ...]) -> QArray:
         """Returns the partial trace of the quantum state.
 
         Args:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -134,7 +134,7 @@ class QArray(eqx.Module):
         """
 
     @abstractmethod
-    def ptrace(self, *keep: tuple[int, ...]) -> QArray:
+    def ptrace(self, *keep: int) -> QArray:
         """Returns the partial trace of the quantum state.
 
         Args:

--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -117,7 +117,7 @@ class SparseDIAQArray(QArray):
         diags = jnp.broadcast_to(self.diags, shape)
         return SparseDIAQArray(diags=diags, offsets=self.offsets, dims=self.dims)
 
-    def ptrace(self, *keep: tuple[int, ...]) -> QArray:
+    def ptrace(self, *keep: int) -> QArray:
         raise NotImplementedError
 
     def powm(self, n: int) -> QArray:

--- a/dynamiqs/qarrays/sparse_dia_qarray.py
+++ b/dynamiqs/qarrays/sparse_dia_qarray.py
@@ -117,7 +117,7 @@ class SparseDIAQArray(QArray):
         diags = jnp.broadcast_to(self.diags, shape)
         return SparseDIAQArray(diags=diags, offsets=self.offsets, dims=self.dims)
 
-    def ptrace(self, keep: tuple[int, ...]) -> QArray:
+    def ptrace(self, *keep: tuple[int, ...]) -> QArray:
         raise NotImplementedError
 
     def powm(self, n: int) -> QArray:


### PR DESCRIPTION
Probably one of the most popular use for `ptrace` is to trace a single mode out, to plot it for instance.
This PR makes the API more straightforward by turning `state.ptrace((0,))` into `state.ptrace(0)`