### PR TITLE
Fix internal sums of QArrays

### DIFF
--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -7,9 +7,8 @@ import diffrax as dx
 import equinox as eqx
 from jax import Array
 from jaxtyping import PyTree
-
 from ...gradient import Autograd, CheckpointAutograd
-from ...qarrays.utils import stack
+from ...qarrays.utils import sum_qarray_pytree
 from .abstract_integrator import BaseIntegrator
 from ...result import Result
 from .abstract_integrator import BaseIntegrator
@@ -218,16 +217,10 @@ class MEDiffraxIntegrator(DiffraxIntegrator, MEInterface):
         # and is thus more efficient numerically with only a negligible numerical error
         # induced on the dynamics.
 
-        def vector_field_dissipative(t, y, _):  # noqa: ANN001, ANN202
-            L = stack(self.L(t))
-            Ld = L.dag()
-            LdL = (Ld @ L).sum(0)
-            tmp = (-1j * self.H(t) - 0.5 * LdL) @ y + 0.5 * (L @ y @ Ld).sum(0)
+        def vector_field(t, y, _):  # noqa: ANN001, ANN202
+            L, H = self.L(t), self.H(t)
+            Hnh = sum_qarray_pytree([-1j * H] + [-0.5 * _L.dag() @ _L for _L in L])
+            tmp = sum_qarray_pytree([Hnh @ y] + [0.5 * _L @ y @ _L.dag() for _L in L])
             return tmp + tmp.dag()
 
-        def vector_field_unitary(t, y, _):  # noqa: ANN001, ANN202
-            tmp = -1j * self.H(t) @ y
-            return tmp + tmp.dag()
-
-        vf = vector_field_dissipative if len(self.Ls) > 0 else vector_field_unitary
-        return dx.ODETerm(vf)
+        return dx.ODETerm(vector_field)

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -8,7 +8,7 @@ import equinox as eqx
 from jax import Array
 from jaxtyping import PyTree
 from ...gradient import Autograd, CheckpointAutograd
-from ...qarrays.utils import sum_qarray_pytree
+from ...qarrays.utils import tree_sum
 from .abstract_integrator import BaseIntegrator
 from ...result import Result
 from .abstract_integrator import BaseIntegrator
@@ -219,8 +219,8 @@ class MEDiffraxIntegrator(DiffraxIntegrator, MEInterface):
 
         def vector_field(t, y, _):  # noqa: ANN001, ANN202
             L, H = self.L(t), self.H(t)
-            Hnh = sum_qarray_pytree([-1j * H] + [-0.5 * _L.dag() @ _L for _L in L])
-            tmp = sum_qarray_pytree([Hnh @ y] + [0.5 * _L @ y @ _L.dag() for _L in L])
+            Hnh = tree_sum([-1j * H] + [-0.5 * _L.dag() @ _L for _L in L])
+            tmp = tree_sum([Hnh @ y] + [0.5 * _L @ y @ _L.dag() for _L in L])
             return tmp + tmp.dag()
 
         return dx.ODETerm(vector_field)

--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -23,7 +23,7 @@ class MEInterface(eqx.Module):
     Ls: list[TimeArray]
 
     def L(self, t: Scalar) -> list[QArray]:
-        return [L(t) for L in self.Ls]  # (nLs, n, n)
+        return [_L(t) for _L in self.Ls]  # (nLs, n, n)
 
 
 class SolveInterface(eqx.Module):

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Sequence
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array, ArrayLike, DTypeLike
@@ -372,3 +373,11 @@ def _assert_dims_match_shape(dims: tuple[int, ...], shape: tuple[int, ...]):
             f'Argument `dims={dims}` is incompatible with the input shape'
             f' `shape={shape}`.'
         )
+
+
+def sum_qarray_pytree(qarrays: list[QArray]) -> QArray:
+    # jax.tree.reduce doesn't call its initializer if the list is not empty
+    # this avoids unwanted conversion from sparse to dense qarrays when summing with 0
+    return jax.tree.reduce(
+        lambda x, y: x + y, qarrays, is_leaf=lambda x: isinstance(x, QArray)
+    )

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -375,7 +375,7 @@ def _assert_dims_match_shape(dims: tuple[int, ...], shape: tuple[int, ...]):
         )
 
 
