### PR TITLE
Add `block_until_ready()` method to qarrays

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -149,6 +149,10 @@ class DenseQArray(QArray):
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
         return np.asarray(self.data, dtype=dtype)
 
+    def block_until_ready(self) -> QArray:
+        _ = self.data.block_until_ready()
+        return self
+
     def __repr__(self) -> str:
         return super().__repr__() + f'\n{self.data}'
 

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -132,10 +132,10 @@ class QArray(eqx.Module):
     # - the properties: dtype, layout, shape, mT
     # - the methods:
     #   - QArray methods: conj, dag, reshape, broadcast_to, ptrace, powm, expm,
-    #                     _abs
+    #                     _abs, block_until_ready
     #   - returning a JAX array or other: norm, trace, sum, squeeze, _eigh, _eigvals,
     #                                     _eigvalsh, devices, isherm
-    #   - conversion methods: to_qutip, to_jax, __array__
+    #   - conversion/utils methods: to_qutip, to_jax, __array__, block_until_ready
     #   - special methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
     #                         __and__, _pow, __getitem__
 
@@ -343,6 +343,10 @@ class QArray(eqx.Module):
 
     def to_numpy(self) -> np.ndarray:
         return np.asarray(self)
+
+    @abstractmethod
+    def block_until_ready(self) -> QArray:
+        pass
 
     def __repr__(self) -> str:
         return (

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -239,6 +239,10 @@ class SparseDIAQArray(QArray):
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
         return self.asdense().__array__(dtype=dtype, copy=copy)
 
+    def block_until_ready(self) -> QArray:
+        _ = self.diags.block_until_ready()
+        return self
+
     def __repr__(self) -> str:
         # === array representation with dots instead of zeros
         if jnp.issubdtype(self.dtype, jnp.complexfloating):


### PR DESCRIPTION
Fixes
```python
>>> dq.mesolve(...).block_until_ready()
AttributeError: 'DenseQArray' object has no attribute 'block_until_ready'
```