### PR TITLE
Dense conversion for eigen-decompositions of sparsedia qarrays

### DIFF
--- a/dynamiqs/dark/dark.py
+++ b/dynamiqs/dark/dark.py
@@ -24,7 +24,7 @@ def quadrature_sign(dim: int, phi: float) -> QArray:
         _(qarray of shape (dim, dim))_ Quadrature sign operator.
     """
     quad = quadrature(dim, phi)
-    L, Q = quad._eigh()
+    L, Q = quad.asdense()._eigh()
     sign_L = jnp.diag(jnp.sign(L))
     array = Q @ sign_L @ dag(Q)
     return asqarray(array)

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -173,16 +173,31 @@ class SparseDIAQArray(QArray):
             'compute its eigen-decomposition.',
             stacklevel=2,
         )
-        return self.to_dense()._eig()
+        return self.asdense()._eig()
 
     def _eigh(self) -> tuple[Array, Array]:
-        raise NotImplementedError
+        warnings.warn(
+            'A SparseDIAQArray has been converted to a DenseQArray while attempting to '
+            'compute its eigen-decomposition.',
+            stacklevel=2,
+        )
+        return self.asdense()._eigh()
 
     def _eigvals(self) -> Array:
-        raise NotImplementedError
+        warnings.warn(
+            'A SparseDIAQArray has been converted to a DenseQArray while attempting to '
+            'compute its eigen-decomposition.',
+            stacklevel=2,
+        )
+        return self.asdense()._eigvals()
 
     def _eigvalsh(self) -> Array:
-        raise NotImplementedError
+        warnings.warn(
+            'A SparseDIAQArray has been converted to a DenseQArray while attempting to '
+            'compute its eigen-decomposition.',
+            stacklevel=2,
+        )
+        return self.asdense()._eigvalsh()
 
     def devices(self) -> set[jax.Device]:
         raise NotImplementedError


### PR DESCRIPTION
Also makes `dq.dark.quadrature_sign` not return a `NotImplementedError`.