### PR TITLE
Various small nits and renamings

### DIFF
--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -8,7 +8,7 @@ import equinox as eqx
 from jax import Array
 from jaxtyping import PyTree
 from ...gradient import Autograd, CheckpointAutograd
-from ...qarrays.utils import tree_sum
+from ...qarrays.utils import sum_qarrays
 from .abstract_integrator import BaseIntegrator
 from ...result import Result
 from ...utils.general import dag
@@ -220,8 +220,8 @@ class MEDiffraxIntegrator(DiffraxIntegrator, MEInterface):
 
         def vector_field(t, y, _):  # noqa: ANN001, ANN202
             L, H = self.L(t), self.H(t)
-            Hnh = tree_sum([-1j * H] + [-0.5 * _L.dag() @ _L for _L in L])
-            tmp = tree_sum([Hnh @ y] + [0.5 * _L @ y @ _L.dag() for _L in L])
+            Hnh = sum_qarrays(-1j * H, *[-0.5 * _L.dag() @ _L for _L in L])
+            tmp = sum_qarrays(Hnh @ y, *[0.5 * _L @ y @ _L.dag() for _L in L])
             return tmp + tmp.dag()
 
         return dx.ODETerm(vector_field)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -170,7 +170,7 @@ class QArray(eqx.Module):
     # - the properties: dtype, layout, shape, mT
     # - the methods:
     #   - QArray methods: conj, dag, reshape, broadcast_to, ptrace, powm, expm,
-    #                     _abs, block_until_ready
+    #                     block_until_ready
     #   - returning a JAX array or other: norm, trace, sum, squeeze, _eigh, _eigvals,
     #                                     _eigvalsh, devices, isherm
     #   - conversion/utils methods: to_qutip, to_jax, __array__, block_until_ready

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -9,7 +9,6 @@ from jax import Array
 
 from .._checks import check_shape
 from .._utils import on_cpu
-from ..qarrays.dense_qarray import DenseQArray
 from ..qarrays.qarray import QArray, QArrayLike, _get_dims, _to_jax
 from ..qarrays.utils import _init_dims, asqarray, to_jax, tree_sum
 
@@ -470,7 +469,6 @@ def norm(x: QArrayLike) -> Array:
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 
     if isket(x) or isbra(x):
-        assert isinstance(x, DenseQArray)
         return jnp.sqrt((jnp.abs(x.to_jax()) ** 2).sum((-2, -1)))
     else:
         return trace(x).real

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -10,7 +10,7 @@ from jax import Array
 from .._checks import check_shape
 from .._utils import on_cpu
 from ..qarrays.qarray import QArray, QArrayLike, _get_dims, _to_jax
-from ..qarrays.utils import _init_dims, asqarray, to_jax, tree_sum
+from ..qarrays.utils import _init_dims, asqarray, sum_qarrays, to_jax
 
 __all__ = [
     'bloch_coordinates',
@@ -594,7 +594,9 @@ def lindbladian(H: QArrayLike, jump_ops: list[QArrayLike], rho: QArrayLike) -> Q
     # === check rho shape
     check_shape(rho, 'rho', '(..., n, n)')
 
-    return -1j * (H @ rho - rho @ H) + tree_sum([dissipator(L, rho) for L in jump_ops])
+    return sum_qarrays(
+        -1j * H @ rho, 1j * rho @ H, *[dissipator(L, rho) for L in jump_ops]
+    )
 
 
 def isket(x: QArrayLike) -> bool:

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .._checks import check_shape
 from ..qarrays.qarray import QArray, QArrayLike
-from ..qarrays.utils import asqarray, tree_sum
+from ..qarrays.utils import asqarray, sum_qarrays
 from .general import dag
 from .operators import eye
 
@@ -249,5 +249,6 @@ def slindbladian(H: QArrayLike, jump_ops: list[QArrayLike]) -> QArray:
     for i, L in enumerate(jump_ops):
         check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
 
-    terms = [-1j * spre(H), 1j * spost(H)] + [sdissipator(L) for L in jump_ops]
-    return tree_sum(terms)
+    return sum_qarrays(
+        -1j * spre(H), 1j * spost(H), *[sdissipator(L) for L in jump_ops]
+    )


### PR DESCRIPTION
Also fixes the bug introduced in recent commit with `dq.lindbladian()` raising an error if `jump_ops` is an empty list.