### PR TITLE
Fix dtypes in QArrays

### DIFF
--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -241,8 +241,21 @@ class SparseDIAQArray(QArray):
 
     def __repr__(self) -> str:
         # === array representation with dots instead of zeros
-        # match '0. +0.j' with any number of spaces
-        pattern = r'0\.\s*\+0\.j'
+        if jnp.issubdtype(self.dtype, jnp.complexfloating):
+            # match '0. +0.j' with any number of spaces
+            pattern = r'(?<!\d)0\.\s*(\+|\-)0\.j'
+        elif jnp.issubdtype(self.dtype, jnp.floating):
+            # match '0.' with any number of spaces
+            pattern = r'(?<!\d)0\.\s*'
+        elif jnp.issubdtype(self.dtype, jnp.integer):
+            # match '0' with any number of spaces
+            pattern = r'(?<!\d)0\s*'
+        else:
+            raise ValueError(
+                'Unsupported dtype for SparseDIAQArray representation, got '
+                f'{self.dtype}.'
+            )
+
         # replace with a centered dot of the same length as the matched string
         replace_with_dot = lambda match: f"{'⋅':^{len(match.group(0))}}"
         data_str = re.sub(pattern, replace_with_dot, str(self.to_jax()))

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -395,9 +395,7 @@ class SparseDIAQArray(QArray):
         N = other.diags.shape[-1]
         broadcast_shape = jnp.broadcast_shapes(self.shape[:-2], other.shape[:-2])
         dtype = jnp.promote_types(self.diags.dtype, other.diags.dtype)
-        diag_dict = defaultdict(
-            lambda: jnp.zeros((*broadcast_shape, N), dtype=dtype)
-        )
+        diag_dict = defaultdict(lambda: jnp.zeros((*broadcast_shape, N), dtype=dtype))
 
         for i, self_offset in enumerate(self.offsets):
             self_diag = self.diags[..., i, :]

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -174,7 +174,7 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
                 len(unique_offsets),
                 qarray.diags.shape[-1],
             )
