### PR TITLE
Update the API of conversion utilities

### DIFF
--- a/dynamiqs/plot/fock.py
+++ b/dynamiqs/plot/fock.py
@@ -8,7 +8,7 @@ from matplotlib.colors import ListedColormap, LogNorm, Normalize
 
 from .._checks import check_shape, check_times
 from ..qarrays.qarray import QArrayLike
-from ..qarrays.type_conversion import asjaxarray
+from ..qarrays.type_conversion import to_jax
 from ..utils.quantum_utils import isdm, isket
 from .utils import (
     add_colorbar,
@@ -70,7 +70,7 @@ def fock(
 
         ![plot_fock_coherent](../../figs_code/plot_fock_coherent.png){.fig}
     """
-    state = asjaxarray(state)
+    state = to_jax(state)
     check_shape(state, 'state', '(n, 1)', '(n, n)')
 
     n = state.shape[0]
@@ -127,7 +127,7 @@ def fock_evolution(
 
         ![plot_fock_evolution_log](../../figs_code/plot_fock_evolution_log.png){.fig}
     """
-    states = asjaxarray(states)
+    states = to_jax(states)
     times = jnp.asarray(times) if times is not None else None
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
     if times is not None:

--- a/dynamiqs/plot/hinton.py
+++ b/dynamiqs/plot/hinton.py
@@ -14,7 +14,7 @@ from matplotlib.colors import Normalize
 
 from .._checks import check_shape
 from ..qarrays.qarray import QArrayLike
-from ..qarrays.type_conversion import asjaxarray
+from ..qarrays.type_conversion import to_jax
 from .utils import add_colorbar, bra_ticks, integer_ticks, ket_ticks, optional_ax
 
 __all__ = ['hinton']
@@ -142,14 +142,14 @@ def hinton(
 
     Examples:
         >>> rho = dq.coherent_dm(16, 2.0)
-        >>> dq.plot.hinton(jnp.abs(rho.asjaxarray()))
+        >>> dq.plot.hinton(jnp.abs(rho.to_jax()))
         >>> renderfig('plot_hinton_coherent')
 
         ![plot_hinton_coherent](../../figs_code/plot_hinton_coherent.png){.fig-half}
 
         >>> a = dq.destroy(16)
         >>> H = a.dag() @ a + 2.0 * (a + a.dag())
-        >>> dq.plot.hinton(jnp.abs(H.asjaxarray()))
+        >>> dq.plot.hinton(jnp.abs(H.to_jax()))
         >>> renderfig('plot_hinton_hamiltonian')
 
         ![plot_hinton_hamiltonian](../../figs_code/plot_hinton_hamiltonian.png){.fig-half}
@@ -190,7 +190,7 @@ def hinton(
 
         ![plot_hinton_large](../../figs_code/plot_hinton_large.png){.fig}
     """  # noqa: E501
-    x = asjaxarray(x)
+    x = to_jax(x)
     check_shape(x, 'x', '(n, n)')
 
     # set different defaults, areas and colors for real matrix, positive real matrix

--- a/dynamiqs/plot/wigner.py
+++ b/dynamiqs/plot/wigner.py
@@ -8,7 +8,7 @@ from matplotlib.colors import Normalize
 
 from .._checks import check_shape
 from ..qarrays.qarray import QArrayLike
-from ..qarrays.type_conversion import asjaxarray, asqarray
+from ..qarrays.type_conversion import asqarray, to_jax
 from ..utils import wigner as compute_wigner
 from .utils import add_colorbar, colors, gif_indices, gifit, grid, optional_ax
 
@@ -29,7 +29,7 @@ def plot_wigner_data(
     cross: bool = False,
     clear: bool = False,
 ):
-    w = asjaxarray(wigner)
+    w = to_jax(wigner)
     check_shape(w, 'wigner', '(n, n)')
 
     # set plot norm

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -125,6 +125,9 @@ class DenseQArray(QArray):
     def devices(self) -> set[Device]:
         return self.data.devices()
 
+    def asdense(self) -> DenseQArray:
+        return self
+
     def assparsedia(self) -> SparseDIAQArray:
         from .sparse_dia_qarray import _array_to_sparsedia
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import get_args
+from typing import TYPE_CHECKING, get_args
 
 import jax
 import jax.numpy as jnp
@@ -14,11 +14,14 @@ from .layout import Layout, dense
 from .qarray import (
     QArray,
     QArrayLike,
-    _asjaxarray,
     _dims_to_qutip,
     _in_last_two_dims,
+    _to_jax,
     isqarraylike,
 )
+
+if TYPE_CHECKING:
+    from .sparse_dia_qarray import SparseDIAQArray
 
 __all__ = ['DenseQArray']
 
@@ -122,13 +125,18 @@ class DenseQArray(QArray):
     def devices(self) -> set[Device]:
         return self.data.devices()
 
+    def assparsedia(self) -> SparseDIAQArray:
+        from .sparse_dia_qarray import _array_to_sparsedia
+
+        return _array_to_sparsedia(self.data, dims=self.dims)
+
     def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
         return jnp.allclose(self.data, self.data.mT.conj(), rtol=rtol, atol=atol)
 
-    def asqobj(self) -> Qobj | list[Qobj]:
+    def to_qutip(self) -> Qobj | list[Qobj]:
         return _dense_to_qobj(self)
 
-    def asjaxarray(self) -> Array:
+    def to_jax(self) -> Array:
         return self.data
 
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
@@ -145,7 +153,7 @@ class DenseQArray(QArray):
         elif isinstance(y, DenseQArray):
             data = self.data * y.data
         elif isqarraylike(y):
-            data = self.data * _asjaxarray(y)
+            data = self.data * _to_jax(y)
         else:
             return NotImplemented
 
@@ -159,7 +167,7 @@ class DenseQArray(QArray):
         elif isinstance(y, DenseQArray):
             data = self.data / y.data
         elif isqarraylike(y):
-            data = self.data / _asjaxarray(y)
+            data = self.data / _to_jax(y)
         else:
             return NotImplemented
 
@@ -173,7 +181,7 @@ class DenseQArray(QArray):
         elif isinstance(y, DenseQArray):
             data = self.data + y.data
         elif isinstance(y, get_args(ArrayLike)):
-            data = self.data + _asjaxarray(y)
+            data = self.data + _to_jax(y)
         else:
             return NotImplemented
 
@@ -187,7 +195,7 @@ class DenseQArray(QArray):
             data = self.data @ y.data
         elif isqarraylike(y):
             dims = self.dims
-            data = self.data @ _asjaxarray(y)
+            data = self.data @ _to_jax(y)
         else:
             return NotImplemented
 
@@ -204,7 +212,7 @@ class DenseQArray(QArray):
             data = y.data @ self.data
         elif isqarraylike(y):
             dims = self.dims
-            data = _asjaxarray(y) @ self.data
+            data = _to_jax(y) @ self.data
         else:
             return NotImplemented
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -129,7 +129,7 @@ class DenseQArray(QArray):
         return self
 
     def assparsedia(self) -> SparseDIAQArray:
-        from .sparse_dia_qarray import _array_to_sparsedia
+        from .sparsedia_qarray import _array_to_sparsedia
 
         return _array_to_sparsedia(self.data, dims=self.dims)
 

--- a/dynamiqs/qarrays/layout.py
+++ b/dynamiqs/qarrays/layout.py
@@ -19,9 +19,11 @@ dia = Layout.DIA
 
 _DEFAULT_LAYOUT = dia
 
+
 def set_global_layout(layout: Layout):
     global _DEFAULT_LAYOUT  # noqa: PLW0603
     _DEFAULT_LAYOUT = layout
+
 
 def get_layout(layout: Layout | None = None) -> Layout:
     if layout is None:

--- a/dynamiqs/qarrays/layout.py
+++ b/dynamiqs/qarrays/layout.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 
 
@@ -14,3 +16,20 @@ class Layout(Enum):
 
 dense = Layout.DENSE
 dia = Layout.DIA
+
+_DEFAULT_LAYOUT = dia
+
+def set_global_layout(layout: Layout):
+    global _DEFAULT_LAYOUT  # noqa: PLW0603
+    _DEFAULT_LAYOUT = layout
+
+def get_layout(layout: Layout | None = None) -> Layout:
+    if layout is None:
+        return _DEFAULT_LAYOUT
+    elif isinstance(layout, Layout):
+        return layout
+    else:
+        raise TypeError(
+            'Argument `layout` must be `dq.dense`, `dq.dia` or `None`, but is'
+            f' `{layout}`.'
+        )

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -27,13 +27,13 @@ def isqarraylike(x: Any) -> bool:
     return False
 
 
-def _asjaxarray(x: QArrayLike) -> Array:
+def _to_jax(x: QArrayLike) -> Array:
     if isinstance(x, QArray):
-        return x.asjaxarray()
+        return x.to_jax()
     elif isinstance(x, Qobj):
         return jnp.asarray(x.full())
     elif isinstance(x, Sequence):
-        return jnp.asarray([_asjaxarray(sub_x) for sub_x in x])
+        return jnp.asarray([_to_jax(sub_x) for sub_x in x])
     else:
         return jnp.asarray(x)
 
@@ -68,7 +68,7 @@ class QArray(eqx.Module):
     #                     _abs
     #   - returning a JAX array or other: norm, trace, sum, squeeze, _eigh, _eigvals,
     #                                     _eigvalsh, devices, isherm
-    #   - conversion methods: asqobj, asjaxarray, __array__
+    #   - conversion methods: to_qutip, to_jax, __array__
     #   - special methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
     #                         __and__, _pow, __getitem__
 
@@ -334,7 +334,7 @@ class QArray(eqx.Module):
         return proj(self)
 
     @abstractmethod
-    def asqobj(self) -> Qobj | list[Qobj]:
+    def to_qutip(self) -> Qobj | list[Qobj]:
         """Convert the quantum state to a QuTiP object.
 
         Returns:
@@ -342,7 +342,7 @@ class QArray(eqx.Module):
         """
 
     @abstractmethod
-    def asjaxarray(self) -> Array:
+    def to_jax(self) -> Array:
         """Convert the quantum state to a JAX array.
 
         Returns:
@@ -359,7 +359,7 @@ class QArray(eqx.Module):
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
         pass
 
-    def asnparray(self) -> np.ndarray:
+    def to_numpy(self) -> np.ndarray:
         """Convert the quantum state to a NumPy array.
 
         Returns:

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -224,6 +224,9 @@ class SparseDIAQArray(QArray):
     def asdense(self) -> DenseQArray:
         return _sparsedia_to_dense(self)
 
+    def assparsedia(self) -> SparseDIAQArray:
+        return self
+
     def isherm(self) -> bool:
         raise NotImplementedError
 

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -19,9 +19,9 @@ from .layout import Layout, dia
 from .qarray import (
     QArray,
     QArrayLike,
-    _asjaxarray,
     _in_last_two_dims,
     _include_last_two_dims,
+    _to_jax,
     isqarraylike,
 )
 
@@ -65,7 +65,7 @@ def _construct_diags(offsets: tuple[int, ...], x: Array) -> Array:
 
 
 def _sparsedia_to_qobj(x: SparseDIAQArray) -> Qobj | list[Qobj]:
-    return x.to_dense().asqobj()
+    return x.asdense().to_qutip()
 
 
 class SparseDIAQArray(QArray):
@@ -195,7 +195,7 @@ class SparseDIAQArray(QArray):
             if _include_last_two_dims(axis, self.ndim):
                 return self.diags.sum(axis)
             else:
-                return self.asjaxarray().sum(axis)
+                return self.to_jax().sum(axis)
         else:
             return SparseDIAQArray(self.dims, self.offsets, self.diags.sum(axis))
 
@@ -205,7 +205,7 @@ class SparseDIAQArray(QArray):
             if _include_last_two_dims(axis, self.ndim):
                 return self.diags.squeeze(axis)
             else:
-                return self.asjaxarray().squeeze(axis)
+                return self.to_jax().squeeze(axis)
         else:
             return SparseDIAQArray(self.dims, self.offsets, self.diags.squeeze(axis))
 
@@ -221,20 +221,20 @@ class SparseDIAQArray(QArray):
     def devices(self) -> set[jax.Device]:
         raise NotImplementedError
 
-    def to_dense(self) -> DenseQArray:
+    def asdense(self) -> DenseQArray:
         return _sparsedia_to_dense(self)
 
     def isherm(self) -> bool:
         raise NotImplementedError
 
-    def asqobj(self) -> Qobj | list[Qobj]:
+    def to_qutip(self) -> Qobj | list[Qobj]:
         return _sparsedia_to_qobj(self)
 
-    def asjaxarray(self) -> Array:
-        return self.to_dense().asjaxarray()
+    def to_jax(self) -> Array:
+        return self.asdense().to_jax()
 
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
-        return self.to_dense().__array__(dtype=dtype, copy=copy)
+        return self.asdense().__array__(dtype=dtype, copy=copy)
 
     def __repr__(self) -> str:
         # === array representation with dots instead of zeros
@@ -242,7 +242,7 @@ class SparseDIAQArray(QArray):
         pattern = r'0\.\s*\+0\.j'
         # replace with a centered dot of the same length as the matched string
         replace_with_dot = lambda match: f"{'⋅':^{len(match.group(0))}}"
-        data_str = re.sub(pattern, replace_with_dot, str(self.asjaxarray()))
+        data_str = re.sub(pattern, replace_with_dot, str(self.to_jax()))
         return super().__repr__() + f', ndiags={self.ndiags}\n{data_str}'
 
     def __mul__(self, other: QArrayLike) -> QArray:
@@ -253,7 +253,7 @@ class SparseDIAQArray(QArray):
         elif isinstance(other, SparseDIAQArray):
             return self._mul_sparse(other)
         elif isqarraylike(other):
-            other = _asjaxarray(other)
+            other = _to_jax(other)
             return self._mul_dense(other)
 
         return NotImplemented
@@ -319,13 +319,13 @@ class SparseDIAQArray(QArray):
             return self._add_sparse(other)
         elif isqarraylike(other):
             warnings.warn(warning_dense_addition, stacklevel=2)
-            other = _asjaxarray(other)
+            other = _to_jax(other)
             return self._add_dense(other)
 
         return NotImplemented
 
     def _add_scalar(self, other: QArrayLike) -> QArray:
-        return self.to_dense() + other
+        return self.asdense() + other
 
     def _add_sparse(self, other: SparseDIAQArray) -> QArray:
         # compute the output offsets
@@ -348,7 +348,7 @@ class SparseDIAQArray(QArray):
         return SparseDIAQArray(self.dims, _numpy_to_tuple(out_offsets), out_diags)
 
     def _add_dense(self, other: Array) -> QArray:
-        return self.to_dense() + other
+        return self.asdense() + other
 
     def __matmul__(self, other: QArrayLike) -> QArray:
         if _is_batched_scalar(other):
@@ -357,7 +357,7 @@ class SparseDIAQArray(QArray):
         if isinstance(other, SparseDIAQArray):
             return self._matmul_dia(other)
         elif isqarraylike(other):
-            other = _asjaxarray(other)
+            other = _to_jax(other)
             return self._matmul_dense(other, left_matmul=True)
 
         return NotImplemented
@@ -367,7 +367,7 @@ class SparseDIAQArray(QArray):
             raise TypeError('Attempted matrix product between a scalar and a QArray.')
 
         if isqarraylike(other):
-            other = _asjaxarray(other)
+            other = _to_jax(other)
             return self._matmul_dense(other, left_matmul=False)
 
         return NotImplemented
@@ -427,13 +427,13 @@ class SparseDIAQArray(QArray):
         if isinstance(other, SparseDIAQArray):
             return self._and_dia(other)
         elif isinstance(other, DenseQArray):
-            return self.to_dense() & other
+            return self.asdense() & other
         else:
             return NotImplemented
 
     def __rand__(self, other: QArray) -> QArray:
         if isinstance(other, DenseQArray):
-            return other & self.to_dense()
+            return other & self.asdense()
         else:
             return NotImplemented
 

--- a/dynamiqs/qarrays/type_conversion.py
+++ b/dynamiqs/qarrays/type_conversion.py
@@ -10,7 +10,7 @@ from qutip import Qobj
 
 from .._checks import check_shape
 from .dense_qarray import DenseQArray, _dense_to_qobj
-from .layout import Layout, dense, get_layout
+from .layout import Layout, dense
 from .qarray import QArray, QArrayLike, _dims_from_qutip, _dims_to_qutip, _to_jax
 from .sparsedia_qarray import (
     SparseDIAQArray,
@@ -24,9 +24,12 @@ __all__ = ['asqarray', 'to_jax', 'to_qutip', 'sparsedia_from_dict']
 
 
 def asqarray(
-    x: QArrayLike, dims: tuple[int, ...] | None = None, layout: Layout = None
+    x: QArrayLike, dims: tuple[int, ...] | None = None, layout: Layout | None = None
 ) -> QArray:
-    layout = get_layout(layout)
+    if layout is None and isinstance(x, QArray):
+        return x
+
+    layout = dense if layout is None else layout
     if layout is dense:
         return _asdense(x, dims=dims)
     else:

--- a/dynamiqs/random.py
+++ b/dynamiqs/random.py
@@ -117,7 +117,7 @@ def herm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
             f'Argument `shape` must be of the form (..., n, n), but is shape={shape}.'
         )
     x = complex(key, shape)
-    return 0.5 * (x + dag(x).asjaxarray())
+    return 0.5 * (x + dag(x).to_jax())
 
 
 def psd(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
@@ -142,7 +142,7 @@ def psd(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
             f'Argument `shape` must be of the form (..., n, n), but is shape={shape}.'
         )
     x = complex(key, shape)
-    return x @ dag(x).asjaxarray()
+    return x @ dag(x).to_jax()
 
 
 def dm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
@@ -167,7 +167,7 @@ def dm(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
             f'Argument `shape` must be of the form (..., n, n), but is shape={shape}.'
         )
     x = psd(key, shape)
-    return unit(x).asjaxarray()
+    return unit(x).to_jax()
 
 
 def ket(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
@@ -191,4 +191,4 @@ def ket(key: PRNGKeyArray, shape: tuple[int, ...]) -> Array:
             f'Argument `shape` must be of the form (..., n, 1), but is shape={shape}.'
         )
     x = complex(key, shape)
-    return unit(x).asjaxarray()
+    return unit(x).to_jax()

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -7,7 +7,7 @@ from jaxtyping import PyTree
 from .gradient import Gradient
 from .options import Options
 from .qarrays.qarray import QArray
-from .qarrays.type_conversion import asjaxarray
+from .qarrays.type_conversion import to_jax
 from .solver import Solver
 
 __all__ = [
@@ -38,7 +38,7 @@ def array_str(x: Array | QArray | None) -> str | None:
     if x is None:
         return None
     type_name = 'Array' if isinstance(x, Array) else 'QArray'
-    x = asjaxarray(x)
+    x = to_jax(x)
     return f'{type_name} {x.dtype} {tuple(x.shape)} | {memory_str(x)}'
 
 
@@ -72,10 +72,10 @@ class Result(eqx.Module):
     def extra(self) -> PyTree | None:
         return self._saved.extra
 
-    def asqobj(self) -> Result:
+    def to_qutip(self) -> Result:
         raise NotImplementedError
 
-    def asnparray(self) -> Result:
+    def to_numpy(self) -> Result:
         raise NotImplementedError
 
     def block_until_ready(self) -> Result:

--- a/dynamiqs/utils/global_settings.py
+++ b/dynamiqs/utils/global_settings.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 import jax
 
-from ..qarrays.layout import Layout, dense, dia
+from ..qarrays.layout import dense, dia, set_global_layout
 
 __all__ = ['set_device', 'set_precision', 'set_matmul_precision', 'set_layout']
 
@@ -93,9 +93,6 @@ def set_matmul_precision(matmul_precision: Literal['low', 'high', 'highest']):
         )
 
 
-_DEFAULT_LAYOUT = dia
-
-
 def set_layout(layout: Literal['dense', 'dia']):
     """Configure the default matrix layout for operators supporting this option.
 
@@ -133,17 +130,4 @@ def set_layout(layout: Literal['dense', 'dia']):
             f"Argument `layout` should be a string 'dense' or 'dia', but is {layout}."
         )
 
-    global _DEFAULT_LAYOUT  # noqa: PLW0603
-    _DEFAULT_LAYOUT = layouts[layout]
-
-
-def get_layout(layout: Layout | None = None) -> Layout:
-    if layout is None:
-        return _DEFAULT_LAYOUT
-    elif isinstance(layout, Layout):
-        return layout
-    else:
-        raise TypeError(
-            'Argument `layout` must be `dq.dense`, `dq.dia` or `None`, but is'
-            f' `{layout}`.'
-        )
+    set_global_layout(layouts[layout])

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -10,8 +10,7 @@ from ..qarrays.dense_qarray import DenseQArray
 from ..qarrays.layout import Layout, dense, get_layout
 from ..qarrays.qarray import QArray
 from ..qarrays.sparsedia_qarray import SparseDIAQArray
-from ..qarrays.type_conversion import asqarray, sparsedia
-from .global_settings import get_layout
+from ..qarrays.type_conversion import asqarray, sparsedia_from_dict
 from .quantum_utils import tensor
 
 __all__ = [
@@ -84,7 +83,7 @@ def eye(*dims: int, layout: Layout | None = None) -> QArray:
         return asqarray(array, dims=dims)
     else:
         diag = jnp.ones(dim, dtype=cdtype())
-        return sparsedia({0: diag}, dims=dims)
+        return sparsedia_from_dict({0: diag}, dims=dims)
 
 
 def zero(*dims: int, layout: Layout | None = None) -> QArray:
@@ -187,7 +186,7 @@ def destroy(*dims: int, layout: Layout | None = None) -> QArray | tuple[QArray, 
         if layout is dense:
             return asqarray(jnp.diag(diag, k=1))
         else:
-            return sparsedia({1: diag})
+            return sparsedia_from_dict({1: diag})
 
     if len(dims) == 1:
         return destroy_single(dims[0])
@@ -255,7 +254,7 @@ def create(*dims: int, layout: Layout | None = None) -> QArray | tuple[QArray, .
         if layout is dense:
             return asqarray(jnp.diag(diag, k=-1))
         else:
-            return sparsedia({-1: diag})
+            return sparsedia_from_dict({-1: diag})
 
     if len(dims) == 1:
         return create_single(dims[0])
@@ -324,7 +323,7 @@ def number(*dims: int, layout: Layout | None = None) -> QArray | tuple[QArray, .
         if layout is dense:
             return asqarray(jnp.diag(diag))
         else:
-            return sparsedia({0: diag})
+            return sparsedia_from_dict({0: diag})
 
     if len(dims) == 1:
         return number_single(dims[0])
@@ -363,7 +362,7 @@ def parity(dim: int, *, layout: Layout | None = None) -> QArray:
     if layout is dense:
         return asqarray(jnp.diag(diag))
     else:
-        return sparsedia({0: diag})
+        return sparsedia_from_dict({0: diag})
 
 
 def displace(dim: int, alpha: ArrayLike) -> DenseQArray:
@@ -525,7 +524,7 @@ def sigmax(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, 1], [1, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia({-1: [1], 1: [1]}, dtype=cdtype())
+        return sparsedia_from_dict({-1: [1], 1: [1]}, dtype=cdtype())
 
 
 def sigmay(*, layout: Layout | None = None) -> QArray:
@@ -550,7 +549,7 @@ def sigmay(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, -1j], [1j, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia({-1: [1j], 1: [-1j]}, dtype=cdtype())
+        return sparsedia_from_dict({-1: [1j], 1: [-1j]}, dtype=cdtype())
 
 
 def sigmaz(*, layout: Layout | None = None) -> QArray:
@@ -575,7 +574,7 @@ def sigmaz(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[1, 0], [0, -1]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia({0: [1, -1]}, dtype=cdtype())
+        return sparsedia_from_dict({0: [1, -1]}, dtype=cdtype())
 
 
 def sigmap(*, layout: Layout | None = None) -> QArray:
@@ -601,7 +600,7 @@ def sigmap(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, 1], [0, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia({1: [1]}, dtype=cdtype())
+        return sparsedia_from_dict({1: [1]}, dtype=cdtype())
 
 
 def sigmam(*, layout: Layout | None = None) -> QArray:
@@ -627,7 +626,7 @@ def sigmam(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, 0], [1, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia({-1: [1]}, dtype=cdtype())
+        return sparsedia_from_dict({-1: [1]}, dtype=cdtype())
 
 
 def hadamard(n: int = 1) -> QArray:

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -7,7 +7,7 @@ from jax.typing import ArrayLike
 
 from .._utils import cdtype
 from ..qarrays.dense_qarray import DenseQArray
-from ..qarrays.layout import Layout, dense
+from ..qarrays.layout import Layout, dense, get_layout
 from ..qarrays.qarray import QArray
 from ..qarrays.sparsedia_qarray import SparseDIAQArray
 from ..qarrays.type_conversion import asqarray, sparsedia

--- a/dynamiqs/utils/quantum_utils/general.py
+++ b/dynamiqs/utils/quantum_utils/general.py
@@ -12,7 +12,7 @@ from ..._checks import check_shape
 from ..._utils import on_cpu
 from ...qarrays.dense_qarray import DenseQArray
 from ...qarrays.qarray import QArray, QArrayLike
-from ...qarrays.type_conversion import asjaxarray, asqarray
+from ...qarrays.type_conversion import asqarray, to_jax
 
 __all__ = [
     'dag',
@@ -231,7 +231,7 @@ def tracemm(x: QArrayLike, y: QArrayLike) -> Array:
     check_shape(x, 'x', '(..., n, n)')
     check_shape(y, 'y', '(..., n, n)')
     # todo: fix perf
-    return (x.asjaxarray() * y.asjaxarray().mT).sum((-2, -1))
+    return (x.to_jax() * y.to_jax().mT).sum((-2, -1))
 
 
 def _hdim(x: QArrayLike) -> int:
@@ -449,7 +449,7 @@ def norm(x: QArrayLike) -> Array:
 
     if isket(x) or isbra(x):
         assert isinstance(x, DenseQArray)
-        return jnp.sqrt((jnp.abs(x.asjaxarray()) ** 2).sum((-2, -1)))
+        return jnp.sqrt((jnp.abs(x.to_jax()) ** 2).sum((-2, -1)))
     else:
         return trace(x).real
 
@@ -1062,7 +1062,7 @@ def bloch_coordinates(x: QArrayLike) -> Array:
         >>> dq.bloch_coordinates(x)
         Array([0.5, 0. , 0. ], dtype=float32)
     """
-    x = asjaxarray(x)  # todo: temporary fix
+    x = to_jax(x)  # todo: temporary fix
     check_shape(x, 'x', '(2, 1)', '(2, 2)')
 
     if isket(x):

--- a/dynamiqs/utils/quantum_utils/general.py
+++ b/dynamiqs/utils/quantum_utils/general.py
@@ -11,6 +11,7 @@ from jaxtyping import ArrayLike
 from ..._checks import check_shape
 from ..._utils import on_cpu
 from ...qarrays.dense_qarray import DenseQArray
+from ...qarrays.layout import dense
 from ...qarrays.qarray import QArray, QArrayLike
 from ...qarrays.type_conversion import asqarray, to_jax
 
@@ -905,8 +906,8 @@ def fidelity(x: QArrayLike, y: QArrayLike) -> Array:
         >>> dq.fidelity(fock0, fock01_dm)
         Array(0.5, dtype=float32)
     """
-    x = asqarray(x)
-    y = asqarray(y)
+    x = asqarray(x, layout=dense)
+    y = asqarray(y, layout=dense)
     check_shape(x, 'x', '(..., n, 1)', '(..., n, n)')
     check_shape(y, 'y', '(..., n, 1)', '(..., n, n)')
 

--- a/dynamiqs/utils/quantum_utils/general.py
+++ b/dynamiqs/utils/quantum_utils/general.py
@@ -11,7 +11,6 @@ from jaxtyping import ArrayLike
 from ..._checks import check_shape
 from ..._utils import on_cpu
 from ...qarrays.dense_qarray import DenseQArray
-from ...qarrays.layout import dense
 from ...qarrays.qarray import QArray, QArrayLike
 from ...qarrays.type_conversion import asqarray, to_jax
 
@@ -906,8 +905,8 @@ def fidelity(x: QArrayLike, y: QArrayLike) -> Array:
         >>> dq.fidelity(fock0, fock01_dm)
         Array(0.5, dtype=float32)
     """
-    x = asqarray(x, layout=dense)
-    y = asqarray(y, layout=dense)
+    x = asqarray(x)
+    y = asqarray(y)
     check_shape(x, 'x', '(..., n, 1)', '(..., n, n)')
     check_shape(y, 'y', '(..., n, 1)', '(..., n, n)')
 

--- a/dynamiqs/utils/quantum_utils/wigner.py
+++ b/dynamiqs/utils/quantum_utils/wigner.py
@@ -9,7 +9,7 @@ from jaxtyping import ArrayLike
 
 from ..._checks import check_shape
 from ...qarrays.qarray import QArrayLike
-from ...qarrays.type_conversion import asjaxarray
+from ...qarrays.type_conversion import to_jax
 from .general import todm
 
 __all__ = ['wigner']
@@ -49,11 +49,11 @@ def wigner(
                 `yvec` if specified.
             - **w** _(array of shape (..., npixels, npixels) or (..., nyvec, nxvec))_ -- Wigner distribution.
     """  # noqa: E501
-    state = asjaxarray(state)
+    state = to_jax(state)
     check_shape(state, 'state', '(..., n, 1)', '(..., n, n)')
 
     # === convert state to density matrix
-    state = asjaxarray(todm(state))
+    state = to_jax(todm(state))
 
     # === prepare xvec and yvec
     xvec = jnp.linspace(-xmax, xmax, npixels) if xvec is None else jnp.asarray(xvec)

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -9,7 +9,7 @@ from jax.typing import ArrayLike
 from .._checks import check_type_int
 from .._utils import cdtype
 from ..qarrays.qarray import QArray
-from ..qarrays.type_conversion import asjaxarray, asqarray
+from ..qarrays.type_conversion import asqarray, to_jax
 from .operators import displace
 from .quantum_utils import tensor
 
@@ -244,7 +244,7 @@ def coherent(dim: int | tuple[int, ...], alpha: ArrayLike | list[ArrayLike]) -> 
         >>> dq.coherent((8, 8), (alpha1[None, :], alpha2[:, None])).shape
         (7, 5, 64, 1)
     """
-    dim = asjaxarray(dim)
+    dim = to_jax(dim)
     check_type_int(dim, 'dim')
 
     # check if dim is a single value or a tuple

--- a/tests/integrator_tester.py
+++ b/tests/integrator_tester.py
@@ -30,7 +30,7 @@ class IntegratorTester:
         # === test ysave
         true_ysave = system.states(system.tsave)
         errs = jnp.linalg.norm(
-            true_ysave.asjaxarray() - result.states.asjaxarray(), axis=(-2, -1)
+            true_ysave.to_jax() - result.states.to_jax(), axis=(-2, -1)
         )
         logging.warning(f'true_ysave = {true_ysave}')
         logging.warning(f'ysave      = {result.states}')

--- a/tests/qarrays/test_sparse_dia_qarray.py
+++ b/tests/qarrays/test_sparse_dia_qarray.py
@@ -48,7 +48,7 @@ class TestSparseDIAQArray:
         )
 
         sparseA = dq.SparseDIAQArray(diags=diagsA, offsets=offsetsA, dims=(N,))
-        denseA = dq.asdense(sparseA)
+        denseA = sparseA.asdense()
 
         self.denseA = make_dictA(denseA)
         self.sparseA = make_dictA(sparseA)
@@ -61,7 +61,7 @@ class TestSparseDIAQArray:
         )
 
         sparseB = dq.SparseDIAQArray(diags=diagsB, offsets=offsetsB, dims=(N,))
-        denseB = dq.asdense(sparseB)
+        denseB = sparseB.asdense()
 
         self.denseB = make_dictB(denseB)
         self.sparseB = make_dictB(sparseB)
@@ -69,8 +69,8 @@ class TestSparseDIAQArray:
     @pytest.mark.parametrize('kA', ['simple', 'batch', 'batch_broadcast'])
     def test_convert(self, kA, rtol=1e-05, atol=1e-08):
         assert jnp.allclose(
-            self.denseA[kA].asjaxarray(),
-            dq.assparsedia(self.denseA[kA]).asjaxarray(),
+            self.denseA[kA].to_jax(),
+            self.denseA[kA].assparsedia().to_jax(),
             rtol=rtol,
             atol=atol,
         )
@@ -80,19 +80,19 @@ class TestSparseDIAQArray:
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
 
-        out_dense_dense = (dA + dB).asjaxarray()
+        out_dense_dense = (dA + dB).to_jax()
 
-        out_dia_dia = dq.asdense(sA + sB).asjaxarray()
+        out_dia_dia = (sA + sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
-            out_dia_dense = (sA + dB).asjaxarray()
+            out_dia_dense = (sA + dB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
-            out_dense_dia = (dA + sB).asjaxarray()
+            out_dense_dia = (dA + sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
 
     @pytest.mark.parametrize(('kA', 'kB'), valid_operation_keys)
@@ -100,18 +100,18 @@ class TestSparseDIAQArray:
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
 
-        out_dense_dense = (dA - dB).asjaxarray()
-        out_dia_dia = dq.asdense(sA - sB).asjaxarray()
+        out_dense_dense = (dA - dB).to_jax()
+        out_dia_dia = (sA - sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
-            out_dia_dense = (sA - dB).asjaxarray()
+            out_dia_dense = (sA - dB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
-            out_dense_dia = (dA - sB).asjaxarray()
+            out_dense_dia = (dA - sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
 
     @pytest.mark.parametrize(('kA', 'kB'), valid_operation_keys)
@@ -119,15 +119,15 @@ class TestSparseDIAQArray:
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
 
-        out_dense_dense = (dA * dB).asjaxarray()
+        out_dense_dense = (dA * dB).to_jax()
 
-        out_dia_dia = dq.asdense(sA * sB).asjaxarray()
+        out_dia_dia = (sA * sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
 
-        out_dia_dense = (sA * dB).asjaxarray()
+        out_dia_dense = (sA * dB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
 
-        out_dense_dia = (dA * sB).asjaxarray()
+        out_dense_dia = (dA * sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
 
     @pytest.mark.parametrize(('kA', 'kB'), valid_operation_keys)
@@ -135,27 +135,27 @@ class TestSparseDIAQArray:
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
 
-        out_dense_dense = (dA @ dB).asjaxarray()
+        out_dense_dense = (dA @ dB).to_jax()
 
-        out_dia_dia = dq.asdense(sA @ sB).asjaxarray()
+        out_dia_dia = (sA @ sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
 
-        out_dia_dense = (sA @ dB).asjaxarray()
+        out_dia_dense = (sA @ dB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
 
-        out_dense_dia = (dA @ sB).asjaxarray()
+        out_dense_dia = (dA @ sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
 
     def test_kronecker(self, rtol=1e-05, atol=1e-08):
         dA, sA = self.denseA['simple'], self.sparseA['simple']
         dB, sB = self.denseB['simple'], self.sparseB['simple']
 
-        out_dense_dense = (dA & dB).asjaxarray()
+        out_dense_dense = (dA & dB).to_jax()
 
-        out_dia_dia = (sA & sB).asjaxarray()
+        out_dia_dia = (sA & sB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
 
-        out_dia_dense = (sA & dB).asjaxarray()
+        out_dia_dense = (sA & dB).to_jax()
         assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
 
     def test_outofbounds(self):
@@ -173,8 +173,8 @@ class TestSparseDIAQArray:
     def test_pow(self, k, rtol=1e-05, atol=1e-08):
         d, s = self.denseA[k], self.sparseA[k]
 
-        out_dense = (d**3).asjaxarray()
-        out_dia = dq.asdense(s**3).asjaxarray()
+        out_dense = (d**3).to_jax()
+        out_dia = (s**3).to_jax()
 
         assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)
 
@@ -182,7 +182,7 @@ class TestSparseDIAQArray:
     def test_powm(self, k, rtol=1e-05, atol=1e-08):
         d, s = self.denseA[k], self.sparseA[k]
 
-        out_dense = d.powm(3).asjaxarray()
-        out_dia = s.powm(3).asjaxarray()
+        out_dense = d.powm(3).to_jax()
+        out_dia = s.powm(3).to_jax()
 
         assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)

--- a/tests/qarrays/test_utils.py
+++ b/tests/qarrays/test_utils.py
@@ -40,7 +40,7 @@ def test_stack_double(rtol=1e-05, atol=1e-08):
     jax_m1 = jnp.stack([jax_m1, 2 * jax_m1, 3 * jax_m1])
 
     jax_m2 = jr.uniform(k2, (n, n))
-    dense_m2, sparse_m2 = dq.asqarray(jax_m2, layout=dq.dense)
+    dense_m2 = dq.asqarray(jax_m2, layout=dq.dense)
     sparse_m2 = dq.asqarray(jax_m2, layout=dq.dia)
     dense_m2 = dq.stack([dense_m2, 2 * dense_m2, 3 * dense_m2])
     sparse_m2 = dq.stack([sparse_m2, 2 * sparse_m2, 3 * sparse_m2])

--- a/tests/qarrays/test_utils.py
+++ b/tests/qarrays/test_utils.py
@@ -9,18 +9,18 @@ def test_stack_simple(rtol=1e-05, atol=1e-08):
     key = jr.key(42)
 
     jax_m = jr.uniform(key, (n, n))
-    dense_m = dq.asqarray(jax_m)
-    sparse_m = dq.assparsedia(jax_m)
+    dense_m = dq.asqarray(jax_m, layout=dq.dense)
+    sparse_m = dq.asqarray(jax_m, layout=dq.dia)
 
     assert jnp.allclose(
-        dq.stack([dense_m, 2 * dense_m]).asjaxarray(),
+        dq.stack([dense_m, 2 * dense_m]).to_jax(),
         jnp.stack([jax_m, 2 * jax_m]),
         rtol=rtol,
         atol=atol,
     )
 
     assert jnp.allclose(
-        dq.stack([sparse_m, 2 * sparse_m]).asjaxarray(),
+        dq.stack([sparse_m, 2 * sparse_m]).to_jax(),
         jnp.stack([jax_m, 2 * jax_m]),
         rtol=rtol,
         atol=atol,
@@ -33,26 +33,28 @@ def test_stack_double(rtol=1e-05, atol=1e-08):
     k1, k2 = jr.split(key)
 
     jax_m1 = jr.uniform(k1, (n, n))
-    dense_m1, sparse_m1 = dq.asqarray(jax_m1), dq.assparsedia(jax_m1)
+    dense_m1 = dq.asqarray(jax_m1, layout=dq.dense)
+    sparse_m1 = dq.asqarray(jax_m1, layout=dq.dia)
     dense_m1 = dq.stack([dense_m1, 2 * dense_m1, 3 * dense_m1])
     sparse_m1 = dq.stack([sparse_m1, 2 * sparse_m1, 3 * sparse_m1])
     jax_m1 = jnp.stack([jax_m1, 2 * jax_m1, 3 * jax_m1])
 
     jax_m2 = jr.uniform(k2, (n, n))
-    dense_m2, sparse_m2 = dq.asqarray(jax_m2), dq.assparsedia(jax_m2)
+    dense_m2, sparse_m2 = dq.asqarray(jax_m2, layout=dq.dense)
+    sparse_m2 = dq.asqarray(jax_m2, layout=dq.dia)
     dense_m2 = dq.stack([dense_m2, 2 * dense_m2, 3 * dense_m2])
     sparse_m2 = dq.stack([sparse_m2, 2 * sparse_m2, 3 * sparse_m2])
     jax_m2 = jnp.stack([jax_m2, 2 * jax_m2, 3 * jax_m2])
 
     assert jnp.allclose(
-        dq.stack([dense_m1, dense_m2]).asjaxarray(),
+        dq.stack([dense_m1, dense_m2]).to_jax(),
         jnp.stack([jax_m1, jax_m2]),
         rtol=rtol,
         atol=atol,
     )
 
     assert jnp.allclose(
-        dq.stack([sparse_m1, sparse_m2]).asjaxarray(),
+        dq.stack([sparse_m1, sparse_m2]).to_jax(),
         jnp.stack([jax_m1, jax_m2]),
         rtol=rtol,
         atol=atol,

--- a/tests/test_time_array.py
+++ b/tests/test_time_array.py
@@ -16,9 +16,9 @@ from dynamiqs.time_array import (
 
 def assert_equal(x, y):
     if isinstance(x, QArray):
-        x = x.asjaxarray()
+        x = x.to_jax()
     if isinstance(y, QArray):
-        y = y.asjaxarray()
+        y = y.to_jax()
     assert jnp.array_equal(x, y)
 
 

--- a/tests/utils/test_operators.py
+++ b/tests/utils/test_operators.py
@@ -24,13 +24,11 @@ def test_operators_dispatch():
     dim = 20
 
     assert jnp.allclose(
-        dq.eye(*dims, layout=dq.dense).to_jax(),
-        dq.eye(*dims, layout=dq.dia).to_jax(),
+        dq.eye(*dims, layout=dq.dense).to_jax(), dq.eye(*dims, layout=dq.dia).to_jax()
     )
 
     assert jnp.allclose(
-        dq.zero(*dims, layout=dq.dense).to_jax(),
-        dq.zero(*dims, layout=dq.dia).to_jax(),
+        dq.zero(*dims, layout=dq.dense).to_jax(), dq.zero(*dims, layout=dq.dia).to_jax()
     )
 
     # === dq.destroy ===
@@ -60,13 +58,11 @@ def test_operators_dispatch():
     # === end dq.create ===
 
     assert jnp.allclose(
-        dq.number(dim, layout=dq.dense).to_jax(),
-        dq.number(dim, layout=dq.dia).to_jax(),
+        dq.number(dim, layout=dq.dense).to_jax(), dq.number(dim, layout=dq.dia).to_jax()
     )
 
     assert jnp.allclose(
-        dq.parity(dim, layout=dq.dense).to_jax(),
-        dq.parity(dim, layout=dq.dia).to_jax(),
+        dq.parity(dim, layout=dq.dense).to_jax(), dq.parity(dim, layout=dq.dia).to_jax()
     )
 
     assert jnp.allclose(

--- a/tests/utils/test_operators.py
+++ b/tests/utils/test_operators.py
@@ -24,82 +24,82 @@ def test_operators_dispatch():
     dim = 20
 
     assert jnp.allclose(
-        dq.eye(*dims, layout=dq.dense).asjaxarray(),
-        dq.eye(*dims, layout=dq.dia).asjaxarray(),
+        dq.eye(*dims, layout=dq.dense).to_jax(),
+        dq.eye(*dims, layout=dq.dia).to_jax(),
     )
 
     assert jnp.allclose(
-        dq.zero(*dims, layout=dq.dense).asjaxarray(),
-        dq.zero(*dims, layout=dq.dia).asjaxarray(),
+        dq.zero(*dims, layout=dq.dense).to_jax(),
+        dq.zero(*dims, layout=dq.dia).to_jax(),
     )
 
     # === dq.destroy ===
 
     assert jnp.allclose(
-        dq.destroy(*dims, layout=dq.dense)[0].asjaxarray(),
-        dq.destroy(*dims, layout=dq.dia)[0].asjaxarray(),
+        dq.destroy(*dims, layout=dq.dense)[0].to_jax(),
+        dq.destroy(*dims, layout=dq.dia)[0].to_jax(),
     )
 
     assert jnp.allclose(
-        dq.destroy(*dims, layout=dq.dense)[1].asjaxarray(),
-        dq.destroy(*dims, layout=dq.dia)[1].asjaxarray(),
+        dq.destroy(*dims, layout=dq.dense)[1].to_jax(),
+        dq.destroy(*dims, layout=dq.dia)[1].to_jax(),
     )
 
     # === dq.create ===
 
     assert jnp.allclose(
-        dq.create(*dims, layout=dq.dense)[0].asjaxarray(),
-        dq.create(*dims, layout=dq.dia)[0].asjaxarray(),
+        dq.create(*dims, layout=dq.dense)[0].to_jax(),
+        dq.create(*dims, layout=dq.dia)[0].to_jax(),
     )
 
     assert jnp.allclose(
-        dq.create(*dims, layout=dq.dense)[1].asjaxarray(),
-        dq.create(*dims, layout=dq.dia)[1].asjaxarray(),
+        dq.create(*dims, layout=dq.dense)[1].to_jax(),
+        dq.create(*dims, layout=dq.dia)[1].to_jax(),
     )
 
     # === end dq.create ===
 
     assert jnp.allclose(
-        dq.number(dim, layout=dq.dense).asjaxarray(),
-        dq.number(dim, layout=dq.dia).asjaxarray(),
+        dq.number(dim, layout=dq.dense).to_jax(),
+        dq.number(dim, layout=dq.dia).to_jax(),
     )
 
     assert jnp.allclose(
-        dq.parity(dim, layout=dq.dense).asjaxarray(),
-        dq.parity(dim, layout=dq.dia).asjaxarray(),
+        dq.parity(dim, layout=dq.dense).to_jax(),
+        dq.parity(dim, layout=dq.dia).to_jax(),
     )
 
     assert jnp.allclose(
-        dq.quadrature(dim, 0.0, layout=dq.dense).asjaxarray(),
-        dq.quadrature(dim, 0.0, layout=dq.dia).asjaxarray(),
+        dq.quadrature(dim, 0.0, layout=dq.dense).to_jax(),
+        dq.quadrature(dim, 0.0, layout=dq.dia).to_jax(),
     )
 
     assert jnp.allclose(
-        dq.position(dim, layout=dq.dense).asjaxarray(),
-        dq.position(dim, layout=dq.dia).asjaxarray(),
+        dq.position(dim, layout=dq.dense).to_jax(),
+        dq.position(dim, layout=dq.dia).to_jax(),
     )
 
     assert jnp.allclose(
-        dq.momentum(dim, layout=dq.dense).asjaxarray(),
-        dq.momentum(dim, layout=dq.dia).asjaxarray(),
+        dq.momentum(dim, layout=dq.dense).to_jax(),
+        dq.momentum(dim, layout=dq.dia).to_jax(),
     )
 
     assert jnp.allclose(
-        dq.sigmax(layout=dq.dense).asjaxarray(), dq.sigmax(layout=dq.dia).asjaxarray()
+        dq.sigmax(layout=dq.dense).to_jax(), dq.sigmax(layout=dq.dia).to_jax()
     )
 
     assert jnp.allclose(
-        dq.sigmay(layout=dq.dense).asjaxarray(), dq.sigmay(layout=dq.dia).asjaxarray()
+        dq.sigmay(layout=dq.dense).to_jax(), dq.sigmay(layout=dq.dia).to_jax()
     )
 
     assert jnp.allclose(
-        dq.sigmaz(layout=dq.dense).asjaxarray(), dq.sigmaz(layout=dq.dia).asjaxarray()
+        dq.sigmaz(layout=dq.dense).to_jax(), dq.sigmaz(layout=dq.dia).to_jax()
     )
 
     assert jnp.allclose(
-        dq.sigmap(layout=dq.dense).asjaxarray(), dq.sigmap(layout=dq.dia).asjaxarray()
+        dq.sigmap(layout=dq.dense).to_jax(), dq.sigmap(layout=dq.dia).to_jax()
     )
 
     assert jnp.allclose(
-        dq.sigmam(layout=dq.dense).asjaxarray(), dq.sigmam(layout=dq.dia).asjaxarray()
+        dq.sigmam(layout=dq.dense).to_jax(), dq.sigmam(layout=dq.dia).to_jax()
     )

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -100,13 +100,13 @@ def test_ket_dm_fidelity_batching():
 def test_hadamard():
     # one qubit
     H1 = 2 ** (-1 / 2) * jnp.array([[1, 1], [1, -1]], dtype=cdtype())
-    assert jnp.allclose(dq.hadamard(1).asjaxarray(), H1)
+    assert jnp.allclose(dq.hadamard(1).to_jax(), H1)
 
     # two qubits
     H2 = 0.5 * jnp.array(
         [[1, 1, 1, 1], [1, -1, 1, -1], [1, 1, -1, -1], [1, -1, -1, 1]], dtype=cdtype()
     )
-    assert jnp.allclose(dq.hadamard(2).asjaxarray(), H2)
+    assert jnp.allclose(dq.hadamard(2).to_jax(), H2)
 
     # three qubits
     H3 = 2 ** (-3 / 2) * jnp.array(
@@ -122,7 +122,7 @@ def test_hadamard():
         ],
         dtype=cdtype(),
     )
-    assert jnp.allclose(dq.hadamard(3).asjaxarray(), H3)
+    assert jnp.allclose(dq.hadamard(3).to_jax(), H3)
 
 
 @pytest.mark.skip('broken test')


### PR DESCRIPTION
This PR updates the API of conversion utilities for QArrays and the like.

The proposed API is as follows:
```python
# for internal dynamiqs type conversion
dq.asqarray(x: QArrayLike, dims, layout) -> QArray
QArray.asdense() -> DenseQArray
QArray.assparsedia() -> SparseDIAQArray

# for external libraries
dq.to_qutip(x: QArrayLike, dims) -> Qobj
dq.to_jax(x: QArrayLike) -> Array
dq.to_numpy(x: QArrayLike) -> np.ndarray
QArray.to_qutip() -> Qobj
QArray.to_jax() -> Array
QArray.to_numpy() -> np.ndarray

# constructor helper function
sparsedia_from_dict(offsets_diags) -> SparseDIAQArray
```

Can review commit by commit.