### PR TITLE
Uniformize naming conventions

### DIFF
--- a/docs/documentation/basics/batching-simulations.md
+++ b/docs/documentation/basics/batching-simulations.md
@@ -171,7 +171,7 @@ The previous examples illustrate batching over one dimension, but you can batch 
     psis = dq.coherent(16, alpha)  # (5, 6, 16, 1)
     ```
 
-### Batching over a TimeQArray
+### Batching over a time-qarray
 
 We have seen how to batch over time-independent objects, but how about time-dependent ones? It's essentially the same, you have to pass a batched [`TimeQArray`][dynamiqs.TimeQArray], in short:
 

--- a/docs/documentation/basics/closed-systems.md
+++ b/docs/documentation/basics/closed-systems.md
@@ -91,7 +91,7 @@ There are two main types of ODE solvers:
 
 ## Using Dynamiqs
 
-You can create the state and Hamiltonian using any qarray-like object. Let's take the example of a two-level system with a simple Hamiltonian:
+You can create the state and Hamiltonian using any qarray-like. Let's take the example of a two-level system with a simple Hamiltonian:
 
 ```python
 import jax.numpy as jnp

--- a/docs/documentation/basics/open-systems.md
+++ b/docs/documentation/basics/open-systems.md
@@ -105,7 +105,7 @@ Also called the **quantum-jump** approach.
 
 ## Using Dynamiqs
 
-You can create the state, Hamiltonian and jump operators using any qarray-like object. Let's take the example of a two-level system with a simple Hamiltonian and a single jump operator:
+You can create the state, Hamiltonian and jump operators using any qarray-like. Let's take the example of a two-level system with a simple Hamiltonian and a single jump operator:
 
 ```python
 import jax.numpy as jnp

--- a/docs/documentation/basics/time-dependent-operators.md
+++ b/docs/documentation/basics/time-dependent-operators.md
@@ -152,7 +152,7 @@ The returned object can be called at different times:
     ```
 
 !!! Note
