### PR TITLE
Introduce a class property `out_axes` for Results

### DIFF
--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -125,8 +125,7 @@ def _vectorized_floquet(
 ) -> FloquetResult:
     # vectorize input over H
     in_axes = (H.in_axes, None, None, None, None, None)
-    # vectorize output over `_saved` and `infos`
-    out_axes = FloquetResult(None, None, None, None, 0, 0, None)
+    out_axes = FloquetResult.out_axes
 
     # cartesian batching only
     nvmap = (H.ndim - 2, 0, 0, 0, 0, 0, 0)

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -112,8 +112,7 @@ def _vectorized_mepropagator(
 ) -> MEPropagatorResult:
     # vectorize input over H and Ls
     in_axes = (H.in_axes, [L.in_axes for L in Ls], None, None, None, None)
-    # vectorize output over `_saved` and `infos`
-    out_axes = MEPropagatorResult(None, None, None, None, 0, 0)
+    out_axes = MEPropagatorResult.out_axes
 
     if options.cartesian_batching:
         nvmap = (H.ndim - 2, [L.ndim - 2 for L in Ls], 0, 0, 0, 0)

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -159,8 +159,7 @@ def _vectorized_mesolve(
 ) -> MESolveResult:
     # vectorize input over H, Ls and rho0
     in_axes = (H.in_axes, [L.in_axes for L in Ls], 0, None, None, None, None, None)
-    # vectorize output over `_saved` and `infos`
-    out_axes = MESolveResult(None, None, None, None, 0, 0)
+    out_axes = MESolveResult.out_axes
 
     if options.cartesian_batching:
         nvmap = (H.ndim - 2, [L.ndim - 2 for L in Ls], rho0.ndim - 2, 0, 0, 0, 0, 0)

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -121,8 +121,7 @@ def _vectorized_sepropagator(
 ) -> SEPropagatorResult:
     # vectorize input over H
     in_axes = (H.in_axes, None, None, None, None)
-    # vectorize output over `_saved` and `infos`
-    out_axes = SEPropagatorResult(None, None, None, None, 0, 0)
+    out_axes = SEPropagatorResult.out_axes
 
     # cartesian batching only
     nvmap = (H.ndim - 2, 0, 0, 0, 0, 0)

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -129,8 +129,7 @@ def _vectorized_sesolve(
 ) -> SESolveResult:
     # vectorize input over H and psi0
     in_axes = (H.in_axes, 0, None, None, None, None, None)
-    # vectorize output over `_saved` and `infos`
-    out_axes = SESolveResult(None, None, None, None, 0, 0)
+    out_axes = SESolveResult.out_axes
 
     if options.cartesian_batching:
         nvmap = (H.ndim - 2, psi0.ndim - 2, 0, 0, 0, 0, 0)

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -103,6 +103,11 @@ class Result(eqx.Module):
         parts_str = '\n'.join(f'{k:<{padding}}: {v}' for k, v in parts.items())
         return f'==== {self.__class__.__name__} ====\n' + parts_str
 
+    @classmethod
+    @property
+    def out_axes(cls) -> SolveResult:
+        return cls(None, None, None, None, 0, 0)
+
 
 class SolveResult(Result):
     @property
@@ -178,6 +183,11 @@ class FloquetResult(Result):
             'Modes': array_str(self.modes),
             'Quasienergies': array_str(self.quasienergies),
         }
+
+    @classmethod
+    @property
+    def out_axes(cls) -> SolveResult:
+        return cls(None, None, None, None, 0, 0, None)
 
 
 class SESolveResult(SolveResult):


### PR DESCRIPTION
Small little addition that makes life easier when vmapping externally over dynamiqs integration functions. Instead of trying to figure out the correct `out_axes`, we can now just call `jax.vmap(...,  out_axes=dq.MESolveResult.out_axes)`.