### PR TITLE
Temporary fix for sharp bits for documentation deployment

### DIFF
--- a/docs/documentation/getting_started/sharp-bits.md
+++ b/docs/documentation/getting_started/sharp-bits.md
@@ -88,6 +88,8 @@ Likewise, you should use `dq.powm()` instead of `**` (element-wise power) to com
     Array([[0.+0.j, 1.+0.j],
            [1.+0.j, 0.+0.j]], dtype=complex64)
     ```
+<!-- skip: end -->
+<!-- todo: temporary fix -->
 
 ## Using a for loop
 


### PR DESCRIPTION
To avoid Sybil error: `ValueError: 'skip: start' cannot follow 'skip: start'` following the merge of 'main' into 'dev-qarray'.