### PR TITLE
Disallow mkdocstrings-python=1.12.0 due to bug parsing strings in signatures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "pytest-sugar",
     "pytest-xdist",
     "mkdocs-material",
-    "mkdocstrings[python]<1.12.0",
+    "mkdocstrings[python]!=1.12.0", # bug with parsing strings in signatures, see https://github.com/mkdocstrings/python/issues/191
     "mkdocs-gen-files",
     "mkdocs-literate-nav",
     "mkdocs-section-index",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "pytest-sugar",
     "pytest-xdist",
     "mkdocs-material",
-    "mkdocstrings[python]",
+    "mkdocstrings[python]<1.12.0",
     "mkdocs-gen-files",
     "mkdocs-literate-nav",
     "mkdocs-section-index",


### PR DESCRIPTION
Temporary fix, see https://github.com/mkdocstrings/python/issues/191.