### PR TITLE
Fix documentation figures rendering

### DIFF
--- a/docs/documentation/basics/workflow.md
+++ b/docs/documentation/basics/workflow.md
@@ -111,6 +111,6 @@ plt.legend(('Analytical', 'Dynamiqs'))
 renderfig('workflow')
 ```
 
-![workflow](/figs_docs/workflow.png){.fig}
+![workflow](../../figs_docs/workflow.png){.fig}
 
 As expected, we find off-resonant Rabi oscillations at the generalized Rabi frequency $\Omega^* = \sqrt{\delta^2 + \Omega^2}$, and with a reduced amplitude $|\Omega / \Omega^*|^2$.

--- a/dynamiqs/plot/fock.py
+++ b/dynamiqs/plot/fock.py
@@ -53,20 +53,20 @@ def fock(
         >>> dq.plot.fock(psi)
         >>> renderfig('plot_fock')
 
-        ![plot_fock](/figs_code/plot_fock.png){.fig}
+        ![plot_fock](../../figs_code/plot_fock.png){.fig}
 
         >>> # the even cat state has only even photon number components
         >>> psi = dq.unit(dq.coherent(32, 3.0) + dq.coherent(32, -3.0))
         >>> dq.plot.fock(psi, allxticks=False, ymax=None)
         >>> renderfig('plot_fock_even_cat')
 
-        ![plot_fock_even_cat](/figs_code/plot_fock_even_cat.png){.fig}
+        ![plot_fock_even_cat](../../figs_code/plot_fock_even_cat.png){.fig}
 
         >>> dq.plot.fock(dq.coherent(16, 1.0), alpha=0.5)
         >>> dq.plot.fock(dq.coherent(16, 2.0), ax=plt.gca(), alpha=0.5, color='red')
         >>> renderfig('plot_fock_coherent')
 
-        ![plot_fock_coherent](/figs_code/plot_fock_coherent.png){.fig}
+        ![plot_fock_coherent](../../figs_code/plot_fock_coherent.png){.fig}
     """
     state = jnp.asarray(state)
     check_shape(state, 'state', '(n, 1)', '(n, n)')
@@ -117,13 +117,13 @@ def fock_evolution(
         >>> dq.plot.fock_evolution(result.states, times=tsave)
         >>> renderfig('plot_fock_evolution')
 
-        ![plot_fock_evolution](/figs_code/plot_fock_evolution.png){.fig}
+        ![plot_fock_evolution](../../figs_code/plot_fock_evolution.png){.fig}
 
         Use the log scale option to visualise low populations:
         >>> dq.plot.fock_evolution(result.states, times=tsave, logscale=True)
         >>> renderfig('plot_fock_evolution_log')
 
-        ![plot_fock_evolution_log](/figs_code/plot_fock_evolution_log.png){.fig}
+        ![plot_fock_evolution_log](../../figs_code/plot_fock_evolution_log.png){.fig}
     """
     states = jnp.asarray(states)
     times = jnp.asarray(times) if times is not None else None

--- a/dynamiqs/plot/hinton.py
+++ b/dynamiqs/plot/hinton.py
@@ -143,27 +143,27 @@ def hinton(
         >>> dq.plot.hinton(jnp.abs(rho))
         >>> renderfig('plot_hinton_coherent')
 
-        ![plot_hinton_coherent](/figs_code/plot_hinton_coherent.png){.fig-half}
+        ![plot_hinton_coherent](../../figs_code/plot_hinton_coherent.png){.fig-half}
 
         >>> a = dq.destroy(16)
         >>> H = dq.dag(a) @ a + 2.0 * (a + dq.dag(a))
         >>> dq.plot.hinton(jnp.abs(H))
         >>> renderfig('plot_hinton_hamiltonian')
 
-        ![plot_hinton_hamiltonian](/figs_code/plot_hinton_hamiltonian.png){.fig-half}
+        ![plot_hinton_hamiltonian](../../figs_code/plot_hinton_hamiltonian.png){.fig-half}
 
         >>> cnot = [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0]]
         >>> dq.plot.hinton(cnot, tickslabel=['00', '01', '10', '11'])
         >>> renderfig('plot_hinton_cnot')
 
-        ![plot_hinton_cnot](/figs_code/plot_hinton_cnot.png){.fig-half}
+        ![plot_hinton_cnot](../../figs_code/plot_hinton_cnot.png){.fig-half}
 
         >>> key = jax.random.PRNGKey(42)
         >>> x = dq.random.complex(key, (16, 16))
         >>> dq.plot.hinton(x)
         >>> renderfig('plot_hinton_random_complex')
 
-        ![plot_hinton_random_complex](/figs_code/plot_hinton_random_complex.png){.fig-half}
+        ![plot_hinton_random_complex](../../figs_code/plot_hinton_random_complex.png){.fig-half}
 
         >>> _, axs = dq.plot.grid(2)
         >>> psi = dq.unit(dq.fock(4, 0) - dq.fock(4, 2))
@@ -172,7 +172,7 @@ def hinton(
         >>> dq.plot.hinton(rho, ax=next(axs))
         >>> renderfig('plot_hinton_fock02')
 
-        ![plot_hinton_fock02](/figs_code/plot_hinton_fock02.png){.fig-half}
+        ![plot_hinton_fock02](../../figs_code/plot_hinton_fock02.png){.fig-half}
 
         >>> _, axs = dq.plot.grid(2)
         >>> x = np.random.uniform(-1.0, 1.0, (10, 10))
@@ -180,13 +180,13 @@ def hinton(
         >>> dq.plot.hinton(jnp.abs(x), ax=next(axs), cmap='Greys', vmax=1.0, ecolor='black')
         >>> renderfig('plot_hinton_real')
 
-        ![plot_hinton_real](/figs_code/plot_hinton_real.png){.fig-half}
+        ![plot_hinton_real](../../figs_code/plot_hinton_real.png){.fig-half}
 
         >>> x = np.random.uniform(-1.0, 1.0, (100, 100))
         >>> dq.plot.hinton(x, vmin=-1.0, vmax=1.0, ewidth=0, clear=True, w=20)
         >>> renderfig('plot_hinton_large')
 
-        ![plot_hinton_large](/figs_code/plot_hinton_large.png){.fig}
+        ![plot_hinton_large](../../figs_code/plot_hinton_large.png){.fig}
     """  # noqa: E501
     x = jnp.asarray(x)
     check_shape(x, 'x', '(n, n)')

--- a/dynamiqs/plot/misc.py
+++ b/dynamiqs/plot/misc.py
@@ -33,7 +33,7 @@ def pwc_pulse(
         >>> dq.plot.pwc_pulse(times, values)
         >>> renderfig('plot_pwc_pulse')
 
-        ![plot_pwc_pulse](/figs_code/plot_pwc_pulse.png){.fig}
+        ![plot_pwc_pulse](../../figs_code/plot_pwc_pulse.png){.fig}
     """
     times = jnp.asarray(times)  # (n + 1)
     values = jnp.asarray(values)  # (n)

--- a/dynamiqs/plot/utils.py
+++ b/dynamiqs/plot/utils.py
@@ -123,7 +123,7 @@ def grid(
         [...]
         >>> renderfig('plot_grid')
 
-        ![plot_grid](/figs_code/plot_grid.png){.fig}
+        ![plot_grid](../../figs_code/plot_grid.png){.fig}
     """
     h = w if h is None else h
     ncols = ceil(n / nrows)
@@ -174,7 +174,7 @@ def mplstyle(*, usetex: bool = False, dpi: int = 72):
         [...]
         >>> renderfig('mplstyle_before')
 
-        ![mplstyle_before](/figs_code/mplstyle_before.png){.fig}
+        ![mplstyle_before](../../figs_code/mplstyle_before.png){.fig}
 
         After (Dynamiqs Matplotlib style):
 
@@ -187,7 +187,7 @@ def mplstyle(*, usetex: bool = False, dpi: int = 72):
         [...]
         >>> renderfig('mplstyle_after')
 
-        ![mplstyle_after](/figs_code/mplstyle_after.png){.fig}
+        ![mplstyle_after](../../figs_code/mplstyle_after.png){.fig}
     """
     plt.rcParams.update(
         {
@@ -347,14 +347,14 @@ def gifit(
         <IPython.core.display.Image object>
         >>> rendergif(gif, 'cos')
 
-        ![plot_cos](/figs_code/cos.gif){.fig}
+        ![plot_cos](../../figs_code/cos.gif){.fig}
 
         >>> alphas = jnp.linspace(0.0, 3.0, 51)
         >>> states = dq.coherent(24, alphas)
         >>> gif = dq.plot.gifit(dq.plot.fock)(states, fps=25)
         >>> rendergif(gif, 'coherent_evolution')
 
-        ![plot_coherent_evolution](/figs_code/coherent_evolution.gif){.fig}
+        ![plot_coherent_evolution](../../figs_code/coherent_evolution.gif){.fig}
     """
 
     @wraps(plot_function)

--- a/dynamiqs/plot/wigner.py
+++ b/dynamiqs/plot/wigner.py
@@ -99,25 +99,25 @@ def wigner(
         >>> dq.plot.wigner(psi)
         >>> renderfig('plot_wigner_coh')
 
-        ![plot_wigner_coh](/figs_code/plot_wigner_coh.png){.fig-half}
+        ![plot_wigner_coh](../../figs_code/plot_wigner_coh.png){.fig-half}
 
         >>> psi = dq.unit(dq.coherent(16, 2) + dq.coherent(16, -2))
         >>> dq.plot.wigner(psi, xmax=4.0, ymax=2.0, colorbar=False)
         >>> renderfig('plot_wigner_cat')
 
-        ![plot_wigner_cat](/figs_code/plot_wigner_cat.png){.fig-half}
+        ![plot_wigner_cat](../../figs_code/plot_wigner_cat.png){.fig-half}
 
         >>> psi = dq.unit(dq.fock(2, 0) + dq.fock(2, 1))
         >>> dq.plot.wigner(psi, xmax=2.0, cross=True)
         >>> renderfig('plot_wigner_01')
 
-        ![plot_wigner_01](/figs_code/plot_wigner_01.png){.fig-half}
+        ![plot_wigner_01](../../figs_code/plot_wigner_01.png){.fig-half}
 
         >>> psi = dq.unit(sum(dq.coherent(32, 3 * a) for a in [1, 1j, -1, -1j]))
         >>> dq.plot.wigner(psi, npixels=201, clear=True)
         >>> renderfig('plot_wigner_4legged')
 
-        ![plot_wigner_4legged](/figs_code/plot_wigner_4legged.png){.fig-half}
+        ![plot_wigner_4legged](../../figs_code/plot_wigner_4legged.png){.fig-half}
     """
     state = jnp.asarray(state)
     check_shape(state, 'state', '(n, 1)', '(n, n)')
@@ -166,7 +166,7 @@ def wigner_mosaic(
         >>> dq.plot.wigner_mosaic(psis)
         >>> renderfig('plot_wigner_mosaic_fock')
 
-        ![plot_wigner_mosaic_fock](/figs_code/plot_wigner_mosaic_fock.png){.fig}
+        ![plot_wigner_mosaic_fock](../../figs_code/plot_wigner_mosaic_fock.png){.fig}
 
         >>> n = 16
         >>> a = dq.destroy(n)
@@ -178,7 +178,7 @@ def wigner_mosaic(
         >>> dq.plot.wigner_mosaic(result.states, n=6, xmax=4.0, ymax=2.0)
         >>> renderfig('plot_wigner_mosaic_cat')
 
-        ![plot_wigner_mosaic_cat](/figs_code/plot_wigner_mosaic_cat.png){.fig}
+        ![plot_wigner_mosaic_cat](../../figs_code/plot_wigner_mosaic_cat.png){.fig}
 
         >>> n = 16
         >>> a = dq.destroy(n)
@@ -189,7 +189,7 @@ def wigner_mosaic(
         >>> dq.plot.wigner_mosaic(result.states, n=25, nrows=5, xmax=4.0)
         >>> renderfig('plot_wigner_mosaic_kerr')
 
-        ![plot_wigner_mosaic_kerr](/figs_code/plot_wigner_mosaic_kerr.png){.fig}
+        ![plot_wigner_mosaic_kerr](../../figs_code/plot_wigner_mosaic_kerr.png){.fig}
     """
     states = jnp.asarray(states)
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
@@ -263,7 +263,7 @@ def wigner_gif(
         >>> gif = dq.plot.wigner_gif(result.states, fps=25, xmax=4.0, ymax=2.0)
         >>> rendergif(gif, 'wigner-cat')
 
-        ![plot_wigner_gif_cat](/figs_code/wigner-cat.gif){.fig}
+        ![plot_wigner_gif_cat](../../figs_code/wigner-cat.gif){.fig}
 
         >>> n = 16
         >>> a = dq.destroy(n)
@@ -276,7 +276,7 @@ def wigner_gif(
         ... )
         >>> rendergif(gif, 'wigner-kerr')
 
-        ![plot_wigner_gif_kerr](/figs_code/wigner-kerr.gif){.fig-half}
+        ![plot_wigner_gif_kerr](../../figs_code/wigner-kerr.gif){.fig-half}
     """
     states = jnp.asarray(states)
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')

--- a/dynamiqs/random.py
+++ b/dynamiqs/random.py
@@ -74,7 +74,7 @@ def complex(  # noqa: A001
         renderfig('random_complex')
         ```
 
-        ![rand_complex](/figs_code/random_complex.png){.fig}
+        ![rand_complex](../../figs_code/random_complex.png){.fig}
 
     Args:
         key: A PRNG key used as the random key.


### PR DESCRIPTION
Figures were not rendering on mike documentation, because we were using absolute paths in links instead of relative ones, see https://github.com/jimporter/mike/issues/20.

Since we need to use relative links, one solution would have been:
```diff
- ![workflow](/figs_docs/workflow.png){.fig}
+ ![workflow](../../figs_docs/workflow.png){.fig}
```
I have instead went with a slightly different solution, which doesn't require knowing the depth of the file in the directory, but that requires specifying the current directory, and that saves images inside each directory.
```diff
- renderfig('workflow')
- ![workflow](/figs_docs/workflow.png){.fig}
+ renderfig('basics/workflow')
+ ![workflow](workflow.png){.fig}
```
