### PR TITLE
Rehaul qarray warnings and checks

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -57,7 +57,11 @@ def _is_batched_scalar(y: ArrayLike) -> bool:
     # check if a qarray-like object is a scalar or a set of scalars of shape (..., 1, 1)
     return isinstance(y, get_args(ScalarLike)) or (
         isinstance(y, get_args(ArrayLike))
-        and (y.ndim == 0 or (y.ndim > 1 and y.shape[-2:] == (1, 1)))
+        and (
+            y.ndim == 0
+            or (y.ndim == 1 and y.shape == (1,))
+            or (y.ndim > 1 and y.shape[-2:] == (1, 1))
+        )
     )
 
 

--- a/dynamiqs/plot/wigner.py
+++ b/dynamiqs/plot/wigner.py
@@ -114,12 +114,7 @@ def wigner(
 
         ![plot_wigner_01](../../figs_code/plot_wigner_01.png){.fig-half}
 
-        >>> psi = (
-        ...     dq.coherent(32, 3)
-        ...     + dq.coherent(32, -3)
-        ...     + dq.coherent(32, 3j)
-        ...     + dq.coherent(32, -3j)
-        ... ).unit()
+        >>> psi = dq.coherent(32, [3, 3j, -3, -3j]).sum(0).unit()
         >>> dq.plot.wigner(psi, npixels=201, clear=True)
         >>> renderfig('plot_wigner_4legged')
 

--- a/dynamiqs/plot/wigner.py
+++ b/dynamiqs/plot/wigner.py
@@ -114,7 +114,12 @@ def wigner(
 
         ![plot_wigner_01](../../figs_code/plot_wigner_01.png){.fig-half}
 
-        >>> psi = sum(dq.coherent(32, 3 * a) for a in [1, 1j, -1, -1j]).unit()
+        >>> psi = (
+        ...     dq.coherent(32, 3)
+        ...     + dq.coherent(32, -3)
+        ...     + dq.coherent(32, 3j)
+        ...     + dq.coherent(32, -3j)
+        ... ).unit()
         >>> dq.plot.wigner(psi, npixels=201, clear=True)
         >>> renderfig('plot_wigner_4legged')
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -48,10 +48,14 @@ class DenseQArray(QArray):
         return DenseQArray(self.dims, data)
 
     def reshape(self, *shape: int) -> QArray:
+        super().reshape(*shape)
+
         data = jnp.reshape(self.data, shape)
         return DenseQArray(self.dims, data)
 
     def broadcast_to(self, *shape: int) -> QArray:
+        super().broadcast_to(*shape)
+
         data = jnp.broadcast_to(self.data, shape)
         return DenseQArray(self.dims, data)
 
@@ -137,15 +141,17 @@ class DenseQArray(QArray):
     def __mul__(self, y: QArrayLike) -> QArray:
         super().__mul__(y)
 
-        if _is_batched_scalar(y):
-            data = self.data * y
-        elif isinstance(y, DenseQArray):
+        if isinstance(y, DenseQArray):
             data = self.data * y.data
+            return DenseQArray(self.dims, data)
         elif isqarraylike(y):
             data = self.data * _to_jax(y)
-        else:
-            return NotImplemented
+            return DenseQArray(self.dims, data)
 
+        return NotImplemented
+
+    def elmul(self, y: QArrayLike) -> QArray:
+        data = self.data * _to_jax(y)
         return DenseQArray(self.dims, data)
 
     def __truediv__(self, y: QArrayLike) -> QArray:
@@ -162,18 +168,20 @@ class DenseQArray(QArray):
 
         return DenseQArray(self.dims, data)
 
-    def __add__(self, y: QArray) -> QArray:
+    def __add__(self, y: QArrayLike) -> QArray:
         super().__add__(y)
 
-        if _is_batched_scalar(y):
-            data = self.data + y
-        elif isinstance(y, DenseQArray):
+        if isinstance(y, DenseQArray):
             data = self.data + y.data
+            return DenseQArray(self.dims, data)
         elif isinstance(y, get_args(ArrayLike)):
             data = self.data + _to_jax(y)
-        else:
-            return NotImplemented
+            return DenseQArray(self.dims, data)
 
+        return NotImplemented
+
+    def addscalar(self, y: ArrayLike) -> QArray:
+        data = self.data + _to_jax(y)
         return DenseQArray(self.dims, data)
 
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
@@ -218,7 +226,7 @@ class DenseQArray(QArray):
 
         return DenseQArray(dims, data)
 
-    def _pow(self, power: int) -> QArray:
+    def elpow(self, power: int) -> QArray:
         data = self.data**power
         return DenseQArray(self.dims, data)
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -48,14 +48,10 @@ class DenseQArray(QArray):
         return DenseQArray(self.dims, data)
 
     def reshape(self, *shape: int) -> QArray:
-        super().reshape(*shape)
-
         data = jnp.reshape(self.data, shape)
         return DenseQArray(self.dims, data)
 
     def broadcast_to(self, *shape: int) -> QArray:
-        super().broadcast_to(*shape)
-
         data = jnp.broadcast_to(self.data, shape)
         return DenseQArray(self.dims, data)
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -134,8 +134,13 @@ class DenseQArray(QArray):
     def __repr__(self) -> str:
         return super().__repr__() + f'\n{self.data}'
 
-    def __mul__(self, y: QArrayLike) -> QArray:
+    def __mul__(self, y: ArrayLike) -> QArray:
         super().__mul__(y)
+
+        return DenseQArray(self.dims, y * self.data)
+
+    def elmul(self, y: QArrayLike) -> QArray:
+        super().elmul(y)
 
         if isinstance(y, DenseQArray):
             data = self.data * y.data
@@ -145,10 +150,6 @@ class DenseQArray(QArray):
             return DenseQArray(self.dims, data)
 
         return NotImplemented
-
-    def elmul(self, y: QArrayLike) -> QArray:
-        data = self.data * _to_jax(y)
-        return DenseQArray(self.dims, data)
 
     def __truediv__(self, y: QArrayLike) -> QArray:
         super().__truediv__(y)

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -139,18 +139,6 @@ class DenseQArray(QArray):
 
         return DenseQArray(self.dims, y * self.data)
 
-    def elmul(self, y: QArrayLike) -> QArray:
-        super().elmul(y)
-
-        if isinstance(y, DenseQArray):
-            data = self.data * y.data
-            return DenseQArray(self.dims, data)
-        elif isqarraylike(y):
-            data = self.data * _to_jax(y)
-            return DenseQArray(self.dims, data)
-
-        return NotImplemented
-
     def __truediv__(self, y: QArrayLike) -> QArray:
         super().__truediv__(y)
 
@@ -176,10 +164,6 @@ class DenseQArray(QArray):
             return DenseQArray(self.dims, data)
 
         return NotImplemented
-
-    def addscalar(self, y: ArrayLike) -> QArray:
-        data = self.data + _to_jax(y)
-        return DenseQArray(self.dims, data)
 
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
         super().__matmul__(y)
@@ -222,6 +206,15 @@ class DenseQArray(QArray):
             return NotImplemented
 
         return DenseQArray(dims, data)
+
+    def addscalar(self, y: ArrayLike) -> QArray:
+        data = self.data + _to_jax(y)
+        return DenseQArray(self.dims, data)
+
+    def elmul(self, y: ArrayLike) -> QArray:
+        super().elmul(y)
+        data = self.data * _to_jax(y)
+        return DenseQArray(self.dims, data)
 
     def elpow(self, power: int) -> QArray:
         data = self.data**power

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -150,9 +150,9 @@ class QArray(eqx.Module):
     | `x.to_numpy()`                                           | Alias of [`dq.to_numpy(x)`][dynamiqs.to_numpy].                |
     | [`x.reshape(*shape)`][dynamiqs.QArray.reshape]           | Returns a reshaped copy of a qarray.                           |
     | [`x.broadcast_to(*shape)`][dynamiqs.QArray.broadcast_to] | Broadcasts a qarray to a new shape.                            |
-    | [`x.addscalar(y)`][dynamiqs.QArray.addscalar]            | Add a scalar-like to a qarray.                                 |
-    | [`x.elmul(y)`][dynamiqs.QArray.elmul]                    | Compute the element-wise multiplication with a qarray.         |
-    | [`x.elpow(power)`][dynamiqs.QArray.elpow]                | Compute the element-wise power of a qarray.                    |
+    | [`x.addscalar(y)`][dynamiqs.QArray.addscalar]            | Adds a scalar.                                                 |
+    | [`x.elmul(y)`][dynamiqs.QArray.elmul]                    | Computes the element-wise multiplication.                      |
+    | [`x.elpow(power)`][dynamiqs.QArray.elpow]                | Computes the element-wise power.                               |
     """  # noqa: E501
 
     # Subclasses should implement:
@@ -394,19 +394,6 @@ class QArray(eqx.Module):
                 'consider using `x.elmul(y)`.'
             )
 
-    @abstractmethod
-    def elmul(self, y: QArrayLike) -> QArray:
-        """Compute the element-wise multiplication with a qarray.
-
-        Args:
-            y: Qarray to multiply element-wise with.
-
-        Returns:
-            New qarray object with element-wise multiplication.
-        """
-        if isinstance(y, QArray):
-            _check_compatible_dims(self.dims, y.dims)
-
     def __rmul__(self, y: QArrayLike) -> QArray:
         return self * y
 
@@ -433,17 +420,6 @@ class QArray(eqx.Module):
 
         if isinstance(y, QArray):
             _check_compatible_dims(self.dims, y.dims)
-
-    @abstractmethod
-    def addscalar(self, y: ArrayLike) -> QArray:
-        """Add a scalar to a qarray.
-
-        Args:
-            y: Scalar to add, whose shape should be broadcastable with the qarray.
-
-        Returns:
-            New qarray object with the scalar added to all elements.
-        """
 
     def __radd__(self, y: QArrayLike) -> QArray:
         return self.__add__(y)
@@ -480,11 +456,33 @@ class QArray(eqx.Module):
         )
 
     @abstractmethod
-    def elpow(self, power: int) -> QArray:
-        """Compute the element-wise power of a QArray.
+    def addscalar(self, y: ArrayLike) -> QArray:
+        """Adds a scalar.
 
         Args:
-            power: Power to raise the QArray to.
+            y: Scalar to add, whose shape should be broadcastable with the qarray.
+
+        Returns:
+            New qarray object resulting from the addition with the scalar.
+        """
+
+    @abstractmethod
+    def elmul(self, y: ArrayLike) -> QArray:
+        """Computes the element-wise multiplication.
+
+        Args:
+            y: Array-like object to multiply with element-wise.
+
+        Returns:
+            New qarray object resulting from the element-wise multiplication.
+        """
+
+    @abstractmethod
+    def elpow(self, power: int) -> QArray:
+        """Computes the element-wise power.
+
+        Args:
+            power: Power to raise to.
 
         Returns:
             New qarray object with elements raised to the specified power.

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -385,7 +385,7 @@ class QArray(eqx.Module):
         return self * (-1)
 
     @abstractmethod
-    def __mul__(self, y: QArrayLike) -> QArray:
+    def __mul__(self, y: ArrayLike) -> QArray:
         if not _is_batched_scalar(y):
             raise NotImplementedError(
                 'Element-wise multiplication of a QArray with another QArray is not '
@@ -393,9 +393,6 @@ class QArray(eqx.Module):
                 '`x @ y` instead. If you want to perform element-wise multiplication, '
                 'consider using `x.elmul(y)`.'
             )
-
-        if isinstance(y, QArray):
-            _check_compatible_dims(self.dims, y.dims)
 
     @abstractmethod
     def elmul(self, y: QArrayLike) -> QArray:
@@ -407,6 +404,8 @@ class QArray(eqx.Module):
         Returns:
             New qarray object with element-wise multiplication.
         """
+        if isinstance(y, QArray):
+            _check_compatible_dims(self.dims, y.dims)
 
     def __rmul__(self, y: QArrayLike) -> QArray:
         return self * y

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -234,11 +234,6 @@ class QArray(eqx.Module):
         Returns:
             New qarray object with the given shape.
         """
-        if shape[-2:] != self.shape[-2:]:
-            raise ValueError(
-                f'Cannot reshape to shape {shape} because the last two dimensions do '
-                f'not match current shape dimensions, {self.shape}.'
-            )
 
     @abstractmethod
     def broadcast_to(self, *shape: int) -> QArray:
@@ -250,11 +245,6 @@ class QArray(eqx.Module):
         Returns:
             New qarray object with the given shape.
         """
-        if shape[-2:] != self.shape[-2:]:
-            raise ValueError(
-                f'Cannot broadcast to shape {shape} because the last two dimensions do '
-                f'not match current shape dimensions, {self.shape}.'
-            )
 
     @abstractmethod
     def ptrace(self, *keep: int) -> QArray:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -388,10 +388,9 @@ class QArray(eqx.Module):
     def __mul__(self, y: ArrayLike) -> QArray:
         if not _is_batched_scalar(y):
             raise NotImplementedError(
-                'Element-wise multiplication of a QArray with another QArray is not '
-                'supported. If you want to compute the matrix multiplication, use '
-                '`x @ y` instead. If you want to perform element-wise multiplication, '
-                'consider using `x.elmul(y)`.'
+                'Element-wise multiplication of a qarray with the `*` operator is not '
+                'supported. For matrix multiplication, use `x @ y`. For element-wise '
+                'multiplication, use `x.elmul(y)`.'
             )
 
     def __rmul__(self, y: QArrayLike) -> QArray:
@@ -412,10 +411,9 @@ class QArray(eqx.Module):
     def __add__(self, y: QArrayLike) -> QArray:
         if _is_batched_scalar(y):
             raise NotImplementedError(
-                'Adding a scalar to a QArray is not supported. If you want to add the '
-                'identity matrix scaled by a scalar, use '
-                '`x + scalar * dq.eye(*x.dims)` instead. If you want to perform '
-                'addition with a scalar, consider using `x.addscalar(scalar)`.'
+                'Adding a scalar to a qarray with the `+` operator is not supported. '
+                'To add a scaled identity matrix, use `x + scalar * dq.eye(*x.dims)`.'
+                ' To add a scalar, use `x.addscalar(scalar)`.'
             )
 
         if isinstance(y, QArray):
@@ -433,12 +431,12 @@ class QArray(eqx.Module):
     @abstractmethod
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
         if _is_batched_scalar(y):
-            raise TypeError('Attempted matrix product between a scalar and a QArray.')
+            raise TypeError('Attempted matrix product between a scalar and a qarray.')
 
     @abstractmethod
     def __rmatmul__(self, y: QArrayLike) -> QArray:
         if _is_batched_scalar(y):
-            raise TypeError('Attempted matrix product between a scalar and a QArray.')
+            raise TypeError('Attempted matrix product between a scalar and a qarray.')
 
     @abstractmethod
     def __and__(self, y: QArray) -> QArray:
@@ -450,9 +448,9 @@ class QArray(eqx.Module):
             return _Metaω.__rpow__(power, self)
 
         raise NotImplementedError(
-            'Computing the element-wise power of a QArray is not supported. If you '
-            'want to compute the matrix power, use `x.pomw(power)` instead. If you '
-            'want to compute the element-wise power, consider using `x.elpow(power)`.'
+            'Computing the element-wise power of a qarray with the `**` operator is '
+            'not supported. For the matrix power, use `x.pomw(power)`. For the '
+            'element-wise power, use `x.elpow(power)`.'
         )
 
     @abstractmethod

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -94,13 +94,21 @@ class SparseDIAQArray(QArray):
         return SparseDIAQArray(self.dims, self.offsets, self.diags.conj())
 
     def reshape(self, *shape: int) -> QArray:
-        super().reshape(*shape)
+        if shape[-2:] != self.shape[-2:]:
+            raise ValueError(
+                f'Cannot reshape to shape {shape} because the last two dimensions do '
+                f'not match current shape dimensions, {self.shape}.'
+            )
 
         offsets, diags = reshape_sparsedia(self.offsets, self.diags, shape)
         return SparseDIAQArray(self.dims, offsets, diags)
 
     def broadcast_to(self, *shape: int) -> QArray:
-        super().broadcast_to(*shape)
+        if shape[-2:] != self.shape[-2:]:
+            raise ValueError(
+                f'Cannot broadcast to shape {shape} because the last two dimensions do '
+                f'not match current shape dimensions, {self.shape}.'
+            )
 
         offsets, diags = broadcast_sparsedia(self.offsets, self.diags, shape)
         return SparseDIAQArray(self.dims, offsets, diags)

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -213,8 +213,13 @@ class SparseDIAQArray(QArray):
         data_str = re.sub(pattern, replace_with_dot, str(self.to_jax()))
         return super().__repr__() + f', ndiags={self.ndiags}\n{data_str}'
 
-    def __mul__(self, y: QArrayLike) -> QArray:
+    def __mul__(self, y: ArrayLike) -> QArray:
         super().__mul__(y)
+
+        return SparseDIAQArray(self.dims, self.offsets, y * self.diags)
+
+    def elmul(self, y: QArrayLike) -> QArray:
+        super().elmul(y)
 
         if isinstance(y, SparseDIAQArray):
             offsets, diags = mul_sparsedia_sparsedia(
@@ -227,9 +232,6 @@ class SparseDIAQArray(QArray):
             return SparseDIAQArray(self.dims, offsets, diags)
 
         return NotImplemented
-
-    def elmul(self, y: QArrayLike) -> QArray:
-        return SparseDIAQArray(self.dims, self.offsets, y * self.diags)
 
     def __truediv__(self, y: QArrayLike) -> QArray:
         raise NotImplementedError

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -205,93 +205,93 @@ class SparseDIAQArray(QArray):
         data_str = re.sub(pattern, replace_with_dot, str(self.to_jax()))
         return super().__repr__() + f', ndiags={self.ndiags}\n{data_str}'
 
-    def __mul__(self, other: QArrayLike) -> QArray:
-        super().__mul__(other)
+    def __mul__(self, y: QArrayLike) -> QArray:
+        super().__mul__(y)
 
-        if isinstance(other, SparseDIAQArray):
+        if isinstance(y, SparseDIAQArray):
             offsets, diags = mul_sparsedia_sparsedia(
-                self.offsets, self.diags, other.offsets, other.diags
+                self.offsets, self.diags, y.offsets, y.diags
             )
             return SparseDIAQArray(self.dims, offsets, diags)
-        elif isqarraylike(other):
-            other = _to_jax(other)
-            offsets, diags = mul_sparsedia_array(self.offsets, self.diags, other)
+        elif isqarraylike(y):
+            y = _to_jax(y)
+            offsets, diags = mul_sparsedia_array(self.offsets, self.diags, y)
             return SparseDIAQArray(self.dims, offsets, diags)
 
         return NotImplemented
 
-    def elmul(self, other: QArrayLike) -> QArray:
-        return SparseDIAQArray(self.dims, self.offsets, other * self.diags)
+    def elmul(self, y: QArrayLike) -> QArray:
+        return SparseDIAQArray(self.dims, self.offsets, y * self.diags)
 
-    def __truediv__(self, other: QArrayLike) -> QArray:
+    def __truediv__(self, y: QArrayLike) -> QArray:
         raise NotImplementedError
 
-    def __add__(self, other: QArrayLike) -> QArray:
-        super().__add__(other)
+    def __add__(self, y: QArrayLike) -> QArray:
+        super().__add__(y)
 
-        if isinstance(other, SparseDIAQArray):
+        if isinstance(y, SparseDIAQArray):
             offsets, diags = add_sparsedia_sparsedia(
-                self.offsets, self.diags, other.offsets, other.diags
+                self.offsets, self.diags, y.offsets, y.diags
             )
             return SparseDIAQArray(self.dims, offsets, diags)
-        elif isqarraylike(other):
+        elif isqarraylike(y):
             warnings.warn(
                 'A sparse array has been converted to dense layout due to element-wise '
                 'addition with a dense array.',
                 stacklevel=2,
             )
-            return self.asdense() + other
+            return self.asdense() + y
 
         return NotImplemented
 
-    def addscalar(self, other: ArrayLike) -> QArray:
+    def addscalar(self, y: ArrayLike) -> QArray:
         warnings.warn(
             'A sparse array has been converted to dense layout due to element-wise '
             'addition with a scalar.',
             stacklevel=2,
         )
-        return self.asdense().addscalar(other)
+        return self.asdense().addscalar(y)
 
-    def __matmul__(self, other: QArrayLike) -> QArray:
-        super().__matmul__(other)
+    def __matmul__(self, y: QArrayLike) -> QArray:
+        super().__matmul__(y)
 
-        if isinstance(other, SparseDIAQArray):
+        if isinstance(y, SparseDIAQArray):
             offsets, diags = matmul_sparsedia_sparsedia(
-                self.offsets, self.diags, other.offsets, other.diags
+                self.offsets, self.diags, y.offsets, y.diags
             )
             return SparseDIAQArray(self.dims, offsets, diags)
-        elif isqarraylike(other):
-            other = _to_jax(other)
-            data = matmul_sparsedia_array(self.offsets, self.diags, other)
+        elif isqarraylike(y):
+            y = _to_jax(y)
+            data = matmul_sparsedia_array(self.offsets, self.diags, y)
             return DenseQArray(self.dims, data)
 
         return NotImplemented
 
-    def __rmatmul__(self, other: QArrayLike) -> QArray:
-        super().__rmatmul__(other)
+    def __rmatmul__(self, y: QArrayLike) -> QArray:
+        super().__rmatmul__(y)
 
-        if isqarraylike(other):
-            other = _to_jax(other)
-            data = matmul_array_sparsedia(other, self.offsets, self.diags)
+        if isqarraylike(y):
+            y = _to_jax(y)
+            data = matmul_array_sparsedia(y, self.offsets, self.diags)
             return DenseQArray(self.dims, data)
 
         return NotImplemented
 
-    def __and__(self, other: QArray) -> QArray:
-        if isinstance(other, SparseDIAQArray):
+    def __and__(self, y: QArray) -> QArray:
+        if isinstance(y, SparseDIAQArray):
             offsets, diags = and_sparsedia_sparsedia(
-                self.offsets, self.diags, other.offsets, other.diags
+                self.offsets, self.diags, y.offsets, y.diags
             )
-            dims = self.dims + other.dims
+            dims = self.dims + y.dims
             return SparseDIAQArray(dims, offsets, diags)
-        elif isinstance(other, DenseQArray):
-            return self.asdense() & other
+        elif isinstance(y, DenseQArray):
+            return self.asdense() & y
 
         return NotImplemented
 
-    def __rand__(self, other: QArray) -> QArray:
-        if isinstance(other, DenseQArray):
-            return other & self.asdense()
+    def __rand__(self, y: QArray) -> QArray:
+        if isinstance(y, DenseQArray):
+            return y & self.asdense()
 
         return NotImplemented
 

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -11,7 +11,7 @@ from .._checks import check_shape
 from .._utils import on_cpu
 from ..qarrays.dense_qarray import DenseQArray
 from ..qarrays.qarray import QArray, QArrayLike, _get_dims, _to_jax
-from ..qarrays.utils import _init_dims, asqarray, to_jax
+from ..qarrays.utils import _init_dims, asqarray, to_jax, tree_sum
 
 __all__ = [
     'bloch_coordinates',
@@ -596,7 +596,7 @@ def lindbladian(H: QArrayLike, jump_ops: list[QArrayLike], rho: QArrayLike) -> Q
     # === check rho shape
     check_shape(rho, 'rho', '(..., n, n)')
 
-    return -1j * (H @ rho - rho @ H) + sum(dissipator(L, rho) for L in jump_ops)
+    return -1j * (H @ rho - rho @ H) + tree_sum([dissipator(L, rho) for L in jump_ops])
 
 
 def isket(x: QArrayLike) -> bool:

--- a/tests/qarrays/test_dense_qarray.py
+++ b/tests/qarrays/test_dense_qarray.py
@@ -9,9 +9,10 @@ class TestDenseQArray:
     def _setup(self):
         self.data = jnp.arange(16).reshape(4, 4) * (1 + 1j)
         self.qarray = asqarray(self.data, dims=(2, 2))
-
         self.other = jnp.arange(16).reshape(4, 4) + 16
         self.qother = asqarray(self.other, dims=(2, 2))
+        self.scalar = 2 + 2j
+        self.bscalar = jnp.ones((3, 2, 1, 1), dtype=jnp.complex64)
 
     def test_dag(self):
         assert jnp.array_equal(self.qarray.dag().data, self.data.mT.conj())
@@ -23,25 +24,60 @@ class TestDenseQArray:
         assert ptrace.dims == (2,)
 
     def test_add(self):
-        scalar = 2 + 2j
-
-        assert jnp.array_equal((self.qarray + scalar).data, self.data + scalar)
         assert jnp.array_equal((self.qarray + self.other).data, self.data + self.other)
         assert jnp.array_equal((self.qarray + self.qother).data, self.data + self.other)
+        with pytest.raises(NotImplementedError):
+            self.qarray + self.scalar
+        with pytest.raises(NotImplementedError):
+            self.qarray + self.bscalar
+
+    def test_radd(self):
+        assert jnp.array_equal((self.other + self.qarray).data, self.other + self.data)
+        assert jnp.array_equal((self.qother + self.qarray).data, self.other + self.data)
+        with pytest.raises(NotImplementedError):
+            self.scalar + self.qarray
+        with pytest.raises(NotImplementedError):
+            self.bscalar + self.qarray
+
+    def test_scalaradd(self):
+        assert jnp.array_equal(
+            self.qarray.addscalar(self.scalar).data, self.data + self.scalar
+        )
+        assert jnp.array_equal(
+            self.qarray.addscalar(self.bscalar).data, self.data + self.bscalar
+        )
 
     def test_sub(self):
-        scalar = 2 + 2j
-
-        assert jnp.array_equal((self.qarray - scalar).data, self.data - scalar)
         assert jnp.array_equal((self.qarray - self.other).data, self.data - self.other)
         assert jnp.array_equal((self.qarray - self.qother).data, self.data - self.other)
+        with pytest.raises(NotImplementedError):
+            self.qarray - self.scalar
+        with pytest.raises(NotImplementedError):
+            self.qarray - self.bscalar
 
     def test_mul(self):
-        scalar = 2 + 2j
+        assert jnp.array_equal(
+            (self.qarray * self.scalar).data, self.data * self.scalar
+        )
+        assert jnp.array_equal(
+            (self.qarray * self.bscalar).data, self.data * self.bscalar
+        )
 
-        assert jnp.array_equal((self.qarray * scalar).data, self.data * scalar)
-        assert jnp.array_equal((self.qarray * self.other).data, self.data * self.other)
-        assert jnp.array_equal((self.qarray * self.qother).data, self.data * self.other)
+    def test_rmul(self):
+        assert jnp.array_equal(
+            (self.scalar * self.qarray).data, self.scalar * self.data
+        )
+        assert jnp.array_equal(
+            (self.bscalar * self.qarray).data, self.bscalar * self.data
+        )
+
+    def test_elmul(self):
+        assert jnp.array_equal(
+            self.qarray.elmul(self.other).data, self.data * self.other
+        )
+        assert jnp.array_equal(
+            self.qarray.elmul(self.qother).data, self.data * self.other
+        )
 
     def test_matmul(self):
         assert jnp.array_equal((self.qarray @ self.other).data, self.data @ self.other)
@@ -63,3 +99,17 @@ class TestDenseQArray:
 
         assert jnp.array_equal(t.data, tensor(self.data, other).data)
         assert t.dims == (2, 2, 3)
+
+    def test_powm(self):
+        assert jnp.array_equal(self.qarray.powm(2).data, self.data @ self.data)
+        assert jnp.array_equal(
+            self.qarray.powm(3).data, self.data @ self.data @ self.data
+        )
+
+    def test_pow(self):
+        with pytest.raises(NotImplementedError):
+            self.qarray**2
+
+    def test_elpow(self):
+        assert jnp.array_equal(self.qarray.elpow(2).data, self.data**2)
+        assert jnp.array_equal(self.qarray.elpow(3).data, self.data**3)

--- a/tests/qarrays/test_sparse_dia_qarray.py
+++ b/tests/qarrays/test_sparse_dia_qarray.py
@@ -41,7 +41,7 @@ class TestSparseDIAQArray:
         diagsB = diagsB.at[2, :1].set(0)
         diagsB = diagsB.at[3, :3].set(0)
 
-        # = matrix A =
+        # matrix A
         make_dictA = lambda x: dict(
             simple=x,
             batch=dq.stack([x, 2 * x]),
@@ -54,7 +54,7 @@ class TestSparseDIAQArray:
         self.denseA = make_dictA(denseA)
         self.sparseA = make_dictA(sparseA)
 
-        # = matrix B =
+        # matrix B
         make_dictB = lambda x: dict(
             simple=x,
             batch=dq.stack([x, 2 * x, 3 * x]),
@@ -67,97 +67,140 @@ class TestSparseDIAQArray:
         self.denseB = make_dictB(denseB)
         self.sparseB = make_dictB(sparseB)
 
+        # scalar
+        self.scalar = 2 + 2j
+        self.bscalar = jnp.ones((2, 2, 1, 1), dtype=jnp.complex64)
+
     @pytest.mark.parametrize('kA', ['simple', 'batch', 'batch_broadcast'])
-    def test_convert(self, kA, rtol=1e-05, atol=1e-08):
-        assert jnp.allclose(
-            self.denseA[kA].to_jax(),
-            self.denseA[kA].assparsedia().to_jax(),
-            rtol=rtol,
-            atol=atol,
-        )
+    def test_convert(self, kA):
+        d = self.denseA[kA]
+        assert _allclose(d.to_jax(), d.assparsedia().to_jax())
 
     @pytest.mark.parametrize(('kA', 'kB'), valid_operation_keys)
-    def test_add(self, kA, kB, rtol=1e-05, atol=1e-08):
+    def test_add(self, kA, kB):
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
-
         out_dense_dense = (dA + dB).to_jax()
-
         out_dia_dia = (sA + sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
 
+        # check dia + dia
+        assert _allclose(out_dense_dense, out_dia_dia)
+
+        # check dia + dense
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
             out_dia_dense = (sA + dB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dia_dense)
 
+        # check dense + dia
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
             out_dense_dia = (dA + sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dense_dia)
+
+        # check addition with a scalar raises an error
+        with pytest.raises(NotImplementedError):
+            sA + self.scalar
+        with pytest.raises(NotImplementedError):
+            sA + self.bscalar
+
+    @pytest.mark.parametrize('kA', ['simple', 'batch', 'batch_broadcast'])
+    def test_scalaradd(self, kA):
+        d, s = self.denseA[kA], self.sparseA[kA]
+
+        assert _allclose(d.addscalar(self.scalar).to_jax(), d.to_jax() + self.scalar)
+        assert _allclose(d.addscalar(self.bscalar).to_jax(), d.to_jax() + self.bscalar)
+        assert _allclose(s.addscalar(self.scalar).to_jax(), s.to_jax() + self.scalar)
+        assert _allclose(s.addscalar(self.bscalar).to_jax(), s.to_jax() + self.bscalar)
 
     @pytest.mark.parametrize(('kA', 'kB'), valid_operation_keys)
-    def test_sub(self, kA, kB, rtol=1e-05, atol=1e-08):
+    def test_sub(self, kA, kB):
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
-
         out_dense_dense = (dA - dB).to_jax()
         out_dia_dia = (sA - sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
 
+        # check dia - dia
+        assert _allclose(out_dense_dense, out_dia_dia)
+
+        # check dia - dense
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
             out_dia_dense = (sA - dB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dia_dense)
 
+        # check dense - dia
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', category=UserWarning)
             out_dense_dia = (dA - sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dense_dia)
+
+        # check subtraction with a scalar raises an error
+        with pytest.raises(NotImplementedError):
+            sA - self.scalar
+        with pytest.raises(NotImplementedError):
+            sA - self.bscalar
+
+    @pytest.mark.parametrize('kA', ['simple', 'batch', 'batch_broadcast'])
+    def test_mul(self, kA):
+        d, s = self.denseA[kA], self.sparseA[kA]
+
+        assert _allclose((d * self.scalar).to_jax(), d.to_jax() * self.scalar)
+        assert _allclose((d * self.bscalar).to_jax(), d.to_jax() * self.bscalar)
+        assert _allclose((s * self.scalar).to_jax(), s.to_jax() * self.scalar)
+        assert _allclose((s * self.bscalar).to_jax(), s.to_jax() * self.bscalar)
+
+        # check multiplication with a qarray raises an error
+        with pytest.raises(NotImplementedError):
+            s * d
+        with pytest.raises(NotImplementedError):
+            s * s
 
     @pytest.mark.parametrize(('kA', 'kB'), valid_operation_keys)
-    def test_mul(self, kA, kB, rtol=1e-05, atol=1e-08):
+    def test_elmul(self, kA, kB):
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
+        out_dense_dense = dA.elmul(dB).to_jax()
 
-        out_dense_dense = (dA * dB).to_jax()
+        # check dia * dia
+        out_dia_dia = sA.elmul(sB).to_jax()
+        assert _allclose(out_dense_dense, out_dia_dia)
 
-        out_dia_dia = (sA * sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
+        # check dia * dense
+        out_dia_dense = sA.elmul(dB).to_jax()
+        assert _allclose(out_dense_dense, out_dia_dense)
 
-        out_dia_dense = (sA * dB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
-
-        out_dense_dia = (dA * sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
+        # check dense * dia
+        out_dense_dia = dA.elmul(sB).to_jax()
+        assert _allclose(out_dense_dense, out_dense_dia)
 
     @pytest.mark.parametrize(('kA', 'kB'), valid_operation_keys)
-    def test_matmul(self, kA, kB, rtol=1e-05, atol=1e-08):
+    def test_matmul(self, kA, kB):
         dA, sA = self.denseA[kA], self.sparseA[kA]
         dB, sB = self.denseB[kB], self.sparseB[kB]
 
         out_dense_dense = (dA @ dB).to_jax()
 
         out_dia_dia = (sA @ sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dia_dia)
 
         out_dia_dense = (sA @ dB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dia_dense)
 
         out_dense_dia = (dA @ sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dense_dia, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dense_dia)
 
-    def test_kronecker(self, rtol=1e-05, atol=1e-08):
+    def test_kronecker(self):
         dA, sA = self.denseA['simple'], self.sparseA['simple']
         dB, sB = self.denseB['simple'], self.sparseB['simple']
 
         out_dense_dense = (dA & dB).to_jax()
 
         out_dia_dia = (sA & sB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dia, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dia_dia)
 
         out_dia_dense = (sA & dB).to_jax()
-        assert jnp.allclose(out_dense_dense, out_dia_dense, rtol=rtol, atol=atol)
+        assert _allclose(out_dense_dense, out_dia_dense)
 
     def test_outofbounds(self):
         # set up matrix
@@ -171,19 +214,23 @@ class TestSparseDIAQArray:
             dq.SparseDIAQArray(diags=diags, offsets=offsets, dims=(N,))
 
     @pytest.mark.parametrize('k', ['simple', 'batch', 'batch_broadcast'])
-    def test_pow(self, k, rtol=1e-05, atol=1e-08):
+    def test_elpow(self, k):
         d, s = self.denseA[k], self.sparseA[k]
 
-        out_dense = (d**3).to_jax()
-        out_dia = (s**3).to_jax()
+        out_dense = d.elpow(3).to_jax()
+        out_dia = s.elpow(3).to_jax()
 
-        assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)
+        assert _allclose(out_dia, out_dense)
 
     @pytest.mark.parametrize('k', ['simple', 'batch', 'batch_broadcast'])
-    def test_powm(self, k, rtol=1e-05, atol=1e-08):
+    def test_powm(self, k):
         d, s = self.denseA[k], self.sparseA[k]
 
         out_dense = d.powm(3).to_jax()
         out_dia = s.powm(3).to_jax()
 
-        assert jnp.allclose(out_dia, out_dense, rtol=rtol, atol=atol)
+        assert _allclose(out_dia, out_dense)
+
+
+def _allclose(a, b, rtol=1e-05, atol=1e-08):
+    return jnp.allclose(a, b, rtol=rtol, atol=atol)


### PR DESCRIPTION
- Introduce stricter operations throughout QArrays (both dense and sparse), e.g. disallow `dq.sigmaz() + 3`, `dq.sigmaz() * dq.sigmax()` or `dq.sigmax()**2`
- Introduce alternative methods `addscalar`, `elmul` and `elpow` to replace these functionnalities
- Move all checks to the base `QArray` class: the only remaining warnings are when a sparse qarray is converted to a dense one
- Rename `other` to `y` throughout SparseQArray to match the naming conventions of the other two files