-    The argument `times` must be sorted in ascending order, but does not need to be evenly spaced. When calling the resulting time-qarray object at time $t$, the returned qarray is the operator $c_k\ O_0$ corresponding to the interval $[t_k, t_{k+1}[$ in which the time $t$ falls. If $t$ does not belong to any time intervals, the returned qarray is null.
+    The argument `times` must be sorted in ascending order, but does not need to be evenly spaced. When calling the resulting time-qarray at time $t$, the returned qarray is the operator $c_k\ O_0$ corresponding to the interval $[t_k, t_{k+1}[$ in which the time $t$ falls. If $t$ does not belong to any time intervals, the returned qarray is null.
 
 ??? Note "Batching PWC operators"
     The batching of the returned time-qarray is specified by `values`. For example, to define a PWC operator batched over a parameter $\theta$:

--- a/docs/documentation/basics/time-dependent-operators.md
+++ b/docs/documentation/basics/time-dependent-operators.md
@@ -9,7 +9,7 @@ import jax.numpy as jnp
 
 ## The [`TimeQArray`][dynamiqs.TimeQArray] type
 
-In Dynamiqs, time-dependent operators are defined with [`TimeQArray`][dynamiqs.TimeQArray] objects. These objects can be called at arbitrary times, and return the corresponding qarray at that time. For example to define the Hamiltonian
+In Dynamiqs, time-dependent operators are defined with type [`TimeQArray`][dynamiqs.TimeQArray]. They can be called at arbitrary times, and return the corresponding qarray at that time. For example to define the Hamiltonian
 $$
     H_x(t)=\cos(2\pi t)\sigma_x
 $$
@@ -40,7 +40,7 @@ QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=3
 
 Finally, time-qarrays also support common utility functions, such as `.conj()`, or `.reshape()`. More details can be found in the [`TimeQArray`][dynamiqs.TimeQArray] API page.
 
-## Defining a [`TimeQArray`][dynamiqs.TimeQArray]
+## Defining a time-qarray
 
 ### Constant operators
 
@@ -48,7 +48,7 @@ A constant operator is defined by
 $$
     O(t) = O_0
 $$
-for any time $t$, where $O_0$ is an arbitrary operator. The most practical way to define constant operators is using qarray-likes. They can also be instantiated as [`TimeQArray`][dynamiqs.TimeQArray] instances using the [`dq.constant()`][dynamiqs.constant] function. For instance, to define the Pauli operator $H = \sigma_z$, you can use any of the following syntaxes:
+for any time $t$, where $O_0$ is an arbitrary operator. The most practical way to define constant operators is using qarray-likes. They can also be instantiated as time-qarrays using the [`dq.constant()`][dynamiqs.constant] function. For instance, to define the Pauli operator $H = \sigma_z$, you can use any of the following syntaxes:
 
 === "Dynamiqs utilities"
     ```python
@@ -97,7 +97,7 @@ In Dynamiqs, PWC operators are defined by:
 - `values`: the constant values $(c_0, \ldots, c_{N-1})$ for each time interval, of shape _(..., N)_,
 - `qarray`: the qarray defining the constant operator $O_0$, of shape _(n, n)_.
 
-To construct a PWC operator, these three arguments must be passed to the [`dq.pwc()`][dynamiqs.pwc] function, which returns a [`TimeQArray`][dynamiqs.TimeQArray] object. When called at some time $t$, this object then returns a qarray with shape _(..., n, n)_. For example, let us define a PWC operator $H(t)$ with constant value $3\sigma_z$ for $t\in[0, 1[$ and $-2\sigma_z$ for $t\in[1, 2[$:
+To construct a PWC operator, these three arguments must be passed to the [`dq.pwc()`][dynamiqs.pwc] function, which returns a time-qarray. When called at some time $t$, this object then returns a qarray with shape _(..., n, n)_. For example, let us define a PWC operator $H(t)$ with constant value $3\sigma_z$ for $t\in[0, 1[$ and $-2\sigma_z$ for $t\in[1, 2[$:
 ```pycon
 >>> times = [0.0, 1.0, 2.0]
 >>> values = [3.0, -2.0]
@@ -177,7 +177,7 @@ where $f(t)$ is a time-dependent scalar. In Dynamiqs, modulated operators are de
 - `f`: a Python function with signature `f(t: float) -> Scalar | Array` that returns the modulating factor $f(t)$ for any time $t$, as a scalar or an array of shape _(...)_,
 - `qarray`: the qarray defining the constant operator $O_0$, of shape _(n, n)_.
 
-To construct a modulated operator, these two arguments must be passed to the [`dq.modulated()`][dynamiqs.modulated] function, which returns a [`TimeQArray`][dynamiqs.TimeQArray] object. When called at some time $t$, this object then returns a qarray with shape _(..., n, n)_. For example, let us define the modulated operator $H(t)=\cos(2\pi t)\sigma_x$:
+To construct a modulated operator, these two arguments must be passed to the [`dq.modulated()`][dynamiqs.modulated] function, which returns a time-qarray. When called at some time $t$, this object then returns a qarray with shape _(..., n, n)_. For example, let us define the modulated operator $H(t)=\cos(2\pi t)\sigma_x$:
 ```pycon
 >>> f = lambda t: jnp.cos(2.0 * jnp.pi * t)
 >>> H = dq.modulated(f, dq.sigmax())
@@ -237,7 +237,7 @@ where $f(t)$ is a time-dependent operator. In Dynamiqs, arbitrary time-dependent
 
 - `f`: a Python function with signature `f(t: float) -> QArray` that returns the operator $f(t)$ for any time $t$, as a qarray of shape _(..., n, n)_.
 
-To construct an arbitrary time-dependent operator, pass this argument to the [`dq.timecallable()`][dynamiqs.timecallable] function, which returns a [`TimeQArray`][dynamiqs.TimeQArray] object. This object then returns a qarray with shape _(..., n, n)_ when called at any time $t$.
+To construct an arbitrary time-dependent operator, pass this argument to the [`dq.timecallable()`][dynamiqs.timecallable] function, which returns a time-qarray. This object then returns a qarray with shape _(..., n, n)_ when called at any time $t$.
 
 For example, let us define the arbitrary time-dependent operator $H(t)=\begin{pmatrix}t & 0\\0 & 1 - t\end{pmatrix}$:
 ```pycon
@@ -263,8 +263,8 @@ The returned object can be called at different times:
      [0. 0.]]
     ```
 
-!!! Warning "The function `f` must return a `QArray` (not a qarray-like!)"
-    An error is raised if the function `f` does not return a `QArray`. This error concerns any other qarray-likes. This is enforced to avoid costly conversions at every time step of the numerical integration.
+!!! Warning "The function `f` must return a qarray (not a qarray-like!)"
+    An error is raised if the function `f` does not return a qarray. This error concerns any other qarray-likes. This is enforced to avoid costly conversions at every time step of the numerical integration.
 
 ??? Note "Batching arbitrary time-dependent operators"
     The batching of the returned time-qarray is specified by the qarray returned by `f`. For example, to define an arbitrary time-dependent operator batched over a parameter $\theta$:

--- a/docs/documentation/basics/time-dependent-operators.md
+++ b/docs/documentation/basics/time-dependent-operators.md
@@ -24,7 +24,7 @@ QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=2
 (2, 2)
 ```
 
-Time-qarrays support common arithmetic operations with scalars, qarray-like objects and other time-qarrays. For example to define the Hamiltonian
+Time-qarrays support common arithmetic operations with scalars, qarray-likes and other time-qarrays. For example to define the Hamiltonian
 $$
     H(t) = \sigma_z + 2 H_x(t) - \sin(\pi t) \sigma_y
 $$
@@ -48,7 +48,7 @@ A constant operator is defined by
 $$
     O(t) = O_0
 $$
-for any time $t$, where $O_0$ is an arbitrary operator. The most practical way to define constant operators is using qarray-like objects. They can also be instantiated as [`TimeQArray`][dynamiqs.TimeQArray] instances using the [`dq.constant()`][dynamiqs.constant] function. For instance, to define the Pauli operator $H = \sigma_z$, you can use any of the following syntaxes:
+for any time $t$, where $O_0$ is an arbitrary operator. The most practical way to define constant operators is using qarray-likes. They can also be instantiated as [`TimeQArray`][dynamiqs.TimeQArray] instances using the [`dq.constant()`][dynamiqs.constant] function. For instance, to define the Pauli operator $H = \sigma_z$, you can use any of the following syntaxes:
 
 === "Dynamiqs utilities"
     ```python
@@ -263,8 +263,8 @@ The returned object can be called at different times:
      [0. 0.]]
     ```
 
-!!! Warning "The function `f` must return a `QArray` (not a qarray-like object!)"
-    An error is raised if the function `f` does not return a `QArray`. This error concerns any other qarray-like objects. This is enforced to avoid costly conversions at every time step of the numerical integration.
+!!! Warning "The function `f` must return a `QArray` (not a qarray-like!)"
+    An error is raised if the function `f` does not return a `QArray`. This error concerns any other qarray-likes. This is enforced to avoid costly conversions at every time step of the numerical integration.
 
 ??? Note "Batching arbitrary time-dependent operators"
     The batching of the returned time-qarray is specified by the qarray returned by `f`. For example, to define an arbitrary time-dependent operator batched over a parameter $\theta$:

--- a/docs/documentation/basics/workflow.md
+++ b/docs/documentation/basics/workflow.md
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 
 ## I. Define the system
 
-After having imported the necessary packages, we can define our system, namely the initial state, the Hamiltonian, and the eventual loss operators. Common states and operators are already defined in Dynamiqs, see the [Python API](../../python_api/index.md) for more details. Otherwise, you can define specific states and operators using any array-like object.
+After having imported the necessary packages, we can define our system, namely the initial state, the Hamiltonian, and the eventual loss operators. Common states and operators are already defined in Dynamiqs, see the [Python API](../../python_api/index.md) for more details. Otherwise, you can define specific states and operators using any array-like.
 
 Here, we will use [`dq.fock()`][dynamiqs.fock] to define the initial state $\ket{\psi_0}=\ket{0}$, [`dq.sigmaz()`][dynamiqs.sigmaz] and [`dq.sigmax()`][dynamiqs.sigmax] to define the Hamiltonian $H = \delta \sigma_z + \Omega \sigma_x$.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,12 +1,12 @@
-*[array-like object]: e.g. Python list, NumPy and JAX array or QuTiP Qobj
-*[Array-like object]: e.g. Python list, NumPy and JAX array or QuTiP Qobj
-*[array-like objects]: e.g. Python lists, NumPy and JAX arrays or QuTiP Qobjs
-*[Array-like objects]: e.g. Python lists, NumPy and JAX arrays or QuTiP Qobjs
+*[array-like]: e.g. Python list, NumPy and JAX array or QuTiP Qobj
+*[Array-like]: e.g. Python list, NumPy and JAX array or QuTiP Qobj
+*[array-likes]: e.g. Python lists, NumPy and JAX arrays or QuTiP Qobjs
+*[Array-likes]: e.g. Python lists, NumPy and JAX arrays or QuTiP Qobjs
 
-*[qarray-like object]: a NumPy array, a JAX array, a Dynamiqs qarray, a QuTiP Qobj, or any (potentially nested) sequence of these types
-*[Qarray-like object]: a NumPy array, a JAX array, a Dynamiqs qarray, a QuTiP Qobj, or any (potentially nested) sequence of these types
-*[qarray-like objects]: NumPy arrays, JAX arrays, Dynamiqs qarrays, QuTiP Qobjs, or any (potentially nested) sequences of these types
-*[Qarray-like objects]: NumPy arrays, JAX arrays, Dynamiqs qarrays, QuTiP Qobjs, or any (potentially nested) sequences  of these types
+*[qarray-like]: a NumPy array, a JAX array, a Dynamiqs qarray, a QuTiP Qobj, or any (potentially nested) sequence of these types
+*[Qarray-like]: a NumPy array, a JAX array, a Dynamiqs qarray, a QuTiP Qobj, or any (potentially nested) sequence of these types
+*[qarray-likes]: NumPy arrays, JAX arrays, Dynamiqs qarrays, QuTiP Qobjs, or any (potentially nested) sequences of these types
+*[Qarray-likes]: NumPy arrays, JAX arrays, Dynamiqs qarrays, QuTiP Qobjs, or any (potentially nested) sequences  of these types
 
 *[PWC]: piecewise constant
 *[SME]: stochastic master equation

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -68,5 +68,5 @@ def _is_batched_scalar(y: ArrayLike) -> bool:
 def _check_compatible_dims(dims1: tuple[int, ...], dims2: tuple[int, ...]):
     if dims1 != dims2:
         raise ValueError(
-            f'QArrays have incompatible dimensions. Got {dims1} and {dims2}.'
+            f'Qarrays have incompatible dimensions. Got {dims1} and {dims2}.'
         )

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -54,7 +54,7 @@ def _concatenate_sort(*args: Array | None) -> Array | None:
 
 
 def _is_batched_scalar(y: ArrayLike) -> bool:
-    # check if a qarray-like object is a scalar or a set of scalars of shape (..., 1, 1)
+    # check if a qarray-like is a scalar or a set of scalars of shape (..., 1, 1)
     return isinstance(y, get_args(ScalarLike)) or (
         isinstance(y, get_args(ArrayLike))
         and (

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -32,7 +32,7 @@ def _astimeqarray(x: QArrayLike | TimeQArray) -> TimeQArray:
             return ConstantTimeQArray(array)
         except (TypeError, ValueError) as e:
             raise TypeError(
-                'Argument must be a qarray-like or a time-qarray object, but has type'
+                'Argument must be a qarray-like or a time-qarray, but has type'
                 f' {obj_type_str(x)}.'
             ) from e
 

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -172,7 +172,7 @@ def _check_floquet_args(
     )
 
     # === check that the Hamiltonian is periodic with the supplied period
-    # attach the check to `tsave` instead of `H` to workaround CallableTimeQArrays that
+    # attach the check to `tsave` instead of `H` to workaround `CallableTimeQArray` that
     # do not have an underlying array to attach the check to
     rtol, atol = 1e-5, 1e-8  # TODO: fix hard-coded tolerance for periodicity check
     tsave = eqx.error_if(

--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -22,7 +22,7 @@ __all__ = ['DenseQArray']
 
 
 class DenseQArray(QArray):
-    r"""DenseQArray is QArray that uses JAX arrays as data storage."""
+    r"""A dense qarray is a qarray that uses JAX arrays as data storage."""
 
     data: Array
 

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -241,7 +241,7 @@ class QArray(eqx.Module):
         """Returns the element-wise complex conjugate of the qarray.
 
         Returns:
-            New qarray object with element-wise complex conjuguated values.
+            New qarray with element-wise complex conjuguated values.
         """
 
     def dag(self) -> QArray:
@@ -254,7 +254,7 @@ class QArray(eqx.Module):
             *shape: New shape, which must match the original size.
 
         Returns:
-            New qarray object with the given shape.
+            New qarray with the given shape.
         """
         if shape[-2:] != self.shape[-2:]:
             raise ValueError(
@@ -278,7 +278,7 @@ class QArray(eqx.Module):
             *shape: New shape, which must be compatible with the original shape.
 
         Returns:
-            New qarray object with the given shape.
+            New qarray with the given shape.
         """
 
     @abstractmethod
@@ -415,7 +415,7 @@ class QArray(eqx.Module):
         """Converts to a dense layout.
 
         Returns:
-            A `DenseQArray` object.
+            A `DenseQArray`.
         """
 
     @abstractmethod
@@ -423,7 +423,7 @@ class QArray(eqx.Module):
         """Converts to a sparse diagonal layout.
 
         Returns:
-            A `SparseDIAQArray` object.
+            A `SparseDIAQArray`.
         """
 
     @abstractmethod
@@ -525,7 +525,7 @@ class QArray(eqx.Module):
             y: Scalar to add, whose shape should be broadcastable with the qarray.
 
         Returns:
-            New qarray object resulting from the addition with the scalar.
+            New qarray resulting from the addition with the scalar.
         """
 
     @abstractmethod
@@ -536,7 +536,7 @@ class QArray(eqx.Module):
             y: Array-like to multiply with element-wise.
 
         Returns:
-            New qarray object resulting from the element-wise multiplication.
+            New qarray resulting from the element-wise multiplication.
         """
 
     @abstractmethod
@@ -547,7 +547,7 @@ class QArray(eqx.Module):
             power: Power to raise to.
 
         Returns:
-            New qarray object with elements raised to the specified power.
+            New qarray with elements raised to the specified power.
         """
 
     @abstractmethod

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -24,7 +24,7 @@ __all__ = ['QArray']
 
 
 def isqarraylike(x: Any) -> bool:
-    r"""Returns True if the input is a qarray-like object.
+    r"""Returns True if the input is a qarray-like.
 
     Args:
         x: Any object.
@@ -35,8 +35,7 @@ def isqarraylike(x: Any) -> bool:
             types.
 
     See also:
-        - [`dq.asqarray()`][dynamiqs.asqarray]: converts a qarray-like object into a
-            qarray.
+        - [`dq.asqarray()`][dynamiqs.asqarray]: converts a qarray-like into a qarray.
 
     Examples:
         >>> dq.isqarraylike(1)
@@ -103,7 +102,7 @@ class QArray(eqx.Module):
 
     Note: Constructing a new qarray from an other array type
         Use the function [`dq.asqarray()`][dynamiqs.asqarray] to create a qarray from a
-        qarray-like object. Objects that can be converted to a `QArray` are of type
+        qarray-like. Objects that can be converted to a `QArray` are of type
         `dq.QArrayLike`. This includes all numeric types (`bool`, `int`, `float`,
         `complex`), a JAX or NumPy array, a QuTiP Qobj, a dynamiqs qarray or any nested
         sequence of these types. See also [`dq.isqarraylike()`][dynamiqs.isqarraylike].
@@ -121,7 +120,7 @@ class QArray(eqx.Module):
 
     Note: Arithmetic operation support
         Qarrays support basic arithmetic operations `-, +, *, /, @` with other
-        qarray-like objects.
+        qarray-likes.
 
     Note: Shortcuts methods to use quantum utilities
         Many functions of the library can be called directly on a qarray rather than

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -533,7 +533,7 @@ class QArray(eqx.Module):
         """Computes the element-wise multiplication.
 
         Args:
-            y: Array-like object to multiply with element-wise.
+            y: Array-like to multiply with element-wise.
 
         Returns:
             New qarray object resulting from the element-wise multiplication.
@@ -586,7 +586,7 @@ def _include_last_two_dims(axis: int | tuple[int, ...] | None, ndim: int) -> boo
 # - a nested sequence of these types.
 # An object of type `QArrayLike` can be converted to a `QArray` with `asqarray`.
 
-# extended array like type
+# extended array-like type
 _QArrayLike = Union[ArrayLike, QArray, Qobj]
 # a type alias for nested sequence of _QArrayLike
 _NestedQArrayLikeSequence = Sequence[Union[_QArrayLike, '_NestedQArrayLikeSequence']]

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -113,7 +113,7 @@ class QArray(eqx.Module):
         ndim _(int)_: Number of dimensions in the shape.
         layout _(Layout)_: Data layout, either `dq.dense` or `dq.dia`.
         dims _(tuple of ints)_: Hilbert space dimension of each subsystem.
-        mT _(QArray)_: Returns the qarray transposed over its last two dimensions.
+        mT _(qarray)_: Returns the qarray transposed over its last two dimensions.
         vectorized _(bool)_: Whether the underlying object is non-vectorized (ket, bra
             or operator) or vectorized (operator in vector form or superoperator in
             matrix form).
@@ -170,7 +170,7 @@ class QArray(eqx.Module):
     # Subclasses should implement:
     # - the properties: dtype, layout, shape, mT
     # - the methods:
-    #   - QArray methods: conj, dag, _reshape_unchecked, broadcast_to, ptrace, powm,
+    #   - qarray methods: conj, dag, _reshape_unchecked, broadcast_to, ptrace, powm,
     #                     expm, block_until_ready
     #   - returning a JAX array or other: norm, trace, sum, squeeze, _eig, _eigh,
     #                                     _eigvals, _eigvalsh, devices, isherm
@@ -208,7 +208,7 @@ class QArray(eqx.Module):
         allowed_shapes = (prod(self.dims), prod(self.dims) ** 2)
         if not (self.shape[-1] in allowed_shapes or self.shape[-2] in allowed_shapes):
             raise ValueError(
-                'Argument `dims` must be compatible with the shape of the QArray, but '
+                'Argument `dims` must be compatible with the shape of the qarray, but '
                 f'got dims {self.dims} and shape {self.shape}.'
             )
 
@@ -558,7 +558,7 @@ class QArray(eqx.Module):
 def _check_compatible_dims(dims1: tuple[int, ...], dims2: tuple[int, ...]):
     if dims1 != dims2:
         raise ValueError(
-            f'QArrays have incompatible Hilbert space dimensions. '
+            f'Qarrays have incompatible Hilbert space dimensions. '
             f'Got {dims1} and {dims2}.'
         )
 
@@ -582,13 +582,13 @@ def _include_last_two_dims(axis: int | tuple[int, ...] | None, ndim: int) -> boo
 # - a JAX array,
 # - a NumPy array,
 # - a QuTiP Qobj,
-# - a dynamiqs QArray,
+# - a dynamiqs `QArray`,
 # - a nested sequence of these types.
 # An object of type `QArrayLike` can be converted to a `QArray` with `asqarray`.
 
 # extended array-like type
 _QArrayLike = Union[ArrayLike, QArray, Qobj]
-# a type alias for nested sequence of _QArrayLike
+# a type alias for nested sequence of `_QArrayLike`
 _NestedQArrayLikeSequence = Sequence[Union[_QArrayLike, '_NestedQArrayLikeSequence']]
 # a type alias for any type compatible with asqarray
 QArrayLike = Union[_QArrayLike, _NestedQArrayLikeSequence]

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -131,8 +131,8 @@ class SparseDIAQArray(QArray):
 
     def expm(self, *, max_squarings: int = 16) -> QArray:
         warnings.warn(
-            'A SparseDIAQArray has been converted to a DenseQArray while computing its '
-            'matrix exponential.',
+            'A `SparseDIAQArray` has been converted to a `DenseQArray` while computing '
+            'its matrix exponential.',
             stacklevel=2,
         )
         x = sparsedia_to_array(self.offsets, self.diags)
@@ -169,32 +169,32 @@ class SparseDIAQArray(QArray):
 
     def _eig(self) -> tuple[Array, QArray]:
         warnings.warn(
-            'A SparseDIAQArray has been converted to a DenseQArray while attempting to '
-            'compute its eigen-decomposition.',
+            'A `SparseDIAQArray` has been converted to a `DenseQArray` while attempting'
+            ' to compute its eigen-decomposition.',
             stacklevel=2,
         )
         return self.asdense()._eig()
 
     def _eigh(self) -> tuple[Array, Array]:
         warnings.warn(
-            'A SparseDIAQArray has been converted to a DenseQArray while attempting to '
-            'compute its eigen-decomposition.',
+            'A `SparseDIAQArray` has been converted to a `DenseQArray` while attempting'
+            ' to compute its eigen-decomposition.',
             stacklevel=2,
         )
         return self.asdense()._eigh()
 
     def _eigvals(self) -> Array:
         warnings.warn(
-            'A SparseDIAQArray has been converted to a DenseQArray while attempting to '
-            'compute its eigen-decomposition.',
+            'A `SparseDIAQArray` has been converted to a `DenseQArray` while attempting'
+            ' to compute its eigen-decomposition.',
             stacklevel=2,
         )
         return self.asdense()._eigvals()
 
     def _eigvalsh(self) -> Array:
         warnings.warn(
-            'A SparseDIAQArray has been converted to a DenseQArray while attempting to '
-            'compute its eigen-decomposition.',
+            'A `SparseDIAQArray` has been converted to a `DenseQArray` while attempting'
+            ' to compute its eigen-decomposition.',
             stacklevel=2,
         )
         return self.asdense()._eigvalsh()
@@ -238,7 +238,7 @@ class SparseDIAQArray(QArray):
             pattern = r'(?<!\d)0\s*'
         else:
             raise ValueError(
-                'Unsupported dtype for SparseDIAQArray representation, got '
+                'Unsupported dtype for `SparseDIAQArray` representation, got '
                 f'{self.dtype}.'
             )
 
@@ -369,6 +369,6 @@ def _check_key_in_batch_dims(key: int | slice | tuple, ndim: int):
 
     if not valid_key:
         raise NotImplementedError(
-            'Getting items from non batching dimensions of a SparseDIAQArray is not '
+            'Getting items from non batching dimensions of a `SparseDIAQArray` is not '
             'supported.'
         )

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -36,7 +36,7 @@ __all__ = [
 def asqarray(
     x: QArrayLike, dims: tuple[int, ...] | None = None, layout: Layout | None = None
 ) -> QArray:
-    """Converts a qarray-like object into a qarray.
+    """Converts a qarray-like into a qarray.
 
     Args:
         x: Object to convert.
@@ -51,7 +51,7 @@ def asqarray(
 
     See also:
         - [`dq.isqarraylike()`][dynamiqs.isqarraylike]: returns True if the input is
-            a qarray-like object.
+            a qarray-like.
 
     Examples:
         >>> dq.asqarray([[1, 0], [0, -1]])
@@ -190,7 +190,7 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
 
 
 def to_jax(x: QArrayLike) -> Array:
-    """Convert a qarray-like object into a JAX array.
+    """Convert a qarray-like into a JAX array.
 
     Args:
         x: Object to convert.
@@ -217,7 +217,7 @@ def to_jax(x: QArrayLike) -> Array:
 
 
 def to_numpy(x: QArrayLike) -> np.ndarray:
-    """Convert a qarray-like object into a NumPy array.
+    """Convert a qarray-like into a NumPy array.
 
     Args:
         x: Object to convert.
@@ -244,7 +244,7 @@ def to_numpy(x: QArrayLike) -> np.ndarray:
 
 
 def to_qutip(x: QArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:
-    r"""Convert a qarray-like object into a QuTiP Qobj or list of Qobjs.
+    r"""Convert a qarray-like into a QuTiP Qobj or list of Qobjs.
 
     Args:
         x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -247,7 +247,7 @@ def to_qutip(x: QArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[
     r"""Convert a qarray-like into a QuTiP Qobj or list of Qobjs.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra,
             density matrix or operator.
         dims _(tuple of ints or None)_: Dimensions of each subsystem in the composite
             system Hilbert space tensor product. Defaults to `None` (`x.dims` if

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -34,7 +34,7 @@ def memory_str(x: Array) -> str:
 
 
 def array_str(x: Array | QArray | None) -> str | None:
-    # TODO: implement memory_str for QArray rather than converting to JAX array
+    # TODO: implement memory_str for `QArray` rather than converting to JAX array
     if x is None:
         return None
     type_name = 'Array' if isinstance(x, Array) else 'QArray'

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -188,9 +188,9 @@ def timecallable(
     with signature `f(t: float) -> QArray` that returns a qarray of shape _(..., n, n)_
     for any time $t$.
 
-    Warning: The function `f` must return a `QArray` (not a qarray-like object!)
+    Warning: The function `f` must return a `QArray` (not a qarray-like!)
         An error is raised if the function `f` does not return a `QArray`. This error
-        concerns any other qarray-like objects. This is enforced to avoid costly
+        concerns any other qarray-likes. This is enforced to avoid costly
         conversions at every time step of the numerical integration.
 
     Args:
@@ -259,7 +259,7 @@ class TimeQArray(eqx.Module):
 
     Note: Arithmetic operation support
         Time-qarrays support basic arithmetic operations `-, +, *` with other
-        qarray-like objects or time-qarrays.
+        qarray-likes or time-qarrays.
     """
 
     # Subclasses should implement:

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -248,7 +248,7 @@ class TimeQArray(eqx.Module):
         ndim _(int)_: Number of dimensions in the shape.
         layout _(Layout)_: Data layout, either `dq.dense` or `dq.dia`.
         dims _(tuple of ints)_: Hilbert space dimension of each subsystem.
-        mT _(TimeQArray)_: Returns the time-qarray transposed over its last two
+        mT _(time-qarray)_: Returns the time-qarray transposed over its last two
             dimensions.
         vectorized _(bool)_: Whether the underlying qarray is non-vectorized (ket, bra
             or operator) or vectorized (operator in vector form or superoperator in
@@ -313,7 +313,7 @@ class TimeQArray(eqx.Module):
     @abstractmethod
     def in_axes(self) -> PyTree[int | None]:
         # returns the `in_axes` arguments that should be passed to vmap in order
-        # to vmap the TimeQArray correctly
+        # to vmap the `TimeQArray` correctly
         pass
 
     @property
@@ -391,7 +391,7 @@ class TimeQArray(eqx.Module):
             t: Time at which to evaluate the time-qarray.
 
         Returns:
-            QArray evaluated at time $t$.
+            Qarray evaluated at time $t$.
         """
 
     def __neg__(self) -> TimeQArray:

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -30,8 +30,8 @@ def constant(qarray: QArrayLike) -> ConstantTimeQArray:
         qarray _(qarray-like of shape (..., n, n))_: Constant qarray $O_0$.
 
     Returns:
-        _(time-qarray object of shape (..., n, n) when called)_ Callable object
-            returning $O_0$ for any time $t$.
+        _(time-qarray of shape (..., n, n) when called)_ Callable returning $O_0$ for
+            any time $t$.
 
     Examples:
         >>> H = dq.constant(dq.sigmaz())
@@ -76,8 +76,8 @@ def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArra
         qarray _(qarray-like of shape (n, n))_: Constant qarray $O_0$.
 
     Returns:
-        _(time-qarray object of shape (..., n, n) when called)_ Callable object
-            returning $O(t)$ for any time $t$.
+        _(time-qarray of shape (..., n, n) when called)_ Callable returning $O(t)$ for
+            any time $t$.
 
     Examples:
         >>> times = [0.0, 1.0, 2.0]
@@ -142,8 +142,8 @@ def modulated(
             discontinuous jump in the function values.
 
     Returns:
-        _(time-qarray object of shape (..., n, n) when called)_ Callable object
-            returning $O(t)$ for any time $t$.
+        _(time-qarray of shape (..., n, n) when called)_ Callable returning $O(t)$ for
+            any time $t$.
 
     Examples:
         >>> f = lambda t: jnp.cos(2.0 * jnp.pi * t)
@@ -188,8 +188,8 @@ def timecallable(
     with signature `f(t: float) -> QArray` that returns a qarray of shape _(..., n, n)_
     for any time $t$.
 
-    Warning: The function `f` must return a `QArray` (not a qarray-like!)
-        An error is raised if the function `f` does not return a `QArray`. This error
+    Warning: The function `f` must return a qarray (not a qarray-like!)
+        An error is raised if the function `f` does not return a qarray. This error
         concerns any other qarray-likes. This is enforced to avoid costly
         conversions at every time step of the numerical integration.
 
@@ -200,8 +200,8 @@ def timecallable(
             discontinuous jump in the function values.
 
     Returns:
-       _(time-qarray object of shape (..., n, n) when called)_ Callable object
-            returning $O(t)$ for any time $t$.
+        _(time-qarray of shape (..., n, n) when called)_ Callable returning $O(t)$ for
+            any time $t$.
 
     Examples:
         >>> f = lambda t: dq.asqarray([[t, 0], [0, 1 - t]])
@@ -330,7 +330,7 @@ class TimeQArray(eqx.Module):
             *shape: New shape, which must match the original size.
 
         Returns:
-            New time-qarray object with the given shape.
+            New time-qarray with the given shape.
         """
 
     @abstractmethod
@@ -341,7 +341,7 @@ class TimeQArray(eqx.Module):
             *shape: New shape, which must be compatible with the original shape.
 
         Returns:
-            New time-qarray object with the given shape.
+            New time-qarray with the given shape.
         """
 
     @abstractmethod
@@ -349,14 +349,14 @@ class TimeQArray(eqx.Module):
         """Returns the element-wise complex conjugate of the time-qarray.
 
         Returns:
-            New time-qarray object with element-wise complex conjuguated values.
+            New time-qarray with element-wise complex conjuguated values.
         """
 
     def dag(self) -> TimeQArray:
         r"""Returns the adjoint (complex conjugate transpose) of the time-qarray.
 
         Returns:
-            New time-qarray object with adjoint values.
+            New time-qarray with adjoint values.
         """
         return self.mT.conj()
 
@@ -367,7 +367,7 @@ class TimeQArray(eqx.Module):
             axis: Axis to squeeze. If `none`, all axes with dimension 1 are squeezed.
 
         Returns:
-            New time-qarray object with squeezed_shape
+            New time-qarray with squeezed_shape
         """
         if axis is None:
             shape = self.shape

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -27,7 +27,7 @@ def constant(qarray: QArrayLike) -> ConstantTimeQArray:
     constant qarray.
 
     Args:
-        qarray _(qarray_like of shape (..., n, n))_: Constant qarray $O_0$.
+        qarray _(qarray-like of shape (..., n, n))_: Constant qarray $O_0$.
 
     Returns:
         _(time-qarray object of shape (..., n, n) when called)_ Callable object
@@ -69,11 +69,11 @@ def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArra
         any time intervals, the returned qarray is null.
 
     Args:
-        times _(array_like of shape (N+1,))_: Time points $t_k$ defining the boundaries
+        times _(array-like of shape (N+1,))_: Time points $t_k$ defining the boundaries
             of the time intervals, where _N_ is the number of time intervals.
-        values _(array_like of shape (..., N))_: Constant values $c_k$ for each time
+        values _(array-like of shape (..., N))_: Constant values $c_k$ for each time
             interval.
-        qarray _(qarray_like of shape (n, n))_: Constant qarray $O_0$.
+        qarray _(qarray-like of shape (n, n))_: Constant qarray $O_0$.
 
     Returns:
         _(time-qarray object of shape (..., n, n) when called)_ Callable object
@@ -137,8 +137,8 @@ def modulated(
         f _(function returning scalar or array of shape (...))_: Function with signature
             `f(t: float) -> Scalar | Array` that returns the modulating factor
             $f(t)$.
-        qarray _(qarray_like of shape (n, n))_: Constant qarray $O_0$.
-        discontinuity_ts _(array_like, optional)_: Times at which there is a
+        qarray _(qarray-like of shape (n, n))_: Constant qarray $O_0$.
+        discontinuity_ts _(array-like, optional)_: Times at which there is a
             discontinuous jump in the function values.
 
     Returns:
@@ -196,7 +196,7 @@ def timecallable(
     Args:
         f _(function returning qarray of shape (..., n, n))_: Function with
             signature `(t: float) -> QArray` that returns the qarray $f(t)$.
-        discontinuity_ts _(array_like, optional)_: Times at which there is a
+        discontinuity_ts _(array-like, optional)_: Times at which there is a
             discontinuous jump in the function values.
 
     Returns:

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -280,7 +280,7 @@ def ptrace(
         >>> rho_bc.shape
         (20, 20)
 
-        If the input qarray-like object `x` does not hold Hilbert space dimensions, you
+        If the input qarray-like `x` does not hold Hilbert space dimensions, you
         can specify them with the argument `dims`. For example, to trace out the second
         subsystem of the Bell state $(\ket{00}+\ket{11})/\sqrt2$:
         >>> bell_state = np.array([1, 0, 0, 1])[:, None] / np.sqrt(2)

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -48,7 +48,7 @@ def dag(x: QArrayLike) -> QArray:
     r"""Returns the adjoint (complex conjugate transpose) of a matrix.
 
     Args:
-        x _(qarray_like of shape (..., m, n))_: Matrix.
+        x _(qarray-like of shape (..., m, n))_: Matrix.
 
     Returns:
        _(qarray of shape (..., n, m))_ Adjoint of `x`.
@@ -74,7 +74,7 @@ def powm(x: QArrayLike, n: int) -> QArray:
     """Returns the $n$-th matrix power of an array.
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Square matrix.
+        x _(qarray-like of shape (..., n, n))_: Square matrix.
         n: Integer exponent.
 
     Returns:
@@ -100,7 +100,7 @@ def expm(x: QArrayLike, *, max_squarings: int = 16) -> QArray:
     The exponential is computed using the scaling-and-squaring approximation method.
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Square matrix.
+        x _(qarray-like of shape (..., n, n))_: Square matrix.
         max_squarings: Number of squarings.
 
     Returns:
@@ -125,7 +125,7 @@ def cosm(x: QArrayLike) -> QArray:
     r"""Returns the cosine of an array.
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Square matrix.
+        x _(qarray-like of shape (..., n, n))_: Square matrix.
 
     Returns:
         _(qarray of shape (..., n, n))_ Cosine of `x`.
@@ -152,7 +152,7 @@ def sinm(x: QArrayLike) -> QArray:
     r"""Returns the sine of an array.
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Square matrix.
+        x _(qarray-like of shape (..., n, n))_: Square matrix.
 
     Returns:
         _(qarray of shape (..., n, n))_ Sine of `x`.
@@ -179,7 +179,7 @@ def trace(x: QArrayLike) -> Array:
     r"""Returns the trace of an array along its last two dimensions.
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Array.
+        x _(qarray-like of shape (..., n, n))_: Array.
 
     Returns:
         _(array of shape (...))_ Trace of `x`.
@@ -212,8 +212,8 @@ def tracemm(x: QArrayLike, y: QArrayLike) -> Array:
         instead of $\mathcal{O}(n^3)$ with the naive formula.
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Array.
-        y _(qarray_like of shape (..., n, n))_: Array.
+        x _(qarray-like of shape (..., n, n))_: Array.
+        y _(qarray-like of shape (..., n, n))_: Array.
 
     Returns:
         _(array of shape (...))_ Trace of `x @ y`.
@@ -244,7 +244,7 @@ def ptrace(
     r"""Returns the partial trace of a ket, bra or density matrix.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
             or density matrix of a composite system.
         keep _(int or tuple of ints)_: Dimensions to keep after partial trace.
         dims _(tuple of ints or None)_: Dimensions of each subsystem in the composite
@@ -362,7 +362,7 @@ def tensor(*args: QArrayLike) -> QArray:
       operators with shape $(..., n_k, n_k)$.
 
     Args:
-        *args _(qarray_like of shape (..., n_k, 1) or (..., 1, n_k) or (..., n_k, n_k))_:
+        *args _(qarray-like of shape (..., n_k, 1) or (..., 1, n_k) or (..., n_k, n_k))_:
             Variable length argument list of kets, bras, density matrices or operators.
 
     Returns:
@@ -394,9 +394,9 @@ def expect(O: QArrayLike, x: QArrayLike) -> Array:
         `dq.expect(O, x).real`.
 
     Args:
-        O _(qarray_like of shape (nO?, n, n))_: Arbitrary operator or list of _nO_
+        O _(qarray-like of shape (nO?, n, n))_: Arbitrary operator or list of _nO_
             operators.
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket,
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket,
             bra or density matrix.
 
     Returns:
@@ -445,7 +445,7 @@ def norm(x: QArrayLike) -> Array:
     matrix, it is $\tr{\rho}$.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
             or density matrix.
 
     Returns:
@@ -480,7 +480,7 @@ def unit(x: QArrayLike) -> QArray:
     The returned object is divided by its norm (see [`dq.norm()`][dynamiqs.norm]).
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
             or density matrix.
 
     Returns:
@@ -510,8 +510,8 @@ def dissipator(L: QArrayLike, rho: QArrayLike) -> QArray:
     $$
 
     Args:
-        L _(qarray_like of shape (..., n, n))_: Jump operator.
-        rho _(qarray_like of shape (..., n, n))_: Density matrix.
+        L _(qarray-like of shape (..., n, n))_: Jump operator.
+        rho _(qarray-like of shape (..., n, n))_: Density matrix.
 
     Returns:
         _(qarray of shape (..., n, n))_ Resulting operator (it is not a density matrix).
@@ -556,10 +556,10 @@ def lindbladian(H: QArrayLike, jump_ops: list[QArrayLike], rho: QArrayLike) -> Q
         This superoperator is also sometimes called *Liouvillian*.
 
     Args:
-        H _(qarray_like of shape (..., n, n))_: Hamiltonian.
-        jump_ops _(list of qarray_like, each of shape (, ..., n, n))_: List of jump
+        H _(qarray-like of shape (..., n, n))_: Hamiltonian.
+        jump_ops _(list of qarray-like, each of shape (, ..., n, n))_: List of jump
             operators.
-        rho _(qarray_like of shape (..., n, n))_: Density matrix.
+        rho _(qarray-like of shape (..., n, n))_: Density matrix.
 
     Returns:
         _(qarray of shape (..., n, n))_ Resulting operator (it is not a density matrix).
@@ -603,7 +603,7 @@ def isket(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of a ket.
 
     Args:
-        x _(qarray_like of shape (...))_: Array.
+        x _(qarray-like of shape (...))_: Array.
 
     Returns:
         True if the last dimension of `x` is 1, False otherwise.
@@ -624,7 +624,7 @@ def isbra(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of a bra.
 
     Args:
-        x _(qarray_like of shape (...))_: Array.
+        x _(qarray-like of shape (...))_: Array.
 
     Returns:
         True if the second to last dimension of `x` is 1, False otherwise.
@@ -645,7 +645,7 @@ def isdm(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of a density matrix.
 
     Args:
-        x _(qarray_like of shape (...))_: Array.
+        x _(qarray-like of shape (...))_: Array.
 
     Returns:
         True if the last two dimensions of `x` are equal, False otherwise.
@@ -666,7 +666,7 @@ def isop(x: QArrayLike) -> bool:
     r"""Returns True if the array is in the format of an operator.
 
     Args:
-        x _(qarray_like of shape (...))_: Array.
+        x _(qarray-like of shape (...))_: Array.
 
     Returns:
         True if the last two dimensions of `x` are equal, False otherwise.
@@ -687,7 +687,7 @@ def isherm(x: QArrayLike, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
     r"""Returns True if the array is Hermitian.
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Array.
+        x _(qarray-like of shape (..., n, n))_: Array.
         rtol: Relative tolerance of the check.
         atol: Absolute tolerance of the check.
 
@@ -709,7 +709,7 @@ def toket(x: QArrayLike) -> QArray:
     r"""Returns the ket representation of a pure quantum state.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
         _(qarray of shape (..., n, 1))_ Ket.
@@ -738,7 +738,7 @@ def tobra(x: QArrayLike) -> QArray:
     r"""Returns the bra representation of a pure quantum state.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
         _(qarray of shape (..., 1, n))_ QArray.
@@ -771,7 +771,7 @@ def todm(x: QArrayLike) -> QArray:
         density matrix, it is returned directly.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n) or (..., n, n))_: Ket, bra
             or density matrix.
 
     Returns:
@@ -806,7 +806,7 @@ def proj(x: QArrayLike) -> QArray:
     $P_{\ket\psi} = \ket\psi\bra\psi$.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
+        x _(qarray-like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
         _(qarray of shape (..., n, n))_ Projection operator.
@@ -832,8 +832,8 @@ def braket(x: QArrayLike, y: QArrayLike) -> Array:
     r"""Returns the inner product $\braket{\psi|\varphi}$ between two kets.
 
     Args:
-        x (qarray_like of shape _(..., n, 1))_: Left-side ket.
-        y (qarray_like of shape _(..., n, 1))_: Right-side ket.
+        x (qarray-like of shape _(..., n, 1))_: Left-side ket.
+        y (qarray-like of shape _(..., n, 1))_: Right-side ket.
 
     Returns:
         _(array of shape (...))_ Complex-valued inner product.
@@ -865,8 +865,8 @@ def overlap(x: QArrayLike, y: QArrayLike) -> Array:
       $\sigma$.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
-        y _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        x _(qarray-like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        y _(qarray-like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
         _(array of shape (...))_ Real-valued overlap.
@@ -911,8 +911,8 @@ def fidelity(x: QArrayLike, y: QArrayLike) -> Array:
         fidelity $F_\text{qutip} = \sqrt{F}$.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
-        y _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        x _(qarray-like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        y _(qarray-like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
         _(array of shape (...))_ Real-valued fidelity.
@@ -999,7 +999,7 @@ def entropy_vn(x: QArrayLike) -> Array:
     It is defined by $S(\rho) = -\tr{\rho \ln \rho}$.
 
     Args:
-        x _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
+        x _(qarray-like of shape (..., n, 1) or (..., n, n))_: Ket or density matrix.
 
     Returns:
         _(array of shape (...))_ Real-valued Von Neumann entropy.
@@ -1041,7 +1041,7 @@ def bloch_coordinates(x: QArrayLike) -> Array:
     By convention, we choose $\phi=0$ if $\theta=0$, and $\theta=\phi=0$ if $r=0$.
 
     Args:
-        x _(qarray_like of shape (2, 1) or (2, 2))_: Ket or density matrix.
+        x _(qarray-like of shape (2, 1) or (2, 2))_: Ket or density matrix.
 
     Returns:
         _(array of shape (3,))_ Spherical coordinates $(r, \theta, \phi)$.

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -741,7 +741,7 @@ def tobra(x: QArrayLike) -> QArray:
         x _(qarray-like of shape (..., n, 1) or (..., 1, n))_: Ket or bra.
 
     Returns:
-        _(qarray of shape (..., 1, n))_ QArray.
+        _(qarray of shape (..., 1, n))_ Qarray.
 
     Examples:
         >>> psi = dq.fock(3, 0)  # shape: (3, 1)

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -376,7 +376,7 @@ def displace(dim: int, alpha: ArrayLike) -> DenseQArray:
 
     Args:
         dim: Dimension of the Hilbert space.
-        alpha _(array_like of shape (...))_: Displacement amplitude.
+        alpha _(array-like of shape (...))_: Displacement amplitude.
 
     Returns:
         _(qarray of shape (..., dim, dim))_ Displacement operator.
@@ -408,7 +408,7 @@ def squeeze(dim: int, z: ArrayLike) -> DenseQArray:
 
     Args:
         dim: Dimension of the Hilbert space.
-        z _(array_like of shape (...))_: Squeezing amplitude.
+        z _(array-like of shape (...))_: Squeezing amplitude.
 
     Returns:
         _(qarray of shape (..., dim, dim))_ Squeezing operator.
@@ -679,7 +679,7 @@ def rx(theta: ArrayLike) -> QArray:
     $$
 
     Args:
-        theta _(array_like of shape (...))_: Rotation angle $\theta$ in radians.
+        theta _(array-like of shape (...))_: Rotation angle $\theta$ in radians.
 
     Returns:
         _(qarray of shape (2, 2))_ $R_x(\theta)$ gate.
@@ -712,7 +712,7 @@ def ry(theta: ArrayLike) -> QArray:
     $$
 
     Args:
-        theta _(array_like of shape (...))_: Rotation angle $\theta$ in radians.
+        theta _(array-like of shape (...))_: Rotation angle $\theta$ in radians.
 
     Returns:
         _(qarray of shape (2, 2))_ $R_y(\theta)$ gate.
@@ -745,7 +745,7 @@ def rz(theta: ArrayLike) -> QArray:
     $$
 
     Args:
-        theta _(array_like of shape (...))_: Rotation angle $\theta$ in radians.
+        theta _(array-like of shape (...))_: Rotation angle $\theta$ in radians.
 
     Returns:
         _(qarray of shape (2, 2))_ $R_z(\theta)$ gate.

--- a/dynamiqs/utils/optimal_control.py
+++ b/dynamiqs/utils/optimal_control.py
@@ -24,7 +24,7 @@ def snap_gate(phase: ArrayLike) -> QArray:
     $$
 
     Args:
-        phase _(array_like of shape (..., n))_: Phase for each Fock state. The last
+        phase _(array-like of shape (..., n))_: Phase for each Fock state. The last
             dimension of the array _n_ defines the Hilbert space dimension.
 
     Returns:
@@ -61,7 +61,7 @@ def cd_gate(dim: int, alpha: ArrayLike) -> QArray:
 
     Args:
         dim: Dimension of the oscillator Hilbert space.
-        alpha _(array_like of shape (...))_: Displacement amplitude.
+        alpha _(array-like of shape (...))_: Displacement amplitude.
 
     Returns:
         _(qarray of shape (..., n, n))_ CD gate operator (acting on the oscillator + TLS

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -32,7 +32,7 @@ def fock(dim: int | tuple[int, ...], number: ArrayLike) -> QArray:
 
     Args:
         dim: Hilbert space dimension of each mode.
-        number _(array_like of shape (...) or (..., len(dim)))_: Fock state number
+        number _(array-like of shape (...) or (..., len(dim)))_: Fock state number
             for each mode, of integer type. If `dim` is a tuple, the last dimension of
             `number` should match the length of `dim`.
 
@@ -129,7 +129,7 @@ def fock_dm(dim: int | tuple[int, ...], number: ArrayLike) -> QArray:
 
     Args:
         dim: Hilbert space dimension of each mode.
-        number _(array_like of shape (...) or (..., len(dim)))_: Fock state number
+        number _(array-like of shape (...) or (..., len(dim)))_: Fock state number
             for each mode, of integer type. If `dim` is a tuple, the last dimension of
             `number` should match the length of `dim`.
 
@@ -195,7 +195,7 @@ def coherent(dim: int | tuple[int, ...], alpha: ArrayLike | list[ArrayLike]) -> 
 
     Args:
         dim: Hilbert space dimension of each mode.
-        alpha _(array_like of shape (...) or (len(dim), ...))_: Coherent state
+        alpha _(array-like of shape (...) or (len(dim), ...))_: Coherent state
             amplitude for each mode. If `dim` is a tuple, the first dimension of
             `alpha` should match the length of `dim`.
 
@@ -267,7 +267,7 @@ def coherent_dm(dim: int | tuple[int, ...], alpha: ArrayLike) -> QArray:
 
     Args:
         dim: Hilbert space dimension of each mode.
-        alpha _(array_like of shape (...) or (..., len(dim)))_: Coherent state
+        alpha _(array-like of shape (...) or (..., len(dim)))_: Coherent state
             amplitude for each mode. If `dim` is a tuple, the last dimension of
             `alpha` should match the length of `dim`.
 

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -31,7 +31,7 @@ def operator_to_vector(x: QArrayLike) -> QArray:
     $$
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Operator.
+        x _(qarray-like of shape (..., n, n))_: Operator.
 
     Returns:
         _(qarray of shape (..., n^2, 1))_ Vectorized operator.
@@ -68,7 +68,7 @@ def vector_to_operator(x: QArrayLike) -> QArray:
     $$
 
     Args:
-        x _(qarray_like of shape (..., n^2, 1))_: Vectorized operator.
+        x _(qarray-like of shape (..., n^2, 1))_: Vectorized operator.
 
     Returns:
         _(qarray of shape (..., n, n))_ Operator.
@@ -104,7 +104,7 @@ def spre(x: QArrayLike) -> QArray:
     $$
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Operator.
+        x _(qarray-like of shape (..., n, n))_: Operator.
 
     Returns:
         _(qarray of shape (..., n^2, n^2))_ Pre-multiplication superoperator.
@@ -130,7 +130,7 @@ def spost(x: QArrayLike) -> QArray:
     $$
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Operator.
+        x _(qarray-like of shape (..., n, n))_: Operator.
 
     Returns:
         _(qarray of shape (..., n^2, n^2))_ Post-multiplication superoperator.
@@ -156,8 +156,8 @@ def sprepost(x: QArrayLike, y: QArrayLike) -> QArray:
     $$
 
     Args:
-        x _(qarray_like of shape (..., n, n))_: Operator for pre-multiplication.
-        y _(qarray_like of shape (..., n, n))_: Operator for post-multiplication.
+        x _(qarray-like of shape (..., n, n))_: Operator for pre-multiplication.
+        y _(qarray-like of shape (..., n, n))_: Operator for post-multiplication.
 
     Returns:
         _(Qarray of shape (..., n^2, n^2))_ Pre- and post-multiplication superoperator.
@@ -191,7 +191,7 @@ def sdissipator(L: QArrayLike) -> QArray:
     $$
 
     Args:
-        L _(qarray_like of shape (..., n, n))_: Jump operator.
+        L _(qarray-like of shape (..., n, n))_: Jump operator.
 
     Returns:
         _(qarray of shape (..., n^2, n^2))_ Dissipation superoperator.
@@ -232,8 +232,8 @@ def slindbladian(H: QArrayLike, jump_ops: list[QArrayLike]) -> QArray:
         This superoperator is also sometimes called *Liouvillian*.
 
     Args:
-        H _(qarray_like of shape (..., n, n))_: Hamiltonian.
-        jump_ops _(list of qarray_like, each of shape (..., n, n))_: List of jump
+        H _(qarray-like of shape (..., n, n))_: Hamiltonian.
+        jump_ops _(list of qarray-like, each of shape (..., n, n))_: List of jump
             operators.
 
     Returns:

--- a/dynamiqs/utils/wigner_utils.py
+++ b/dynamiqs/utils/wigner_utils.py
@@ -29,14 +29,14 @@ def wigner(
     The Wigner distribution is computed on a grid of coordinates $(x, y)$.
 
     Args:
-        state _(qarray_like of shape (..., n, 1) or (..., n, n))_: Ket or density
+        state _(qarray-like of shape (..., n, 1) or (..., n, n))_: Ket or density
             matrix.
         xmax: Maximum absolute value of the $x$ coordinate.
         ymax: Maximum absolute value of the $y$ coordinate.
         npixels: Number of pixels in each direction.
-        xvec _(array_like of shape (nxvec,), optional)_: $x$ coordinates. If `None`,
+        xvec _(array-like of shape (nxvec,), optional)_: $x$ coordinates. If `None`,
             defaults to `xvec = jnp.linspace(-xmax, xmax, npixels)`.
-        yvec _(array_like of shape (nyvec,), optional)_: $y$ coordinates. If `None`,
+        yvec _(array-like of shape (nyvec,), optional)_: $y$ coordinates. If `None`,
             defaults to `yvec = jnp.linspace(-ymax, ymax, npixels)`.
         g: Scaling factor of Wigner quadratures, such that $a = g(x + iy)/2$.
 


### PR DESCRIPTION
This PR propose to unify the naming conventions. The new rules are:
- use `array-like` not `array like` or `array_like`
- use `qarray-like` not `qarray like` or `qarray_like`
- use `time-qarray`, not `time qarray` or `time_qarray`
- You can use plural e.g. `array-likes` and capital e.g. `Array-likes`.
- Use backticks for a type e.g. `ArrayLike` or `QArray` or `TimeQArray`
- avoid using “object” after a type ("an array-like object" -> "an array-like")

I added them to https://linear.app/dynamiqs/issue/DYN-254/improve-contributingmd.