### PR TITLE
Remove `FutureWarning` filter

### DIFF
--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -52,9 +52,6 @@ class DiffraxIntegrator(BaseIntegrator, SaveMixin):
         with warnings.catch_warnings():
             # TODO: remove once complex support is stabilized in diffrax
             warnings.simplefilter('ignore', UserWarning)
-            # TODO: remove once https://github.com/patrick-kidger/diffrax/issues/445 is
-            # closed
-            warnings.simplefilter('ignore', FutureWarning)
 
             # === prepare diffrax arguments
             fn = lambda t, y, args: self.save(y)  # noqa: ARG005


### PR DESCRIPTION
Several equinox releases have been pushed since then, the warning should not be needed anymore. 