### PR TITLE
Fix `ptrace` for qarrays

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -80,9 +80,7 @@ class DenseQArray(QArray):
     def ptrace(self, *keep: int) -> QArray:
         from ..utils.quantum_utils.general import ptrace
 
-        dims = tuple(self.dims[dim] for dim in keep)
-        data = ptrace(self.data, keep, self.dims)
-        return DenseQArray(dims, data)
+        return ptrace(self.data, keep, self.dims)
 
     def powm(self, n: int) -> QArray:
         data = jnp.linalg.matrix_power(self.data, n)

--- a/dynamiqs/utils/quantum_utils/general.py
+++ b/dynamiqs/utils/quantum_utils/general.py
@@ -270,16 +270,27 @@ def ptrace(
         (3, 4, 5)
         >>> psi_abc.shape
         (60, 1)
-        >>> rho_a = dq.ptrace(psi_abc, 0, (3, 4, 5))
+        >>> rho_a = dq.ptrace(psi_abc, 0)
         >>> rho_a.dims
         (3,)
         >>> rho_a.shape
         (3, 3)
-        >>> rho_bc = dq.ptrace(psi_abc, (1, 2), (3, 4, 5))
+        >>> rho_bc = dq.ptrace(psi_abc, (1, 2))
         >>> rho_bc.dims
         (4, 5)
         >>> rho_bc.shape
         (20, 20)
+
+        If the input qarray-like object `x` does not hold Hilbert space dimensions, you
+        can specify them with the argument `dims`. For example, to trace out the second
+        subsystem of the Bell state $(\ket{00}+\ket{11})/\sqrt2$:
+        >>> bell_state = np.array([1, 0, 0, 1])[:, None] / np.sqrt(2)
+        >>> bell_state.shape
+        (4, 1)
+        >>> dq.ptrace(bell_state, 0, dims=(2, 2))
+        QArray: shape=(2, 2), dims=(2,), dtype=float32, layout=dense
+        [[0.5 0. ]
+         [0.  0.5]]
     """
     xdims = _get_dims(x)
     x = _to_jax(x)

--- a/dynamiqs/utils/quantum_utils/general.py
+++ b/dynamiqs/utils/quantum_utils/general.py
@@ -10,7 +10,7 @@ from jax import Array
 from ..._checks import check_shape
 from ..._utils import on_cpu
 from ...qarrays.dense_qarray import DenseQArray
-from ...qarrays.qarray import QArray, QArrayLike, _to_jax_and_dims
+from ...qarrays.qarray import QArray, QArrayLike, _get_dims, _to_jax
 from ...qarrays.utils import _init_dims, asqarray, to_jax
 
 __all__ = [
@@ -281,7 +281,8 @@ def ptrace(
         >>> rho_bc.shape
         (20, 20)
     """
-    x, xdims = _to_jax_and_dims(x)
+    xdims = _get_dims(x)
+    x = _to_jax(x)
     dims = _init_dims(xdims, dims, x.shape)
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 


### PR DESCRIPTION
We can now do `x.ptrace(*keep)` for a `QArray`, this was not yet ported.