### PR TITLE
Fix bug when summing with an zero sparse qarray

### DIFF
--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -347,7 +347,7 @@ class SparseDIAQArray(QArray):
 
     def _add_sparse(self, other: SparseDIAQArray) -> QArray:
         # compute the output offsets
-        out_offsets = np.union1d(self.offsets, other.offsets)
+        out_offsets = np.union1d(self.offsets, other.offsets).astype(int)
 
         # initialize the output diagonals
         batch_shape = jnp.broadcast_shapes(self.shape[:-2], other.shape[:-2])


### PR DESCRIPTION
Closes https://github.com/dynamiqs/dynamiqs/issues/805.

Bug comes from numpy:
```python
import numpy as np
assert np.union1d((1,), (1,)).dtype == np.int64
assert np.union1d((), (1,)).dtype == np.float64
```