### PR TITLE
Better documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,17 +50,18 @@ import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128            # Hilbert space dimension
+omega = 1.0        # frequency
+kappa = 0.1        # decay rate
+alpha0 = 1.0       # initial coherent state amplitude
+tend = 2 * jnp.pi  # total evolution time (one full revolution)
 
 # initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
 psi0 = dq.coherent(n, alpha0)
-tsave = jnp.linspace(0, 1.0, 101)
+tsave = jnp.linspace(0, tend, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -68,10 +69,10 @@ print(result)
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 477.95ms ◆ remaining 0.00ms
 ==== MESolveResult ====
 Solver  : Tsit5
-Infos   : 7 steps (7 accepted, 0 rejected)
+Infos   : 116 steps (107 accepted, 9 rejected)
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
 ```
 
@@ -85,10 +86,11 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128            # Hilbert space dimension
+omega = 1.0        # frequency
+kappa = 0.1        # decay rate
+alpha0 = 1.0       # initial coherent state amplitude
+tend = 2 * jnp.pi  # total evolution time (one full revolution)
 
 def population(omega, kappa, alpha0):
     """Return the oscillator population after time evolution."""
@@ -97,7 +99,7 @@ def population(omega, kappa, alpha0):
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
     psi0 = dq.coherent(n, alpha0)
-    tsave = jnp.linspace(0, 1.0, 101)
+    tsave = jnp.linspace(0, tend, 101)
 
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -113,10 +115,10 @@ print(f'Gradient w.r.t. alpha0: {grads[2]:.4f}')
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 86.63ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 444.31ms ◆ remaining 0.00ms
 Gradient w.r.t. omega : 0.0000
-Gradient w.r.t. kappa : -0.9048
-Gradient w.r.t. alpha0: 1.8097
+Gradient w.r.t. kappa : -3.3520
+Gradient w.r.t. alpha0: 1.0670
 ```
 
 > [!Note]
@@ -135,8 +137,8 @@ Gradient w.r.t. alpha0: 1.8097
 > \end{pmatrix}
 > \approx \begin{pmatrix}
 >   0.0 \\
->   -0.9048 \\
->   1.8097
+>   -3.3520 \\
+>   1.0670
 > \end{pmatrix}
 > $$
 

--- a/README.md
+++ b/README.md
@@ -43,25 +43,25 @@ pip install dynamiqs
 
 ### Simulate a lossy quantum harmonic oscillator
 
-This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$, starting from the initial coherent state $\ket{\alpha_0}$.
+This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$ from time $0$ to time $T$, starting from the initial coherent state $\ket{\alpha_0}$.
 
 ```python
 import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 16             # Hilbert space dimension
-omega = 1.0        # frequency
-kappa = 0.1        # decay rate
-alpha0 = 1.0       # initial coherent state amplitude
-tend = 2 * jnp.pi  # total evolution time (one full revolution)
+n = 16          # Hilbert space dimension
+omega = 1.0     # frequency
+kappa = 0.1     # decay rate
+alpha0 = 1.0    # initial coherent state amplitude
+T = 2 * jnp.pi  # total evolution time (one full revolution)
 
 # initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
 psi0 = dq.coherent(n, alpha0)
-tsave = jnp.linspace(0, tend, 101)
+tsave = jnp.linspace(0, T, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -86,11 +86,11 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 16             # Hilbert space dimension
-omega = 1.0        # frequency
-kappa = 0.1        # decay rate
-alpha0 = 1.0       # initial coherent state amplitude
-tend = 2 * jnp.pi  # total evolution time (one full revolution)
+n = 16          # Hilbert space dimension
+omega = 1.0     # frequency
+kappa = 0.1     # decay rate
+alpha0 = 1.0    # initial coherent state amplitude
+T = 2 * jnp.pi  # total evolution time (one full revolution)
 
 def population(omega, kappa, alpha0):
     """Return the oscillator population after time evolution."""
@@ -99,7 +99,7 @@ def population(omega, kappa, alpha0):
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
     psi0 = dq.coherent(n, alpha0)
-    tsave = jnp.linspace(0, tend, 101)
+    tsave = jnp.linspace(0, T, 101)
 
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 128            # Hilbert space dimension
+n = 16             # Hilbert space dimension
 omega = 1.0        # frequency
 kappa = 0.1        # decay rate
 alpha0 = 1.0       # initial coherent state amplitude
@@ -69,11 +69,11 @@ print(result)
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 477.95ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 6.30ms ◆ remaining 0.00ms
 ==== MESolveResult ====
-Solver  : Tsit5
-Infos   : 116 steps (107 accepted, 9 rejected)
-States  : Array complex64 (101, 128, 128) | 12.62 Mb
+Solver : Tsit5
+Infos  : 40 steps (40 accepted, 0 rejected)
+States : Array complex64 (101, 16, 16) | 202.00 Kb
 ```
 
 ### Compute gradients with respect to some parameters
@@ -86,7 +86,7 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 128            # Hilbert space dimension
+n = 16             # Hilbert space dimension
 omega = 1.0        # frequency
 kappa = 0.1        # decay rate
 alpha0 = 1.0       # initial coherent state amplitude
@@ -115,7 +115,7 @@ print(f'Gradient w.r.t. alpha0: {grads[2]:.4f}')
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 444.31ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 5.94ms ◆ remaining 0.00ms
 Gradient w.r.t. omega : 0.0000
 Gradient w.r.t. kappa : -3.3520
 Gradient w.r.t. alpha0: 1.0670

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ print(result)
 ==== MESolveResult ====
 Solver : Tsit5
 Infos  : 40 steps (40 accepted, 0 rejected)
-States : Array complex64 (101, 16, 16) | 202.00 Kb
+States : Array complex64 (101, 16, 16) | 202.0 Kb
 ```
 
 ### Compute gradients with respect to some parameters

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -44,7 +44,7 @@ import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 128            # Hilbert space dimension
+n = 16             # Hilbert space dimension
 omega = 1.0        # frequency
 kappa = 0.1        # decay rate
 alpha0 = 1.0       # initial coherent state amplitude
@@ -63,11 +63,11 @@ print(result)
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 477.95ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 6.30ms ◆ remaining 0.00ms
 ==== MESolveResult ====
-Solver  : Tsit5
-Infos   : 116 steps (107 accepted, 9 rejected)
-States  : Array complex64 (101, 128, 128) | 12.62 Mb
+Solver : Tsit5
+Infos  : 40 steps (40 accepted, 0 rejected)
+States : Array complex64 (101, 16, 16) | 202.00 Kb
 ```
 
 ### Compute gradients with respect to some parameters
@@ -80,7 +80,7 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 128            # Hilbert space dimension
+n = 16             # Hilbert space dimension
 omega = 1.0        # frequency
 kappa = 0.1        # decay rate
 alpha0 = 1.0       # initial coherent state amplitude
@@ -109,7 +109,7 @@ print(f'Gradient w.r.t. alpha0: {grads[2]:.4f}')
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 444.31ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 5.94ms ◆ remaining 0.00ms
 Gradient w.r.t. omega : 0.0000
 Gradient w.r.t. kappa : -3.3520
 Gradient w.r.t. alpha0: 1.0670

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -37,25 +37,25 @@ pip install dynamiqs
 
 ### Simulate a lossy quantum harmonic oscillator
 
-This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$, starting from the initial coherent state $\ket{\alpha_0}$.
+This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$ from time $0$ to time $T$, starting from the initial coherent state $\ket{\alpha_0}$.
 
 ```python
 import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 16             # Hilbert space dimension
-omega = 1.0        # frequency
-kappa = 0.1        # decay rate
-alpha0 = 1.0       # initial coherent state amplitude
-tend = 2 * jnp.pi  # total evolution time (one full revolution)
+n = 16          # Hilbert space dimension
+omega = 1.0     # frequency
+kappa = 0.1     # decay rate
+alpha0 = 1.0    # initial coherent state amplitude
+T = 2 * jnp.pi  # total evolution time (one full revolution)
 
 # initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
 psi0 = dq.coherent(n, alpha0)
-tsave = jnp.linspace(0, tend, 101)
+tsave = jnp.linspace(0, T, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -80,11 +80,11 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 16             # Hilbert space dimension
-omega = 1.0        # frequency
-kappa = 0.1        # decay rate
-alpha0 = 1.0       # initial coherent state amplitude
-tend = 2 * jnp.pi  # total evolution time (one full revolution)
+n = 16          # Hilbert space dimension
+omega = 1.0     # frequency
+kappa = 0.1     # decay rate
+alpha0 = 1.0    # initial coherent state amplitude
+T = 2 * jnp.pi  # total evolution time (one full revolution)
 
 def population(omega, kappa, alpha0):
     """Return the oscillator population after time evolution."""
@@ -93,7 +93,7 @@ def population(omega, kappa, alpha0):
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
     psi0 = dq.coherent(n, alpha0)
-    tsave = jnp.linspace(0, tend, 101)
+    tsave = jnp.linspace(0, T, 101)
 
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -67,7 +67,7 @@ print(result)
 ==== MESolveResult ====
 Solver : Tsit5
 Infos  : 40 steps (40 accepted, 0 rejected)
-States : Array complex64 (101, 16, 16) | 202.00 Kb
+States : Array complex64 (101, 16, 16) | 202.0 Kb
 ```
 
 ### Compute gradients with respect to some parameters

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -44,17 +44,18 @@ import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128            # Hilbert space dimension
+omega = 1.0        # frequency
+kappa = 0.1        # decay rate
+alpha0 = 1.0       # initial coherent state amplitude
+tend = 2 * jnp.pi  # total evolution time (one full revolution)
 
 # initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
 psi0 = dq.coherent(n, alpha0)
-tsave = jnp.linspace(0, 1.0, 101)
+tsave = jnp.linspace(0, tend, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -62,10 +63,10 @@ print(result)
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 477.95ms ◆ remaining 0.00ms
 ==== MESolveResult ====
 Solver  : Tsit5
-Infos   : 7 steps (7 accepted, 0 rejected)
+Infos   : 116 steps (107 accepted, 9 rejected)
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
 ```
 
@@ -79,10 +80,11 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128            # Hilbert space dimension
+omega = 1.0        # frequency
+kappa = 0.1        # decay rate
+alpha0 = 1.0       # initial coherent state amplitude
+tend = 2 * jnp.pi  # total evolution time (one full revolution)
 
 def population(omega, kappa, alpha0):
     """Return the oscillator population after time evolution."""
@@ -91,7 +93,7 @@ def population(omega, kappa, alpha0):
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
     psi0 = dq.coherent(n, alpha0)
-    tsave = jnp.linspace(0, 1.0, 101)
+    tsave = jnp.linspace(0, tend, 101)
 
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -107,10 +109,10 @@ print(f'Gradient w.r.t. alpha0: {grads[2]:.4f}')
 ```
 
 ```text
-|██████████| 100.0% ◆ elapsed 86.63ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 444.31ms ◆ remaining 0.00ms
 Gradient w.r.t. omega : 0.0000
-Gradient w.r.t. kappa : -0.9048
-Gradient w.r.t. alpha0: 1.8097
+Gradient w.r.t. kappa : -3.3520
+Gradient w.r.t. alpha0: 1.0670
 ```
 
 ℹ️ On this specific example, we can verify the result analytically. The state remains a coherent state at all time with complex amplitude $\alpha(t) = \alpha_0 e^{-\kappa t/2} e^{i\omega t}$, and the final photon number is thus $\bar{n} = |\alpha(T)|^2 = \alpha_0^2 e^{-\kappa T}$. We can then compute the gradient with respect to the three parameters $\theta = (\omega, \kappa, \alpha_0)$:
@@ -128,8 +130,8 @@ $$
 \end{pmatrix}
 \approx \begin{pmatrix}
   0.0 \\
-  -0.9048 \\
-  1.8097
+  -3.3520 \\
+  1.0670
 \end{pmatrix}
 $$
 

--- a/docs/documentation/basics/workflow.md
+++ b/docs/documentation/basics/workflow.md
@@ -84,8 +84,8 @@ print(result)
 ==== SESolveResult ====
 Solver  : Dopri5
 Infos   : 56 steps (48 accepted, 8 rejected)
-States  : Array complex64 (101, 2, 1) | 1.58 Kb
-Expects : Array complex64 (1, 101) | 0.79 Kb
+States  : Array complex64 (101, 2, 1) | 1.6 Kb
+Expects : Array complex64 (1, 101) | 0.8 Kb
 ```
 
 ## IV. Analyze the results

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -11,17 +11,18 @@ import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128            # Hilbert space dimension
+omega = 1.0        # frequency
+kappa = 0.1        # decay rate
+alpha0 = 1.0       # initial coherent state amplitude
+tend = 2 * jnp.pi  # total evolution time (one full revolution)
 
 # initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
 psi0 = dq.coherent(n, alpha0)
-tsave = jnp.linspace(0, 1.0, 101)
+tsave = jnp.linspace(0, tend, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -29,10 +30,10 @@ print(result)
 ```
 
 ```text title="Output"
-|██████████| 100.0% ◆ elapsed 66.94ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 477.95ms ◆ remaining 0.00ms
 ==== MESolveResult ====
 Solver  : Tsit5
-Infos   : 7 steps (7 accepted, 0 rejected)
+Infos   : 116 steps (107 accepted, 9 rejected)
 States  : Array complex64 (101, 128, 128) | 12.62 Mb
 ```
 
@@ -46,10 +47,11 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 128       # Hilbert space dimension
-omega = 1.0   # frequency
-kappa = 0.1   # decay rate
-alpha0 = 1.0  # initial coherent state amplitude
+n = 128            # Hilbert space dimension
+omega = 1.0        # frequency
+kappa = 0.1        # decay rate
+alpha0 = 1.0       # initial coherent state amplitude
+tend = 2 * jnp.pi  # total evolution time (one full revolution)
 
 def population(omega, kappa, alpha0):
     """Return the oscillator population after time evolution."""
@@ -58,7 +60,7 @@ def population(omega, kappa, alpha0):
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
     psi0 = dq.coherent(n, alpha0)
-    tsave = jnp.linspace(0, 1.0, 101)
+    tsave = jnp.linspace(0, tend, 101)
 
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -74,10 +76,10 @@ print(f'Gradient w.r.t. alpha0: {grads[2]:.4f}')
 ```
 
 ```text title="Output"
-|██████████| 100.0% ◆ elapsed 86.63ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 444.31ms ◆ remaining 0.00ms
 Gradient w.r.t. omega : 0.0000
-Gradient w.r.t. kappa : -0.9048
-Gradient w.r.t. alpha0: 1.8097
+Gradient w.r.t. kappa : -3.3520
+Gradient w.r.t. alpha0: 1.0670
 ```
 
 !!! Note
@@ -96,7 +98,7 @@ Gradient w.r.t. alpha0: 1.8097
     \end{pmatrix}
     \approx \begin{pmatrix}
       0.0 \\
-      -0.9048 \\
-      1.8097
+      -3.3520 \\
+      1.0670
     \end{pmatrix}
     $$

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -4,25 +4,25 @@ First time using Dynamiqs? Below are a few basic examples to help you get starte
 
 ## Simulate a lossy quantum harmonic oscillator
 
-This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$, starting from the initial coherent state $\ket{\alpha_0}$.
+This first example shows simulation of a lossy harmonic oscillator with Hamiltonian $H=\omega a^\dagger a$ and a single jump operator $L=\sqrt{\kappa} a$ from time $0$ to time $T$, starting from the initial coherent state $\ket{\alpha_0}$.
 
 ```python
 import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 16             # Hilbert space dimension
-omega = 1.0        # frequency
-kappa = 0.1        # decay rate
-alpha0 = 1.0       # initial coherent state amplitude
-tend = 2 * jnp.pi  # total evolution time (one full revolution)
+n = 16          # Hilbert space dimension
+omega = 1.0     # frequency
+kappa = 0.1     # decay rate
+alpha0 = 1.0    # initial coherent state amplitude
+T = 2 * jnp.pi  # total evolution time (one full revolution)
 
 # initialize operators, initial state and saving times
 a = dq.destroy(n)
 H = omega * dq.dag(a) @ a
 jump_ops = [jnp.sqrt(kappa) * a]
 psi0 = dq.coherent(n, alpha0)
-tsave = jnp.linspace(0, tend, 101)
+tsave = jnp.linspace(0, T, 101)
 
 # run simulation
 result = dq.mesolve(H, jump_ops, psi0, tsave)
@@ -47,11 +47,11 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 16             # Hilbert space dimension
-omega = 1.0        # frequency
-kappa = 0.1        # decay rate
-alpha0 = 1.0       # initial coherent state amplitude
-tend = 2 * jnp.pi  # total evolution time (one full revolution)
+n = 16          # Hilbert space dimension
+omega = 1.0     # frequency
+kappa = 0.1     # decay rate
+alpha0 = 1.0    # initial coherent state amplitude
+T = 2 * jnp.pi  # total evolution time (one full revolution)
 
 def population(omega, kappa, alpha0):
     """Return the oscillator population after time evolution."""
@@ -60,7 +60,7 @@ def population(omega, kappa, alpha0):
     H = omega * dq.dag(a) @ a
     jump_ops = [jnp.sqrt(kappa) * a]
     psi0 = dq.coherent(n, alpha0)
-    tsave = jnp.linspace(0, tend, 101)
+    tsave = jnp.linspace(0, T, 101)
 
     # run simulation
     result = dq.mesolve(H, jump_ops, psi0, tsave)

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -29,7 +29,7 @@ result = dq.mesolve(H, jump_ops, psi0, tsave)
 print(result)
 ```
 
-```text
+```text title="Output"
 |██████████| 100.0% ◆ elapsed 6.30ms ◆ remaining 0.00ms
 ==== MESolveResult ====
 Solver : Tsit5

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -34,7 +34,7 @@ print(result)
 ==== MESolveResult ====
 Solver : Tsit5
 Infos  : 40 steps (40 accepted, 0 rejected)
-States : Array complex64 (101, 16, 16) | 202.00 Kb
+States : Array complex64 (101, 16, 16) | 202.0 Kb
 ```
 
 ## Compute gradients with respect to some parameters

--- a/docs/documentation/getting_started/examples.md
+++ b/docs/documentation/getting_started/examples.md
@@ -11,7 +11,7 @@ import dynamiqs as dq
 import jax.numpy as jnp
 
 # parameters
-n = 128            # Hilbert space dimension
+n = 16             # Hilbert space dimension
 omega = 1.0        # frequency
 kappa = 0.1        # decay rate
 alpha0 = 1.0       # initial coherent state amplitude
@@ -29,12 +29,12 @@ result = dq.mesolve(H, jump_ops, psi0, tsave)
 print(result)
 ```
 
-```text title="Output"
-|██████████| 100.0% ◆ elapsed 477.95ms ◆ remaining 0.00ms
+```text
+|██████████| 100.0% ◆ elapsed 6.30ms ◆ remaining 0.00ms
 ==== MESolveResult ====
-Solver  : Tsit5
-Infos   : 116 steps (107 accepted, 9 rejected)
-States  : Array complex64 (101, 128, 128) | 12.62 Mb
+Solver : Tsit5
+Infos  : 40 steps (40 accepted, 0 rejected)
+States : Array complex64 (101, 16, 16) | 202.00 Kb
 ```
 
 ## Compute gradients with respect to some parameters
@@ -47,7 +47,7 @@ import jax.numpy as jnp
 import jax
 
 # parameters
-n = 128            # Hilbert space dimension
+n = 16             # Hilbert space dimension
 omega = 1.0        # frequency
 kappa = 0.1        # decay rate
 alpha0 = 1.0       # initial coherent state amplitude
@@ -76,7 +76,7 @@ print(f'Gradient w.r.t. alpha0: {grads[2]:.4f}')
 ```
 
 ```text title="Output"
-|██████████| 100.0% ◆ elapsed 444.31ms ◆ remaining 0.00ms
+|██████████| 100.0% ◆ elapsed 5.94ms ◆ remaining 0.00ms
 Gradient w.r.t. omega : 0.0000
 Gradient w.r.t. kappa : -3.3520
 Gradient w.r.t. alpha0: 1.0670

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -18,11 +18,11 @@ def memory_bytes(x: Array) -> int:
 def memory_str(x: Array) -> str:
     mem = memory_bytes(x)
     if mem < 1024**2:
-        return f'{mem / 1024:.2f} Kb'
+        return f'{mem / 1024:.1f} Kb'
     elif mem < 1024**3:
-        return f'{mem / 1024**2:.2f} Mb'
+        return f'{mem / 1024**2:.1f} Mb'
     else:
-        return f'{mem / 1024**3:.2f} Gb'
+        return f'{mem / 1024**3:.1f} Gb'
 
 
 def array_str(x: Array | None) -> str | None:


### PR DESCRIPTION
The previous dynamic was a bit lame 😅

<p align="center">
    <img width="300" src="https://github.com/user-attachments/assets/0508d41a-71b1-4709-88ef-bb05cd2592dd">
</p>

- Changed the example final time to perform a full revolution.
- Fixed the truncature to a reasonable size.
- Change result memory printing precision to `.1f` instead of `.2f`.
- Introduce the parameter $T$ used in calculations in system description and code.