### PR TITLE
Fix the Floquet periodicity check using `eqx.tree_at`

### DIFF
--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -175,11 +175,11 @@ def _check_floquet_args(
     # === check that the Hamiltonian is periodic with the supplied period
     # attach the check to `tsave` instead of `H` to workaround CallableTimeQArrays that
     # do not have an underlying array to attach the check to
-    tol = 1e-6  # TODO: fix hard-coded tolerance for periodicity check
+    rtol, atol = 1e-5, 1e-8  # TODO: fix hard-coded tolerance for periodicity check
     tsave = eqx.error_if(
         tsave,
         jnp.logical_not(
-            eqx.tree_equal(H(0.0), H(T), rtol=tol, atol=tol, typematch=True)
+            eqx.tree_equal(H(0.0), H(T), rtol=rtol, atol=atol, typematch=True)
         ),
         'The Hamiltonian H is not periodic with the supplied period T.',
     )

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -175,9 +175,12 @@ def _check_floquet_args(
     # === check that the Hamiltonian is periodic with the supplied period
     # attach the check to `tsave` instead of `H` to workaround CallableTimeQArrays that
     # do not have an underlying array to attach the check to
+    tol = 1e-6  # TODO: fix hard-coded tolerance for periodicity check
     tsave = eqx.error_if(
         tsave,
-        jnp.logical_not(jnp.isclose(H(0.0)._underlying_array, H(T)._underlying_array)),
+        jnp.logical_not(
+            eqx.tree_equal(H(0.0), H(T), rtol=tol, atol=tol, typematch=True)
+        ),
         'The Hamiltonian H is not periodic with the supplied period T.',
     )
 

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -53,10 +53,6 @@ class DenseQArray(QArray):
         data = self.data.mT
         return self._replace(data=data)
 
-    @property
-    def _underlying_array(self) -> Array:
-        return self.data
-
     def conj(self) -> QArray:
         data = self.data.conj()
         return self._replace(data=data)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -170,7 +170,7 @@ class QArray(eqx.Module):
     """  # noqa: E501
 
     # Subclasses should implement:
-    # - the properties: dtype, layout, shape, mT, _underlying_array
+    # - the properties: dtype, layout, shape, mT
     # - the methods:
     #   - QArray methods: conj, dag, reshape, broadcast_to, ptrace, powm, expm,
     #                     block_until_ready
@@ -237,10 +237,6 @@ class QArray(eqx.Module):
     @property
     def ndim(self) -> int:
         return len(self.shape)
-
-    @property
-    def _underlying_array(self) -> Array:
-        pass
 
     @abstractmethod
     def conj(self) -> QArray:

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -101,10 +101,6 @@ class SparseDIAQArray(QArray):
         return self._replace(offsets=offsets, diags=diags)
 
     @property
-    def _underlying_array(self) -> Array:
-        return self.diags
-
-    @property
     def ndiags(self) -> int:
         return len(self.offsets)
 


### PR DESCRIPTION
Follow up on https://github.com/dynamiqs/dynamiqs/pull/836 to use `eqx.tree_equal` for the periodicity check, which is much more neat than my previous `_underlying_array` thing. 

The only issue is that I have to hardcode a tolerence for the check. In principe, we could add it to `dq.Options`, but I'm a bit annoyed to have to add such a global option for only one little check. At some point, we should think of how to properly handle such cases.