### PR TITLE
Refactor reformat

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -61,7 +61,7 @@ class DenseQArray(QArray):
         data = self.data.conj()
         return self._replace(data=data)
 
-    def reshape(self, *shape: int) -> QArray:
+    def _reshape_unchecked(self, shape: tuple[int, ...]) -> QArray:
         data = jnp.reshape(self.data, shape)
         return self._replace(data=data)
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -61,7 +61,7 @@ class DenseQArray(QArray):
         data = self.data.conj()
         return self._replace(data=data)
 
-    def _reshape_unchecked(self, shape: tuple[int, ...]) -> QArray:
+    def _reshape_unchecked(self, *shape: int) -> QArray:
         data = jnp.reshape(self.data, shape)
         return self._replace(data=data)
 

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -271,10 +271,10 @@ class QArray(eqx.Module):
 
     @abstractmethod
     def _reshape_unchecked(self, shape: tuple[int, ...]) -> QArray:
-        """Does the heavy-lifting for `reshape` but skips all checks.
-        This private method allows for more powerful reshapes that
-        are useful for vectorization.
-        """
+        # Does the heavy-lifting for `reshape` but skips all checks.
+        # This private method allows for more powerful reshapes that
+        # are useful for vectorization.
+        pass
 
     @abstractmethod
     def broadcast_to(self, *shape: int) -> QArray:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -267,10 +267,10 @@ class QArray(eqx.Module):
                 f'Cannot reshape to shape {shape} because the last two dimensions do '
                 f'not match current shape dimensions, {self.shape}.'
             )
-        return self._reshape_unchecked(shape)
+        return self._reshape_unchecked(*shape)
 
     @abstractmethod
-    def _reshape_unchecked(self, shape: tuple[int, ...]) -> QArray:
+    def _reshape_unchecked(self, *shape: int) -> QArray:
         # Does the heavy-lifting for `reshape` but skips all checks.
         # This private method allows for more powerful reshapes that
         # are useful for vectorization.

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -253,7 +253,6 @@ class QArray(eqx.Module):
     def dag(self) -> QArray:
         return self.mT.conj()
 
-    @abstractmethod
     def reshape(self, *shape: int) -> QArray:
         """Returns a reshaped copy of a qarray.
 
@@ -262,6 +261,19 @@ class QArray(eqx.Module):
 
         Returns:
             New qarray object with the given shape.
+        """
+        if shape[-2:] != self.shape[-2:]:
+            raise ValueError(
+                f'Cannot reshape to shape {shape} because the last two dimensions do '
+                f'not match current shape dimensions, {self.shape}.'
+            )
+        return self._reshape_unchecked(shape)
+
+    @abstractmethod
+    def _reshape_unchecked(self, shape: tuple[int, ...]) -> QArray:
+        """Does the heavy-lifting for `reshape` but skips all checks.
+        This private method allows for more powerful reshapes that
+        are useful for vectorization.
         """
 
     @abstractmethod

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -112,13 +112,7 @@ class SparseDIAQArray(QArray):
         diags = self.diags.conj()
         return self._replace(diags=diags)
 
-    def reshape(self, *shape: int) -> QArray:
-        if shape[-2:] != self.shape[-2:]:
-            raise ValueError(
-                f'Cannot reshape to shape {shape} because the last two dimensions do '
-                f'not match current shape dimensions, {self.shape}.'
-            )
-
+    def _reshape_unchecked(self, shape: tuple[int, ...]) -> QArray:
         offsets, diags = reshape_sparsedia(self.offsets, self.diags, shape)
         return self._replace(offsets=offsets, diags=diags)
 

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -112,7 +112,7 @@ class SparseDIAQArray(QArray):
         diags = self.diags.conj()
         return self._replace(diags=diags)
 
-    def _reshape_unchecked(self, shape: tuple[int, ...]) -> QArray:
+    def _reshape_unchecked(self, *shape: int) -> QArray:
         offsets, diags = reshape_sparsedia(self.offsets, self.diags, shape)
         return self._replace(offsets=offsets, diags=diags)
 

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -51,7 +51,7 @@ def operator_to_vector(x: QArrayLike) -> QArray:
     x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
     bshape = x.shape[:-2]
-    x = x.mT.reshape(*bshape, -1, 1)
+    x = x.mT._reshape_unchecked((*bshape, -1, 1))  # noqa: SLF001
     return x._replace(vectorized=True)
 
 
@@ -90,7 +90,7 @@ def vector_to_operator(x: QArrayLike) -> QArray:
     bshape = x.shape[:-2]
     n = int(np.sqrt(x.shape[-2]))
     x = x._replace(dims=(n,))
-    x = x.reshape(*bshape, n, n).mT
+    x = x._reshape_unchecked((*bshape, n, n)).mT  # noqa: SLF001
     return x._replace(vectorized=False)
 
 

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -51,7 +51,7 @@ def operator_to_vector(x: QArrayLike) -> QArray:
     x = asqarray(x)
     check_shape(x, 'x', '(..., n, n)')
     bshape = x.shape[:-2]
-    x = x.mT._reshape_unchecked((*bshape, -1, 1))  # noqa: SLF001
+    x = x.mT._reshape_unchecked(*bshape, -1, 1)  # noqa: SLF001
     return x._replace(vectorized=True)
 
 
@@ -90,7 +90,7 @@ def vector_to_operator(x: QArrayLike) -> QArray:
     bshape = x.shape[:-2]
     n = int(np.sqrt(x.shape[-2]))
     x = x._replace(dims=(n,))
-    x = x._reshape_unchecked((*bshape, n, n)).mT  # noqa: SLF001
+    x = x._reshape_unchecked(*bshape, n, n).mT  # noqa: SLF001
     return x._replace(vectorized=False)
 
 


### PR DESCRIPTION
Solves vectorization bug where checks were too stricts. 
Instead of making them more flexible with weird conditions for internal use only, I created a `_reshape_unchecked` method that skips all checks and gives full power. This avoids weird conditions such as `shape[-2] == shape[-2] or shape[-2] == shape[-2] * shape[-1] and shape[-1] == 1`

Another option was to move the `operator_to_vector` logic inside the classes but it boiled to adding this `_reshape_unchecked` anyway