-            updated_diags = jnp.zeros(add_diags_shape)
+            updated_diags = jnp.zeros(add_diags_shape, dtype=qarray.diags.dtype)
             for i, offset in enumerate(qarray.offsets):
                 idx = offset_to_index[offset]
                 updated_diags = updated_diags.at[..., idx, :].set(

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -47,13 +47,13 @@ def asqarray(
 
     Examples:
         >>> dq.asqarray([[1, 0], [0, -1]])
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dense
-        [[ 1.+0.j  0.+0.j]
-         [ 0.+0.j -1.+0.j]]
+        QArray: shape=(2, 2), dims=(2,), dtype=int32, layout=dense
+        [[ 1  0]
+         [ 0 -1]]
         >>> dq.asqarray([[1, 0], [0, -1]], layout=dq.dia)
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
-        [[ 1.+0.j    ⋅   ]
-         [   ⋅    -1.+0.j]]
+        QArray: shape=(2, 2), dims=(2,), dtype=int32, layout=dia, ndiags=1
+        [[ 1  ⋅]
+         [ ⋅ -1]]
         >>> dq.asqarray([dq.sigmax(), dq.sigmay(), dq.sigmaz()])
         QArray: shape=(3, 2, 2), dims=(2,), dtype=complex64, layout=dense
         [[[ 0.+0.j  1.+0.j]
@@ -348,19 +348,19 @@ def sparsedia_from_dict(
     Examples:
         >>> dq.sparsedia_from_dict({0: [1, 2, 3], 1: [4, 5], -1: [6, 7]})
         QArray: shape=(3, 3), dims=(3,), dtype=int32, layout=dia, ndiags=3
-        [[1.+0.j 4.+0.j   ⋅   ]
-         [6.+0.j 2.+0.j 5.+0.j]
-         [  ⋅    7.+0.j 3.+0.j]]
+        [[1 4 ⋅]
+         [6 2 5]
+         [⋅ 7 3]]
         >>> dq.sparsedia_from_dict({0: jnp.ones((3, 2))})
         QArray: shape=(3, 2, 2), dims=(2,), dtype=float32, layout=dia, ndiags=1
-        [[[1.+0.j   ⋅   ]
-          [  ⋅    1.+0.j]]
+        [[[1. ⋅ ]
+          [ ⋅ 1.]]
         <BLANKLINE>
-         [[1.+0.j   ⋅   ]
-          [  ⋅    1.+0.j]]
+         [[1. ⋅ ]
+          [ ⋅ 1.]]
         <BLANKLINE>
-         [[1.+0.j   ⋅   ]
-          [  ⋅    1.+0.j]]]
+         [[1. ⋅ ]
+          [ ⋅ 1.]]]
     """
     # === offsets
     offsets = tuple(offsets_diags.keys())

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -9,7 +9,6 @@ from jaxtyping import Array, ArrayLike, DTypeLike
 from qutip import Qobj
 
 from .._checks import check_shape
-from .._utils import cdtype
 from .dense_qarray import DenseQArray, _dense_to_qobj
 from .layout import Layout, dense
 from .qarray import (
@@ -91,7 +90,7 @@ def _asdense(x: QArrayLike, dims: tuple[int, ...] | None = None) -> DenseQArray:
         # the appropriate shape
         return stack([_asdense(sub_x, dims=dims) for sub_x in x])
 
-    x = jnp.asarray(x).astype(cdtype())
+    x = jnp.asarray(x)
     dims = _init_dims(x, dims)
     return DenseQArray(dims, x)
 
@@ -114,7 +113,7 @@ def _assparsedia(x: QArrayLike, dims: tuple[int, ...] | None = None) -> SparseDI
         # the appropriate shape
         return stack([_assparsedia(sub_x, dims=dims) for sub_x in x])
 
-    x = jnp.asarray(x).astype(cdtype())
+    x = jnp.asarray(x)
     dims = _init_dims(x, dims)
     return _array_to_sparsedia(x, dims=dims)
 
@@ -175,7 +174,7 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
                 len(unique_offsets),
                 qarray.diags.shape[-1],
             )
-            updated_diags = jnp.zeros(add_diags_shape, dtype=cdtype())
+            updated_diags = jnp.zeros(add_diags_shape)
             for i, offset in enumerate(qarray.offsets):
                 idx = offset_to_index[offset]
                 updated_diags = updated_diags.at[..., idx, :].set(

--- a/dynamiqs/time_array.py
+++ b/dynamiqs/time_array.py
@@ -206,13 +206,13 @@ def timecallable(
         >>> f = lambda t: dq.asqarray([[t, 0], [0, 1 - t]])
         >>> H = dq.timecallable(f)
         >>> H(0.5)
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dense
-        [[0.5+0.j 0. +0.j]
-         [0. +0.j 0.5+0.j]]
+        QArray: shape=(2, 2), dims=(2,), dtype=float32, layout=dense
+        [[0.5 0. ]
+         [0.  0.5]]
         >>> H(1.0)
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dense
-        [[1.+0.j 0.+0.j]
-         [0.+0.j 0.+0.j]]
+        QArray: shape=(2, 2), dims=(2,), dtype=float32, layout=dense
+        [[1. 0.]
+         [0. 0.]]
     """
     # check f is callable
     if not callable(f):

--- a/dynamiqs/utils/quantum_utils/general.py
+++ b/dynamiqs/utils/quantum_utils/general.py
@@ -189,7 +189,7 @@ def trace(x: QArrayLike) -> Array:
     Examples:
         >>> x = jnp.ones((3, 3))
         >>> dq.trace(x)
-        Array(3.+0.j, dtype=complex64)
+        Array(3., dtype=float32)
     """
     x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
@@ -224,7 +224,7 @@ def tracemm(x: QArrayLike, y: QArrayLike) -> Array:
         >>> x = jnp.ones((3, 3))
         >>> y = jnp.ones((3, 3))
         >>> dq.tracemm(x, y)
-        Array(9.+0.j, dtype=complex64)
+        Array(9., dtype=float32)
     """
     x = asqarray(x)
     y = asqarray(y)


### PR DESCRIPTION
Follow up to https://github.com/dynamiqs/dynamiqs/pull/798 to fix dtypes all around QArrays. The dtype is not enforced to be complex anymore, and is determined from the input data. Fixes some representation bugs for sparse arrays too.