### PR TITLE
Fix colorbar rendering under constrained_layout

### DIFF
--- a/dynamiqs/plot/fock.py
+++ b/dynamiqs/plot/fock.py
@@ -155,4 +155,4 @@ def fock_evolution(
     ket_ticks(ax.yaxis)
 
     if colorbar:
-        add_colorbar(ax, cmap, norm, size='2%', pad='2%')
+        add_colorbar(ax, cmap, norm, size=0.02, pad=0.02)

--- a/dynamiqs/plot/hinton.py
+++ b/dynamiqs/plot/hinton.py
@@ -113,7 +113,7 @@ def _plot_hinton(
     # === colorbar
     if colorbar:
         norm = Normalize(colors_vmin, colors_vmax)
-        cax = add_colorbar(ax, cmap, norm, size='4%', pad='4%')
+        cax = add_colorbar(ax, cmap, norm, size=0.04, pad=0.04)
         if colors_vmin == -jnp.pi and colors_vmax == jnp.pi:
             cax.set_yticks([-jnp.pi, 0.0, jnp.pi], labels=[r'$-\pi$', r'$0$', r'$\pi$'])
 

--- a/dynamiqs/plot/utils.py
+++ b/dynamiqs/plot/utils.py
@@ -280,7 +280,7 @@ def minorticks_off(axis: Axis):
 def add_colorbar(
     ax: Axes, cmap: str, norm: Normalize, *, size: float = 0.05, pad: float = 0.05
 ) -> Axes:
-    # append a new axes on the right with the same height
+    # insert a new axes on the right with the same height
     cax = ax.inset_axes([1 + size, 0, pad, 1])
     mappable = mpl.cm.ScalarMappable(norm=norm, cmap=cmap)
     plt.colorbar(mappable=mappable, cax=cax)

--- a/dynamiqs/plot/utils.py
+++ b/dynamiqs/plot/utils.py
@@ -17,7 +17,6 @@ from matplotlib.axis import Axis
 from matplotlib.colors import Normalize
 from matplotlib.figure import Figure
 from matplotlib.ticker import FixedLocator, MaxNLocator, MultipleLocator, NullLocator
-from mpl_toolkits.axes_grid1 import make_axes_locatable
 from PIL import Image as PILImage
 from tqdm import tqdm
 
@@ -279,11 +278,10 @@ def minorticks_off(axis: Axis):
 
 
 def add_colorbar(
-    ax: Axes, cmap: str, norm: Normalize, *, size: str = '5%', pad: str = '5%'
+    ax: Axes, cmap: str, norm: Normalize, *, size: float = 0.05, pad: float = 0.05
 ) -> Axes:
     # append a new axes on the right with the same height
-    divider = make_axes_locatable(ax)
-    cax = divider.append_axes('right', size=size, pad=pad)
+    cax = ax.inset_axes([1 + size, 0, pad, 1])
     mappable = mpl.cm.ScalarMappable(norm=norm, cmap=cmap)
     plt.colorbar(mappable=mappable, cax=cax)
     cax.grid(False)


### PR DESCRIPTION
```python
import dynamiqs as dq
import matplotlib.pyplot as plt
import numpy as np

# === example 1
_, axs = dq.plot.grid(2)
x = np.random.uniform(-1.0, 1.0, (10, 10))
dq.plot.hinton(x, ax=next(axs), vmin=-1.0, vmax=1.0)
dq.plot.hinton(np.abs(x), ax=next(axs), cmap='Greys', vmax=1.0, ecolor='black')

# === example 2
_, axs = dq.plot.grid(2)
psi = dq.unit(dq.fock(4, 0) - dq.fock(4, 2))
dq.plot.hinton(dq.todm(psi), ax=next(axs))
rho = dq.unit(dq.fock_dm(4, 0) + dq.fock_dm(4, 2))
dq.plot.hinton(rho, ax=next(axs))

# === example 3
states = dq.coherent(16, (1.0, 2.0))
fig, axs = plt.subplots(1, 2, sharey=True, sharex=True, constrained_layout=True)
dq.plot.wigner(states[0], ax=axs[0], colorbar=False)
dq.plot.wigner(states[1], ax=axs[1], colorbar=True)
```

Before:
![image](https://github.com/user-attachments/assets/63ffd981-439e-48b9-b42e-3040c833dd6d)
![image](https://github.com/user-attachments/assets/5be13618-44f1-45d0-9063-288b228749f1)
![image](https://github.com/user-attachments/assets/9be0aefa-303c-44cf-9ae7-fac09a72e257)

After:
![image](https://github.com/user-attachments/assets/6a52ef5c-026c-4b27-977f-aa861657328e)
![image](https://github.com/user-attachments/assets/92acf856-2fa7-493d-8d20-eb473e665db0)
![image](https://github.com/user-attachments/assets/8b31b3e8-38c8-4197-9a19-a47cafc6dcac)

Closes DYN-127.