### PR TITLE
Minor nits on top of qarray types refactoring

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -21,6 +21,7 @@ _bkron = jnp.vectorize(jnp.kron, signature='(a,b),(c,d)->(ac,bd)')
 
 def _dense_to_qobj(x: DenseQArray) -> Qobj | list[Qobj]:
     if x.ndim > 2:
+        # TODO: generalize to any nested sequence with the appropriate shape
         return [_dense_to_qobj(sub_x, dims=x.dims) for sub_x in x]
     else:
         dims = _dims_to_qutip(x.dims, x.shape)

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -27,7 +27,7 @@ def _dense_to_qobj(x: DenseQArray) -> Qobj | list[Qobj]:
         return Qobj(x, dims=dims)
 
 
-def _dims_to_qutip(dims: tuple[int, ...], shape: tuple[int, ...]) -> list:
+def _dims_to_qutip(dims: tuple[int, ...], shape: tuple[int, ...]) -> list[list[int]]:
     dims = list(dims)
     if shape[-1] == 1:  # [[3], [1]] or [[3, 4], [1, 1]]
         dims = [dims, [1] * len(dims)]

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -22,7 +22,7 @@ __all__ = ['QArray', 'QArrayLike', 'isqarraylike']
 def isqarraylike(x: Any) -> bool:
     if isinstance(x, get_args(_QArrayLike)):
         return True
-    elif isinstance(x, list):
+    elif isinstance(x, Sequence):
         return all(isqarraylike(sub_x) for sub_x in x)
     return False
 
@@ -477,12 +477,12 @@ def _include_last_two_dims(axis: int | tuple[int, ...] | None, ndim: int) -> boo
 # - a NumPy array,
 # - a QuTiP Qobj,
 # - a dynamiqs QArray,
-# - a nested list of these types.
+# - a nested sequence of these types.
 # An object of type `QArrayLike` can be converted to a `QArray` with `asqarray`.
 
 # extended array like type
 _QArrayLike = Union[ArrayLike, QArray, Qobj]
-# a type alias for nested list of _QArrayLike
-_NestedQArrayLikeList = list[Union[_QArrayLike, '_NestedQArrayLikeList']]
+# a type alias for nested sequence of _QArrayLike
+_NestedQArrayLikeSequence = Sequence[Union[_QArrayLike, '_NestedQArrayLikeSequence']]
 # a type alias for any type compatible with asqarray
-QArrayLike = Union[_QArrayLike, _NestedQArrayLikeList]
+QArrayLike = Union[_QArrayLike, _NestedQArrayLikeSequence]


### PR DESCRIPTION
Follow-up to #725.

@gautierronan we also need to fix (or add todos):
-  [ ] `_dims_to_qutip` should support a `dims=None` (potentially called in `asqobj`)
- [ ] `_asjaxarray` is exactly the same as `asjaxarray`, should we juste rename the first?
- [ ] Methods accepting `QArrayLike` don't actually support `QArrayLike` (`asdense`, `assparsedia`, `asqobj`). Basically anywhere we take in a `QArrayLike`, we should write the method to support, for example:
   ```python
    x = (np.array([[[1, 2, 3]], [4, 5, 6]]]), dq.fock(3, (0, 1)))
    ```
- [ ] `_warn_qarray_dims` doesn't work on `qobj`, doesn't work on list of qarray.