### PR TITLE
Fix `Expm` solver to always use dense generators

### DIFF
--- a/dynamiqs/integrators/core/expm_integrator.py
+++ b/dynamiqs/integrators/core/expm_integrator.py
@@ -70,7 +70,7 @@ class ExpmIntegrator(AbstractIntegrator, SaveMixin):
         delta_ts = jnp.diff(times)  # (ntimes-1,)
 
         # === batch-compute the propagators $e^{\Delta t A}$ on each time interval
-        As = jax.vmap(self.generator)(times[:-1])  # (ntimes-1, N, N)
+        As = jax.vmap(self.generator)(times[:-1]).asdense()  # (ntimes-1, N, N)
         step_propagators = expm(delta_ts[:, None, None] * As)  # (ntimes-1, N, N)
 
         # === combine the propagators together

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -176,7 +176,11 @@ class SparseDIAQArray(QArray):
             return self @ self.powm(n - 1)
 
     def expm(self, *, max_squarings: int = 16) -> QArray:
-        # todo: implement dia specific method or raise warning for dense conversion
+        warnings.warn(
+            'A SparseDIAQArray has been converted to a DenseQArray while computing its '
+            'matrix exponential.',
+            stacklevel=2,
+        )
         return _sparsedia_to_dense(self).expm(max_squarings=max_squarings)
 
     def norm(self) -> Array:

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -73,6 +73,10 @@ class Expm(Solver):
     $$
 
     Warning:
+        If the Hamiltonian or jump operators are sparse arrays, they will be silently
+        converted to dense arrays before computing their matrix exponentials.
+
+    Warning:
         This solver is not recommended for open systems of large dimension, due to
         the $\mathcal{O}(n^6)$ scaling of computing the Liouvillian exponential.
 


### PR DESCRIPTION
On top of https://github.com/dynamiqs/dynamiqs/pull/829.