-def sum_qarray_pytree(qarrays: list[QArray]) -> QArray:
+def tree_sum(qarrays: list[QArray]) -> QArray:
     # jax.tree.reduce doesn't call its initializer if the list is not empty
     # this avoids unwanted conversion from sparse to dense qarrays when summing with 0
     return jax.tree.reduce(

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import jax
 import numpy as np
 
 from .._checks import check_shape
 from ..qarrays.qarray import QArray, QArrayLike
-from ..qarrays.utils import asqarray
+from ..qarrays.utils import asqarray, sum_qarray_pytree
 from .operators import eye
 from .quantum_utils import dag
 
@@ -251,12 +250,4 @@ def slindbladian(H: QArrayLike, jump_ops: list[QArrayLike]) -> QArray:
         check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
 
     terms = [-1j * spre(H), 1j * spost(H)] + [sdissipator(L) for L in jump_ops]
-    return sum_qarrays(terms)
-
-
-def sum_qarrays(qarrays: list[QArray]) -> QArray:
-    # jax.tree.reduce doesn't call its initializer if the list is not empty
-    # this avoids unwanted conversion from sparse to dense qarrays when summing with 0
-    return jax.tree.reduce(
-        lambda x, y: x + y, qarrays, is_leaf=lambda x: isinstance(x, QArray)
-    )
+    return sum_qarray_pytree(terms)

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .._checks import check_shape
 from ..qarrays.qarray import QArray, QArrayLike
-from ..qarrays.utils import asqarray, sum_qarray_pytree
+from ..qarrays.utils import asqarray, tree_sum
 from .operators import eye
 from .quantum_utils import dag
 
@@ -250,4 +250,4 @@ def slindbladian(H: QArrayLike, jump_ops: list[QArrayLike]) -> QArray:
         check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
 
     terms = [-1j * spre(H), 1j * spost(H)] + [sdissipator(L) for L in jump_ops]
-    return sum_qarray_pytree(terms)
+    return tree_sum(terms)


### PR DESCRIPTION
Proper fix for 74b18cee880b30dd61773b9155a3c7924e832f45.

Also fixes the implementation of `vector_field` for `dq.mesolve`. This yields 5-10% improvement on small systems (and equivalent runtimes on larger systems), e.g. on:
```python
import jax
import jax.numpy as jnp
import dynamiqs as dq

# === Prepare objects ===
# parameters
n = 50
delta = 0.1
epsilon = 2
gamma = 1
nth = 0.8

# operators
a = dq.destroy(n)
H = delta * dq.dag(a) @ a + epsilon * (a + dq.dag(a))
L = [jnp.sqrt(gamma * (1 + nth)) * a, jnp.sqrt(gamma * nth) * dq.dag(a)]
y = dq.todm(dq.fock(n, 0))

# save times
tsave = jnp.linspace(0.0, 1.0, 101)
options = dq.Options(progress_meter=None)
dq.mesolve(H, L, y, tsave, options=options).block_until_ready()
%timeit dq.mesolve(H, L, y, tsave, options=options).block_until_ready()
```
Before: `43 ms ± 344 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)`
After: `37.6 ms ± 266 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)`
(reproducible over many tries)

Benchmark difference can also be checked directly on the vector field definition:
```python
import jax
import jax.numpy as jnp
import dynamiqs as dq
from dynamiqs.qarrays.utils import tree_sum

# === Prepare objects ===
# parameters
n = 50
delta = 0.1
epsilon = 2
gamma = 1
nth = 0.8

# operators
a = dq.destroy(n)
H = delta * dq.dag(a) @ a + epsilon * (a + dq.dag(a))
L = [jnp.sqrt(gamma * (1 + nth)) * a, jnp.sqrt(gamma * nth) * dq.dag(a)]
y = dq.todm(dq.fock(n, 0))

# === Vector field definition ===
@jax.jit
def vector_field_old(H, L, y):
    L = dq.stack(L)
    Ld = L.dag()
    LdL = (Ld @ L).sum(0)
    tmp = (-1j * H - 0.5 * LdL) @ y + 0.5 * (L @ y @ Ld).sum(0)
    return tmp + tmp.dag()

@jax.jit
def vector_field_new(H, L, y):
    Hnh = tree_sum([-1j * H] + [-0.5 * _L.dag() @ _L for _L in L])
    tmp = tree_sum([Hnh @ y] + [0.5 * _L @ y @ _L.dag() for _L in L])
    return tmp + tmp.dag()


# === Run ===
vector_field_old(H, L, y).block_until_ready()
%timeit vector_field_old(H, L, y).block_until_ready()

vector_field_new(H, L, y).block_until_ready()
%timeit vector_field_new(H, L, y).block_until_ready()
```
Before: `109 µs ± 1.96 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)`
After: `95.5 µs ± 2.29 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)`