### PR TITLE
Simplify implementation of vectorization utilities

### DIFF
--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -95,17 +95,10 @@ def is_shape(x: object) -> bool:
 
 
 def _flat_vectorize(  # noqa: C901
-    f: TimeArray,
+    f: callable,
     n_batch: PyTree[Shape],
     out_axes: PyTree[int | None],
-) -> TimeArray:
-    """Vectorize a Hamiltonian function.
-
-    Args:
-        f: the Hamiltonian function.
-        n_batch: the batch shape of the Hamiltonian.
-        out_axes_false: the out axes of the Hamiltonian.
-    """
+) -> callable:
     broadcast_shape = jtu.tree_leaves(n_batch, is_shape)
     broadcast_shape = jnp.broadcast_shapes(*broadcast_shape)
 
@@ -163,10 +156,10 @@ def _flat_vectorize(  # noqa: C901
 
 
 def _cartesian_vectorize(
-    f: TimeArray,
+    f: callable,
     n_batch: PyTree[Shape],
     out_axes: PyTree[int | None],
-) -> TimeArray:
+) -> callable:
     # todo :write doc
 
     # We use `jax.tree_util` to handle nested batching (such as `jump_ops`).

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -94,9 +94,7 @@ def is_shape(x: object) -> bool:
 
 
 def _flat_vectorize(  # noqa: C901
-    f: callable,
-    n_batch: PyTree[Shape],
-    out_axes: PyTree[int | None],
+    f: callable, n_batch: PyTree[Shape], out_axes: PyTree[int | None]
 ) -> callable:
     broadcast_shape = jax.tree.leaves(n_batch, is_shape)
     broadcast_shape = jnp.broadcast_shapes(*broadcast_shape)
@@ -155,9 +153,7 @@ def _flat_vectorize(  # noqa: C901
 
 
 def _cartesian_vectorize(
-    f: callable,
-    n_batch: PyTree[Shape],
-    out_axes: PyTree[int | None],
+    f: callable, n_batch: PyTree[Shape], out_axes: PyTree[int | None]
 ) -> callable:
     # todo :write doc
 

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -94,13 +94,6 @@ def is_shape(x: object) -> bool:
     return isinstance(x, Shape)
 
 
-def tree_false_to_none(
-    tree: PyTree, is_leaf: callable[PyTree, bool] | None = None
-) -> PyTree:
-    """Replace all `False` values in a tree by `None`."""
-    return jtu.tree_map(lambda x: x if x is not False else None, tree, is_leaf=is_leaf)
-
-
 def _flat_vectorize(  # noqa: C901
     f: TimeArray,
     n_batch: PyTree[Shape],

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -115,7 +115,7 @@ def _vectorized_mepropagator(
     # this leaf should be vmapped on.
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = MEPropagatorResult(False, False, False, False, 0, 0)
+    out_axes = MEPropagatorResult(None, None, None, None, 0, 0)
 
     if not options.cartesian_batching:
         broadcast_shape = jnp.broadcast_shapes(

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -165,7 +165,7 @@ def _vectorized_mesolve(
     # this leaf should be vmapped on.
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = MESolveResult(False, False, False, False, 0, 0)
+    out_axes = MESolveResult(None, None, None, None, 0, 0)
 
     if not options.cartesian_batching:
         broadcast_shape = jnp.broadcast_shapes(

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -122,7 +122,7 @@ def _vectorized_sepropagator(
     n_batch = (H.in_axes, Shape(), Shape(), Shape(), Shape())
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = SEPropagatorResult(False, False, False, False, 0, 0)
+    out_axes = SEPropagatorResult(None, None, None, None, 0, 0)
 
     # compute vectorized function
     f = _cartesian_vectorize(_sepropagator, n_batch, out_axes)

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -147,7 +147,7 @@ def _vectorized_sesolve(
     )
 
     # the result is vectorized over `_saved` and `infos`
-    out_axes = SESolveResult(False, False, False, False, 0, 0)
+    out_axes = SESolveResult(None, None, None, None, 0, 0)
 
     # compute vectorized function with given batching strategy
     if options.cartesian_batching:


### PR DESCRIPTION
Small simplifications on the vectorization code (remove the `False`/`None` logic, fix typings, use `jax.tree`).

Suggest reviewing commit by commit.

Also, I think it will bug if a jump operator is a `SummedTimeArray` which is batched over. We should probably play the same tricks as with the Hamiltonian, although this is quite niche. 