### PR TITLE
Modify options to add support for local options

### DIFF
--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -16,7 +16,6 @@ doc_sections = {
     'time_qarray': (['dynamiqs/time_qarray.py'], 'dq'),
     'solver': (['dynamiqs/solver.py'], 'dq.solver'),
     'gradient': (['dynamiqs/gradient.py'], 'dq.gradient'),
-    'options': (['dynamiqs/options.py'], 'dq'),
     'result': (['dynamiqs/result.py'], 'dq'),
     'hermitian_conjugate': (['dynamiqs/hermitian_conjugate.py'], 'dq'),
     'utils/operators': (['dynamiqs/utils/operators.py'], 'dq'),

--- a/docs/python_api/options/Options.md
+++ b/docs/python_api/options/Options.md
@@ -1,0 +1,4 @@
+::: dynamiqs.options.Options
+    options:
+        namespace: dq
+        separate_signature: False

--- a/docs/templates/python/material/class.html.jinja
+++ b/docs/templates/python/material/class.html.jinja
@@ -9,16 +9,20 @@
     <code class="doc-symbol doc-symbol-heading doc-symbol-class">
     </code>
   {% endif %}
+  {# same heading regardless of the config.separate_signature value #}
+  <span class="doc doc-object-name doc-class-name">{{ class_full_name }}</span>
+  {#
   {% if config.separate_signature %}
     <span class="doc doc-object-name doc-class-name">{{ class_full_name }}</span>
   {% elif config.merge_init_into_class and "__init__" in class.all_members %}
     {% with function = class.all_members["__init__"] %}
       {%+ filter highlight(language="python", inline=True) %}
-      {{ class_full_name }}
-      {% include "signature"|get_template with context %}
-    {% endfilter %}
-  {% endwith %}
-{% else %}
-  <code>{{ class_full_name }}</code>
-{% endif %}
+        {{ class_full_name }}
+        {% include "signature"|get_template with context %}
+      {% endfilter %}
+    {% endwith %}
+  {% else %}
+    <code>{{ class_full_name }}</code>
+  {% endif %}
+  #}
 {% endblock heading %}

--- a/dynamiqs/conftest.py
+++ b/dynamiqs/conftest.py
@@ -68,6 +68,7 @@ def rendergif():
 pytest_collect_file = Sybil(
     parsers=[DocTestParser(optionflags=ELLIPSIS), PythonCodeBlockParser()],
     patterns=['*.py'],
+    excludes=['options.py'],
     setup=sybil_setup,
     fixtures=[
         '_jax_set_printoptions',

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -9,7 +9,7 @@ from jaxtyping import Array, ArrayLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
-from ...options import Options
+from ...options import Options, check_options
 from ...qarrays.qarray import QArrayLike
 from ...result import FloquetResult
 from ...solver import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Solver, Tsit5
@@ -112,6 +112,7 @@ def floquet(
     # === check arguments
     tsave = check_times(tsave, 'tsave')
     H, T, tsave = _check_floquet_args(H, T, tsave)
+    check_options(options, 'floquet')
 
     # We implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -97,7 +97,8 @@ def floquet(
             [`Kvaerno5`][dynamiqs.solver.Kvaerno5],
             [`Euler`][dynamiqs.solver.Euler]).
         gradient: Algorithm used to compute the gradient.
-        options: Generic options, see [`dq.Options`][dynamiqs.Options].
+        options: Generic options, see [`dq.Options`][dynamiqs.Options] (supported:
+            `progress_meter`, `t0`).
 
     Returns:
         [`dq.FloquetResult`][dynamiqs.FloquetResult] object holding the result of the

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -9,7 +9,7 @@ from jaxtyping import Array, ArrayLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
-from ...options import Options
+from ...options import Options, check_options
 from ...qarrays.dense_qarray import DenseQArray
 from ...qarrays.qarray import QArrayLike
 from ...result import MEPropagatorResult
@@ -93,6 +93,7 @@ def mepropagator(
     # === check arguments
     _check_mepropagator_args(H, Ls)
     tsave = check_times(tsave, 'tsave')
+    check_options(options, 'mepropagator')
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -77,7 +77,9 @@ def mepropagator(
         gradient: Algorithm used to compute the gradient. The default is
             solver-dependent, refer to the documentation of the chosen solver for more
             details.
-        options: Generic options, see [`dq.Options`][dynamiqs.Options].
+        options: Generic options, see [`dq.Options`][dynamiqs.Options] (supported:
+            `save_propagators`, `cartesian_batching`, `progress_meter`, `t0`,
+            `save_extra`).
 
     Returns:
         [`dq.MEPropagatorResult`][dynamiqs.MEPropagatorResult] object holding

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -78,8 +78,7 @@ def mepropagator(
             solver-dependent, refer to the documentation of the chosen solver for more
             details.
         options: Generic options, see [`dq.Options`][dynamiqs.Options] (supported:
-            `save_propagators`, `cartesian_batching`, `progress_meter`, `t0`,
-            `save_extra`).
+            `save_propagators`, `cartesian_batching`, `t0`, `save_extra`).
 
     Returns:
         [`dq.MEPropagatorResult`][dynamiqs.MEPropagatorResult] object holding

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -116,7 +116,9 @@ def mesolve(
         gradient: Algorithm used to compute the gradient. The default is
             solver-dependent, refer to the documentation of the chosen solver for more
             details.
-        options: Generic options, see [`dq.Options`][dynamiqs.Options].
+        options: Generic options, see [`dq.Options`][dynamiqs.Options] (supported:
+            `save_states`, `cartesian_batching`, `progress_meter`, `t0`,
+            `save_extra`).
 
     Returns:
         [`dq.MESolveResult`][dynamiqs.MESolveResult] object holding the result of the

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -10,7 +10,7 @@ from jaxtyping import ArrayLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
-from ...options import Options
+from ...options import Options, check_options
 from ...qarrays.qarray import QArray, QArrayLike
 from ...qarrays.utils import asqarray
 from ...result import MESolveResult
@@ -135,6 +135,7 @@ def mesolve(
     # === check arguments
     _check_mesolve_args(H, Ls, rho0, exp_ops)
     tsave = check_times(tsave, 'tsave')
+    check_options(options, 'mesolve')
 
     # === convert rho0 to density matrix
     rho0 = rho0.todm()

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -88,7 +88,9 @@ def sepropagator(
         gradient: Algorithm used to compute the gradient. The default is
             solver-dependent, refer to the documentation of the chosen solver for more
             details.
-        options: Generic options, see [`dq.Options`][dynamiqs.Options].
+        options: Generic options, see [`dq.Options`][dynamiqs.Options] (supported:
+            `save_propagators`, `cartesian_batching`, `progress_meter`, `t0`,
+            `save_extra`).
 
     Returns:
         [`dq.SEPropagatorResult`][dynamiqs.SEPropagatorResult] object holding

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -8,7 +8,7 @@ from jaxtyping import Array, ArrayLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
-from ...options import Options
+from ...options import Options, check_options
 from ...qarrays.layout import dense
 from ...qarrays.qarray import QArrayLike
 from ...result import SEPropagatorResult
@@ -103,6 +103,7 @@ def sepropagator(
     # === check arguments
     _check_sepropagator_args(H)
     tsave = check_times(tsave, 'tsave')
+    check_options(options, 'sepropagator')
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -89,8 +89,7 @@ def sepropagator(
             solver-dependent, refer to the documentation of the chosen solver for more
             details.
         options: Generic options, see [`dq.Options`][dynamiqs.Options] (supported:
-            `save_propagators`, `cartesian_batching`, `progress_meter`, `t0`,
-            `save_extra`).
+            `save_propagators`, `progress_meter`, `t0`, `save_extra`).
 
     Returns:
         [`dq.SEPropagatorResult`][dynamiqs.SEPropagatorResult] object holding

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -9,7 +9,7 @@ from jaxtyping import ArrayLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
-from ...options import Options
+from ...options import Options, check_options
 from ...qarrays.qarray import QArray, QArrayLike
 from ...qarrays.utils import asqarray
 from ...result import SESolveResult
@@ -109,6 +109,7 @@ def sesolve(
     # === check arguments
     _check_sesolve_args(H, psi0, exp_ops)
     tsave = check_times(tsave, 'tsave')
+    check_options(options, 'sesolve')
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -91,7 +91,9 @@ def sesolve(
         gradient: Algorithm used to compute the gradient. The default is
             solver-dependent, refer to the documentation of the chosen solver for more
             details.
-        options: Generic options, see [`dq.Options`][dynamiqs.Options].
+        options: Generic options, see [`dq.Options`][dynamiqs.Options] (supported:
+            `save_states`, `cartesian_batching`, `progress_meter`, `t0`,
+            `save_extra`).
 
     Returns:
         [`dq.SESolveResult`][dynamiqs.SESolveResult] object holding the result of the

--- a/dynamiqs/integrators/core/floquet_integrator.py
+++ b/dynamiqs/integrators/core/floquet_integrator.py
@@ -22,10 +22,13 @@ class FloquetIntegrator(BaseIntegrator):
 
 class SEFloquetIntegrator(FloquetIntegrator, SEInterface):
     def run(self) -> PyTree:
+        # enforce `save_propagators` to be `True` for _sepropagator
+        options = self.options.replace(save_propagators=True)
+
         # compute propagators for all times at once, with the last being one period
         ts = jnp.append(self.ts, self.t0 + self.T)
         seprop_result = _sepropagator(
-            self.H, ts, solver=self.solver, gradient=self.gradient, options=self.options
+            self.H, ts, solver=self.solver, gradient=self.gradient, options=options
         )
 
         # diagonalize the final propagator to get the Floquet modes at t=t0

--- a/dynamiqs/integrators/core/floquet_integrator.py
+++ b/dynamiqs/integrators/core/floquet_integrator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import jax.numpy as jnp
 from jaxtyping import PyTree
 
@@ -23,7 +25,7 @@ class FloquetIntegrator(BaseIntegrator):
 class SEFloquetIntegrator(FloquetIntegrator, SEInterface):
     def run(self) -> PyTree:
         # enforce `save_propagators` to be `True` for _sepropagator
-        options = self.options.replace(save_propagators=True)
+        options = replace(self.options, save_propagators=True)
 
         # compute propagators for all times at once, with the last being one period
         ts = jnp.append(self.ts, self.t0 + self.T)

--- a/dynamiqs/integrators/core/floquet_integrator.py
+++ b/dynamiqs/integrators/core/floquet_integrator.py
@@ -24,7 +24,7 @@ class FloquetIntegrator(BaseIntegrator):
 class SEFloquetIntegrator(FloquetIntegrator, SEInterface):
     def run(self) -> PyTree:
         # enforce `save_propagators` to be `True` for _sepropagator
-        options = eqx.tree_at(lambda opt: opt.save_propagators, self.options, False)
+        options = eqx.tree_at(lambda opt: opt.save_propagators, self.options, True)
 
         # compute propagators for all times at once, with the last being one period
         ts = jnp.append(self.ts, self.t0 + self.T)

--- a/dynamiqs/integrators/core/floquet_integrator.py
+++ b/dynamiqs/integrators/core/floquet_integrator.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
-
+import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import PyTree
 
@@ -25,7 +24,7 @@ class FloquetIntegrator(BaseIntegrator):
 class SEFloquetIntegrator(FloquetIntegrator, SEInterface):
     def run(self) -> PyTree:
         # enforce `save_propagators` to be `True` for _sepropagator
-        options = replace(self.options, save_propagators=True)
+        options = eqx.tree_at(lambda opt: opt.save_propagators, self.options, False)
 
         # compute propagators for all times at once, with the last being one period
         ts = jnp.append(self.ts, self.t0 + self.T)

--- a/dynamiqs/integrators/core/floquet_integrator.py
+++ b/dynamiqs/integrators/core/floquet_integrator.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import replace
-
 import jax.numpy as jnp
 from jaxtyping import PyTree
 
@@ -24,13 +22,10 @@ class FloquetIntegrator(BaseIntegrator):
 
 class SEFloquetIntegrator(FloquetIntegrator, SEInterface):
     def run(self) -> PyTree:
-        # enforce `save_propagators` to be `True` for _sepropagator
-        options = replace(self.options, save_propagators=True)
-
         # compute propagators for all times at once, with the last being one period
         ts = jnp.append(self.ts, self.t0 + self.T)
         seprop_result = _sepropagator(
-            self.H, ts, solver=self.solver, gradient=self.gradient, options=options
+            self.H, ts, solver=self.solver, gradient=self.gradient, options=self.options
         )
 
         # diagonalize the final propagator to get the Floquet modes at t=t0

--- a/dynamiqs/integrators/core/floquet_integrator.py
+++ b/dynamiqs/integrators/core/floquet_integrator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import jax.numpy as jnp
 from jaxtyping import PyTree
 
@@ -22,10 +24,13 @@ class FloquetIntegrator(BaseIntegrator):
 
 class SEFloquetIntegrator(FloquetIntegrator, SEInterface):
     def run(self) -> PyTree:
+        # enforce `save_propagators` to be `True` for _sepropagator
+        options = replace(self.options, save_propagators=True)
+
         # compute propagators for all times at once, with the last being one period
         ts = jnp.append(self.ts, self.t0 + self.T)
         seprop_result = _sepropagator(
-            self.H, ts, solver=self.solver, gradient=self.gradient, options=self.options
+            self.H, ts, solver=self.solver, gradient=self.gradient, options=options
         )
 
         # diagonalize the final propagator to get the Floquet modes at t=t0

--- a/dynamiqs/integrators/core/save_mixin.py
+++ b/dynamiqs/integrators/core/save_mixin.py
@@ -16,9 +16,42 @@ class AbstractSaveMixin(OptionsInterface):
 
     @abstractmethod
     def save(self, y: PyTree) -> Saved:
+        pass
+
+    @abstractmethod
+    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+        pass
+
+
+class PropagatorSaveMixin(AbstractSaveMixin):
+    """Mixin to assist integrators computing propagators with data saving."""
+
+    def save(self, y: PyTree) -> Saved:
+        ysave = y if self.options.save_propagators else None
+        extra = self.options.save_extra(y) if self.options.save_extra else None
+        return PropagatorSaved(ysave, extra)
+
+    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+        # if save_propagators is False save only last propagator
+        if not self.options.save_propagators:
+            saved = eqx.tree_at(
+                lambda x: x.ysave, saved, ylast, is_leaf=lambda x: x is None
+            )
+
+        return saved
+
+
+class SolveSaveMixin(AbstractSaveMixin):
+    """Mixin to assist integrators computing time evolution with data saving."""
+
+    def save(self, y: PyTree) -> Saved:
         ysave = y if self.options.save_states else None
         extra = self.options.save_extra(y) if self.options.save_extra else None
-        return Saved(ysave, extra)
+        if self.Es is not None:
+            Esave = jnp.stack([expect(E, y) for E in self.Es])
+        else:
+            Esave = None
+        return SolveSaved(ysave, extra, Esave)
 
     def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
         # if save_states is False save only last state
@@ -26,30 +59,7 @@ class AbstractSaveMixin(OptionsInterface):
             saved = eqx.tree_at(
                 lambda x: x.ysave, saved, ylast, is_leaf=lambda x: x is None
             )
-        return saved
 
-
-class PropagatorSaveMixin(AbstractSaveMixin):
-    """Mixin to assist integrators computing propagators with data saving."""
-
-    def save(self, y: PyTree) -> Saved:
-        saved = super().save(y)
-        return PropagatorSaved(saved.ysave, saved.extra)
-
-
-class SolveSaveMixin(AbstractSaveMixin):
-    """Mixin to assist integrators computing time evolution with data saving."""
-
-    def save(self, y: PyTree) -> Saved:
-        saved = super().save(y)
-        if self.Es is not None:
-            Esave = jnp.stack([expect(E, y) for E in self.Es])
-        else:
-            Esave = None
-        return SolveSaved(saved.ysave, saved.extra, Esave)
-
-    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
-        saved = super().postprocess_saved(saved, ylast)
         # reorder Esave after jax.lax.scan stacking (ntsave, nE) -> (nE, ntsave)
         if saved.Esave is not None:
             saved = eqx.tree_at(lambda x: x.Esave, saved, saved.Esave.swapaxes(-1, -2))

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -17,8 +17,6 @@ class Options(eqx.Module):
     Args:
         save_states: If `True`, the state is saved at every time in `tsave`,
             otherwise only the final state is returned.
-        verbose: If `True`, print information about the integration, otherwise
-            nothing is printed.
         cartesian_batching: If `True`, batched arguments are treated as separated
             batch dimensions, otherwise the batching is performed over a single
             shared batched dimension.
@@ -37,7 +35,6 @@ class Options(eqx.Module):
     """
 
     save_states: bool = True
-    verbose: bool = True
     cartesian_batching: bool = True
     progress_meter: AbstractProgressMeter | None = TqdmProgressMeter()
     t0: ScalarLike | None = None
@@ -46,7 +43,6 @@ class Options(eqx.Module):
     def __init__(
         self,
         save_states: bool = True,
-        verbose: bool = True,
         cartesian_batching: bool = True,
         progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),  # noqa: B008
         t0: ScalarLike | None = None,
@@ -56,7 +52,6 @@ class Options(eqx.Module):
             progress_meter = NoProgressMeter()
 
         self.save_states = save_states
-        self.verbose = verbose
         self.cartesian_batching = cartesian_batching
         self.progress_meter = progress_meter
         self.t0 = t0

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -66,3 +66,36 @@ class Options(eqx.Module):
 
     def __str__(self) -> str:
         return tree_str_inline(self)
+
+
+def check_options(options: Options, solver_name: str):
+    if solver_name in ('sesolve', 'mesolve'):
+        valid_options = (
+            'save_states',
+            'cartesian_batching',
+            'progress_meter',
+            't0',
+            'save_extra',
+        )
+    elif solver_name in ('sepropagator', 'mepropagator'):
+        valid_options = (
+            'save_propagators',
+            'cartesian_batching',
+            'progress_meter',
+            't0',
+            'save_extra',
+        )
+    elif solver_name == 'floquet':
+        valid_options = ('progress_meter', 't0')
+    else:
+        raise ValueError(f'Unknown solver name: {solver_name}')
+
+    # check that all attributes are set to their default values except for the ones
+    # specified in `valid_options`
+    for key, value in options.__dict__.items():
+        if key not in valid_options and value != getattr(Options(), key):
+            raise ValueError(
+                f'Option {key} was set to {value} but is not used by '
+                f'the quantum solver. Valid options for {solver_name} are: '
+                f'{", ".join(valid_options)}'
+            )

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -62,9 +62,7 @@ class Options(eqx.Module):
         self.t0 = t0
 
         # make `save_extra` a valid Pytree with `Partial`
-        if save_extra is not None:
-            save_extra = jtu.Partial(save_extra)
-        self.save_extra = save_extra
+        self.save_extra = jtu.Partial(save_extra) if save_extra is not None else None
 
     def __str__(self) -> str:
         return tree_str_inline(self)

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -17,6 +17,8 @@ class Options(eqx.Module):
     Args:
         save_states: If `True`, the state is saved at every time in `tsave`,
             otherwise only the final state is returned.
+        save_propagators: If `True`, the propagator is saved at every time in `tsave`,
+            otherwise only the final propagator is returned.
         cartesian_batching: If `True`, batched arguments are treated as separated
             batch dimensions, otherwise the batching is performed over a single
             shared batched dimension.
@@ -35,6 +37,7 @@ class Options(eqx.Module):
     """
 
     save_states: bool = True
+    save_propagators: bool = True
     cartesian_batching: bool = True
     progress_meter: AbstractProgressMeter | None = TqdmProgressMeter()
     t0: ScalarLike | None = None
@@ -43,6 +46,7 @@ class Options(eqx.Module):
     def __init__(
         self,
         save_states: bool = True,
+        save_propagators: bool = True,
         cartesian_batching: bool = True,
         progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),  # noqa: B008
         t0: ScalarLike | None = None,
@@ -52,6 +56,7 @@ class Options(eqx.Module):
             progress_meter = NoProgressMeter()
 
         self.save_states = save_states
+        self.save_propagators = save_propagators
         self.cartesian_batching = cartesian_batching
         self.progress_meter = progress_meter
         self.t0 = t0

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -16,8 +16,8 @@ class Options(eqx.Module):
 
     The `Options` class provides a unified interface for specifying options specific to
     quantum solvers. Each quantum solver may only use a subset of these options,
-    so if you modify an option that the solver does not recognize from its default
-    value, an error is raised.
+    and an error will be raised if you modify an option that the solver does not
+    support.
 
     === "`dq.sesolve`"
         **Parameters**

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -66,9 +66,6 @@ class Options(eqx.Module):
 
         - **save_propagators** – If `True`, the propagator is saved at every time in
             `tsave`, otherwise only the final propagator is returned.
-        - **cartesian_batching** – If `True`, batched arguments are treated as separated
-            batch dimensions, otherwise the batching is performed over a single
-            shared batched dimension.
         - **progress_meter** – Progress meter indicating how far the solve has
             progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress
             meter. Pass `None` for no output, see other options in
@@ -176,5 +173,5 @@ def check_options(options: Options, solver_name: str):
             raise ValueError(
                 f'Option {key} was set to {value} but is not used by '
                 f'the quantum solver. Valid options for {solver_name} are: '
-                f'{", ".join(valid_options)}'
+                f'{', '.join(valid_options)}'
             )

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -20,6 +20,16 @@ class Options(eqx.Module):
     support.
 
     === "`dq.sesolve()`"
+        ```python
+        Options(
+            save_states: bool = True,
+            cartesian_batching: bool = True,
+            progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+            t0: ScalarLike | None = None,
+            save_extra: callable[[Array], PyTree] | None = None,
+        )
+        ```
+
         **Parameters**
 
         - **save_states** – If `True`, the state is saved at every time in `tsave`,
@@ -41,6 +51,16 @@ class Options(eqx.Module):
             the result object returned by the solvers.
 
     === "`dq.mesolve()`"
+        ```python
+        Options(
+            save_states: bool = True,
+            cartesian_batching: bool = True,
+            progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+            t0: ScalarLike | None = None,
+            save_extra: callable[[Array], PyTree] | None = None,
+        )
+        ```
+
         **Parameters**
 
         - **save_states** – If `True`, the state is saved at every time in `tsave`,
@@ -62,6 +82,15 @@ class Options(eqx.Module):
             the result object returned by the solvers.
 
     === "`dq.sepropagator()`"
+        ```python
+        Options(
+            save_propagators: bool = True,
+            progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+            t0: ScalarLike | None = None,
+            save_extra: callable[[Array], PyTree] | None = None,
+        )
+        ```
+
         **Parameters**
 
         - **save_propagators** – If `True`, the propagator is saved at every time in
@@ -80,6 +109,15 @@ class Options(eqx.Module):
             the result object returned by the solvers.
 
     === "`dq.mepropagator()`"
+        ```python
+        Options(
+            save_propagators: bool = True,
+            cartesian_batching: bool = True,
+            t0: ScalarLike | None = None,
+            save_extra: callable[[Array], PyTree] | None = None,
+        )
+        ```
+
         **Parameters**
 
         - **save_propagators** – If `True`, the propagator is saved at every time in
@@ -95,6 +133,13 @@ class Options(eqx.Module):
             the result object returned by the solvers.
 
     === "`dq.floquet()`"
+        ```python
+        Options(
+            progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+            t0: ScalarLike | None = None,
+        )
+        ```
+
         **Parameters**
 
         - **progress_meter** – Progress meter indicating how far the solve has

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -12,29 +12,108 @@ __all__ = ['Options']
 
 
 class Options(eqx.Module):
-    """Generic options for the quantum solvers.
+    """Generic options for quantum solvers.
 
-    Args:
-        save_states: If `True`, the state is saved at every time in `tsave`,
+    The `Options` class provides a unified interface for specifying options specific to
+    quantum solvers. Each quantum solver may only use a subset of these options,
+    so if you modify an option that the solver does not recognize from its default
+    value, an error is raised.
+
+    === "`dq.sesolve`"
+        **Parameters**
+
+        - **save_states** – If `True`, the state is saved at every time in `tsave`,
             otherwise only the final state is returned.
-        save_propagators: If `True`, the propagator is saved at every time in `tsave`,
-            otherwise only the final propagator is returned.
-        cartesian_batching: If `True`, batched arguments are treated as separated
+        - **cartesian_batching** – If `True`, batched arguments are treated as separated
             batch dimensions, otherwise the batching is performed over a single
             shared batched dimension.
-        progress_meter: Progress meter indicating how far the solve has progressed.
-            Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress meter. Pass
-            `None` for no output, see other options in
+        - **progress_meter** – Progress meter indicating how far the solve has
+            progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress
+            meter. Pass `None` for no output, see other options in
             [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
             If gradients are computed, the progress meter only displays during the
             forward pass.
-        t0: Initial time. If `None`, defaults to the first time in `tsave`.
-        save_extra _(function, optional)_: A function with signature
+        - **t0** – Initial time. If `None`, defaults to the first time in `tsave`.
+        - **save_extra** _(function, optional)_ – A function with signature
             `f(QArray) -> PyTree` that takes a state or propagator as input and returns
             a PyTree. This can be used to save additional arbitrary data during the
             integration. The additional data is accessible in the `extra` attribute of
             the result object returned by the solvers.
-    """
+
+    === "`dq.mesolve`"
+        **Parameters**
+
+        - **save_states** – If `True`, the state is saved at every time in `tsave`,
+            otherwise only the final state is returned.
+        - **cartesian_batching** – If `True`, batched arguments are treated as separated
+            batch dimensions, otherwise the batching is performed over a single
+            shared batched dimension.
+        - **progress_meter** – Progress meter indicating how far the solve has
+            progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress
+            meter. Pass `None` for no output, see other options in
+            [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
+            If gradients are computed, the progress meter only displays during the
+            forward pass.
+        - **t0** – Initial time. If `None`, defaults to the first time in `tsave`.
+        - **save_extra** _(function, optional)_ – A function with signature
+            `f(QArray) -> PyTree` that takes a state or propagator as input and returns
+            a PyTree. This can be used to save additional arbitrary data during the
+            integration. The additional data is accessible in the `extra` attribute of
+            the result object returned by the solvers.
+
+    === "`dq.sepropagator`"
+        **Parameters**
+
+        - **save_propagators** – If `True`, the propagator is saved at every time in
+            `tsave`, otherwise only the final propagator is returned.
+        - **cartesian_batching** – If `True`, batched arguments are treated as separated
+            batch dimensions, otherwise the batching is performed over a single
+            shared batched dimension.
+        - **progress_meter** – Progress meter indicating how far the solve has
+            progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress
+            meter. Pass `None` for no output, see other options in
+            [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
+            If gradients are computed, the progress meter only displays during the
+            forward pass.
+        - **t0** – Initial time. If `None`, defaults to the first time in `tsave`.
+        - **save_extra** _(function, optional)_ – A function with signature
+            `f(QArray) -> PyTree` that takes a state or propagator as input and returns
+            a PyTree. This can be used to save additional arbitrary data during the
+            integration. The additional data is accessible in the `extra` attribute of
+            the result object returned by the solvers.
+
+    === "`dq.mepropagator`"
+        **Parameters**
+
+        - **save_propagators** – If `True`, the propagator is saved at every time in
+            `tsave`, otherwise only the final propagator is returned.
+        - **cartesian_batching** – If `True`, batched arguments are treated as separated
+            batch dimensions, otherwise the batching is performed over a single
+            shared batched dimension.
+        - **progress_meter** – Progress meter indicating how far the solve has
+            progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress
+            meter. Pass `None` for no output, see other options in
+            [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
+            If gradients are computed, the progress meter only displays during the
+            forward pass.
+        - **t0** – Initial time. If `None`, defaults to the first time in `tsave`.
+        - **save_extra** _(function, optional)_ – A function with signature
+            `f(QArray) -> PyTree` that takes a state or propagator as input and returns
+            a PyTree. This can be used to save additional arbitrary data during the
+            integration. The additional data is accessible in the `extra` attribute of
+            the result object returned by the solvers.
+
+    === "`dq.floquet`"
+        **Parameters**
+
+        - **progress_meter** – Progress meter indicating how far the solve has
+            progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress
+            meter. Pass `None` for no output, see other options in
+            [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
+            If gradients are computed, the progress meter only displays during the
+            forward pass.
+        - **t0** – Initial time. If `None`, defaults to the first time in `tsave`.
+    """  # noqa: RUF002
 
     save_states: bool = True
     save_propagators: bool = True

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -87,12 +87,6 @@ class Options(eqx.Module):
         - **cartesian_batching** – If `True`, batched arguments are treated as separated
             batch dimensions, otherwise the batching is performed over a single
             shared batched dimension.
-        - **progress_meter** – Progress meter indicating how far the solve has
-            progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm) progress
-            meter. Pass `None` for no output, see other options in
-            [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
-            If gradients are computed, the progress meter only displays during the
-            forward pass.
         - **t0** – Initial time. If `None`, defaults to the first time in `tsave`.
         - **save_extra** _(function, optional)_ – A function with signature
             `f(QArray) -> PyTree` that takes a state or propagator as input and returns

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -19,7 +19,7 @@ class Options(eqx.Module):
     and an error will be raised if you modify an option that the solver does not
     support.
 
-    === "`dq.sesolve`"
+    === "`dq.sesolve()`"
         **Parameters**
 
         - **save_states** – If `True`, the state is saved at every time in `tsave`,
@@ -40,7 +40,7 @@ class Options(eqx.Module):
             integration. The additional data is accessible in the `extra` attribute of
             the result object returned by the solvers.
 
-    === "`dq.mesolve`"
+    === "`dq.mesolve()`"
         **Parameters**
 
         - **save_states** – If `True`, the state is saved at every time in `tsave`,
@@ -61,7 +61,7 @@ class Options(eqx.Module):
             integration. The additional data is accessible in the `extra` attribute of
             the result object returned by the solvers.
 
-    === "`dq.sepropagator`"
+    === "`dq.sepropagator()`"
         **Parameters**
 
         - **save_propagators** – If `True`, the propagator is saved at every time in
@@ -79,7 +79,7 @@ class Options(eqx.Module):
             integration. The additional data is accessible in the `extra` attribute of
             the result object returned by the solvers.
 
-    === "`dq.mepropagator`"
+    === "`dq.mepropagator()`"
         **Parameters**
 
         - **save_propagators** – If `True`, the propagator is saved at every time in
@@ -94,7 +94,7 @@ class Options(eqx.Module):
             integration. The additional data is accessible in the `extra` attribute of
             the result object returned by the solvers.
 
-    === "`dq.floquet`"
+    === "`dq.floquet()`"
         **Parameters**
 
         - **progress_meter** – Progress meter indicating how far the solve has

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -164,8 +164,9 @@ def check_options(options: Options, solver_name: str):
     # specified in `valid_options`
     for key, value in options.__dict__.items():
         if key not in valid_options and value != getattr(Options(), key):
+            valid_options_str = ', '.join(f'`{x}`' for x in valid_options)
             raise ValueError(
-                f'Option {key} was set to {value} but is not used by '
-                f'the quantum solver. Valid options for {solver_name} are: '
-                f'{', '.join(valid_options)}'
+                f'Option `{key}` was set to `{value}` but is not used by '
+                f'the quantum solver `dq.{solver_name}()` (valid options: '
+                f'{valid_options_str}).'
             )

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -139,26 +139,26 @@ class Options(eqx.Module):
 
 
 def check_options(options: Options, solver_name: str):
-    if solver_name in ('sesolve', 'mesolve'):
-        valid_options = (
+    supported_options = {
+        'sesolve': (
             'save_states',
             'cartesian_batching',
             'progress_meter',
             't0',
             'save_extra',
-        )
-    elif solver_name in ('sepropagator', 'mepropagator'):
-        valid_options = (
-            'save_propagators',
+        ),
+        'mesolve': (
+            'save_states',
             'cartesian_batching',
             'progress_meter',
             't0',
             'save_extra',
-        )
-    elif solver_name == 'floquet':
-        valid_options = ('progress_meter', 't0')
-    else:
-        raise ValueError(f'Unknown solver name: {solver_name}')
+        ),
+        'sepropagator': ('save_propagators', 'progress_meter', 't0', 'save_extra'),
+        'mepropagator': ('save_propagators', 'cartesian_batching', 't0', 'save_extra'),
+        'floquet': ('progress_meter', 't0'),
+    }
+    valid_options = supported_options[solver_name]
 
     # check that all attributes are set to their default values except for the ones
     # specified in `valid_options`

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -300,7 +300,8 @@ class SEPropagatorResult(PropagatorResult):
 
     Attributes:
         propagators _(qarray of shape (..., nsave, n, n))_: Saved propagators with
-            `nsave = ntsave`, or `nsave = 1` if `options.save_states` is set to `False`.
+            `nsave = ntsave`, or `nsave = 1` if `options.save_propagators` is set to
+            `False`.
         final_propagator _(qarray of shape (..., n, n))_: Saved final propagator.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options` (see [`dq.Options`][dynamiqs.Options]).
@@ -326,7 +327,8 @@ class MEPropagatorResult(PropagatorResult):
 
     Attributes:
         propagators _(qarray of shape (..., nsave, n^2, n^2))_: Saved propagators with
-            `nsave = ntsave`, or `nsave = 1` if `options.save_states` is set to `False`.
+            `nsave = ntsave`, or `nsave = 1` if `options.save_propagators` is set to
+            `False`.
         final_propagator _(qarray of shape (..., n^2, n^2))_: Saved final propagator.
         extra _(PyTree or None)_: Extra data saved with `save_extra()` if
             specified in `options` (see [`dq.Options`][dynamiqs.Options]).

--- a/tests/mepropagator/test_expm.py
+++ b/tests/mepropagator/test_expm.py
@@ -35,14 +35,14 @@ class TestMEPropagator(IntegratorTester):
         true_ysave = system.states(system.tsave).to_jax()
         assert jnp.allclose(prop_ysave, true_ysave, atol=ysave_atol)
 
-    @pytest.mark.parametrize('save_states', [True, False])
-    def test_correctness_pwc(self, save_states, ysave_atol: float = 1e-4):
+    @pytest.mark.parametrize('save_propagators', [True, False])
+    def test_correctness_pwc(self, save_propagators, ysave_atol: float = 1e-4):
         times = [0.0, 1.0, 2.0]
         values = [3.0, -2.0]
         _H, Ls = rand_mepropagator_args(2, (), [(), ()])
         H = pwc(times, values, _H)
         tsave = jnp.asarray([0.5, 1.0, 2.0])
-        options = Options(save_states=save_states)
+        options = Options(save_propagators=save_propagators)
         propresult = mepropagator(H, Ls, tsave, options=options)
         propagators = propresult.propagators.to_jax()
         U0 = eye(H.shape[-1] ** 2).to_jax()
@@ -50,5 +50,5 @@ class TestMEPropagator(IntegratorTester):
         lindbladian_2 = slindbladian(-2.0 * H.qarray, Ls)
         U1 = jax.scipy.linalg.expm(lindbladian_1.to_jax() * 0.5)
         U2 = jax.scipy.linalg.expm(lindbladian_2.to_jax() * 1.0)
-        true_propagators = jnp.stack([U0, U1, U2 @ U1]) if save_states else U2 @ U1
+        true_propagators = jnp.stack([U0, U1, U2 @ U1]) if save_propagators else U2 @ U1
         assert jnp.allclose(propagators, true_propagators, atol=ysave_atol)

--- a/tests/sepropagator/test_sepropagator.py
+++ b/tests/sepropagator/test_sepropagator.py
@@ -22,46 +22,46 @@ class TestSEPropagator(IntegratorTester):
         prop_ysave = (propresult.propagators @ y0).to_jax()
         assert jnp.allclose(true_ysave, prop_ysave, atol=ysave_atol)
 
-    @pytest.mark.parametrize('save_states', [True, False])
+    @pytest.mark.parametrize('save_propagators', [True, False])
     @pytest.mark.parametrize('solver', [None, Tsit5()])
     @pytest.mark.parametrize('nH', [(), (4,), (4, 5)])
     def test_correctness_complex(
-        self, nH, save_states, solver, ysave_atol: float = 3e-4
+        self, nH, save_propagators, solver, ysave_atol: float = 3e-4
     ):
         H = constant(random.herm(jax.random.PRNGKey(42), (*nH, 2, 2)))
         tsave = jnp.linspace(1.0, 10.0, 3)
-        options = Options(save_states=save_states, t0=0.0)
+        options = Options(save_propagators=save_propagators, t0=0.0)
         propresult = sepropagator(H, tsave, solver=solver, options=options)
         propagators = propresult.propagators.to_jax()
-        ts = tsave if save_states else jnp.asarray([10.0])
+        ts = tsave if save_propagators else jnp.asarray([10.0])
         Hts = jnp.einsum('...ij,t->...tij', H.qarray.to_jax(), ts)
         true_propagators = jax.scipy.linalg.expm(-1j * Hts)
         assert jnp.allclose(propagators, true_propagators, atol=ysave_atol)
 
-    @pytest.mark.parametrize('save_states', [True, False])
+    @pytest.mark.parametrize('save_propagators', [True, False])
     @pytest.mark.parametrize('solver', [None, Tsit5()])
-    def test_correctness_pwc(self, save_states, solver, ysave_atol: float = 1e-4):
+    def test_correctness_pwc(self, save_propagators, solver, ysave_atol: float = 1e-4):
         times = [0.0, 1.0, 2.0]
         values = [3.0, -2.0]
         qarray = sigmay()
         H = pwc(times, values, qarray)
         tsave = jnp.asarray([0.5, 1.0, 2.0])
-        options = Options(save_states=save_states)
+        options = Options(save_propagators=save_propagators)
         propresult = sepropagator(H, tsave, solver=solver, options=options)
         propagators = propresult.propagators.to_jax()
         U0 = eye(H.shape[-1]).to_jax()
         U1 = jax.scipy.linalg.expm(-1j * H.qarray.to_jax() * 3.0 * 0.5)
         U2 = jax.scipy.linalg.expm(-1j * H.qarray.to_jax() * -2.0 * 1.0)
-        if save_states:
+        if save_propagators:
             true_propagators = jnp.stack((U0, U1, U2 @ U1))
         else:
             true_propagators = (U2 @ U1)[None]
         assert jnp.allclose(propagators, true_propagators, atol=ysave_atol)
 
-    @pytest.mark.parametrize('save_states', [True, False])
+    @pytest.mark.parametrize('save_propagators', [True, False])
     @pytest.mark.parametrize('solver', [None, Tsit5()])
     def test_correctness_summed_pwc(
-        self, save_states, solver, ysave_atol: float = 1e-4
+        self, save_propagators, solver, ysave_atol: float = 1e-4
     ):
         times_1 = [0.0, 1.0, 2.0]
         times_2 = [0.0, 0.5, 1.0, 2.5]
@@ -71,7 +71,7 @@ class TestSEPropagator(IntegratorTester):
         H2 = pwc(times_2, values_2, sigmax())
         H = H1 + H2
         tsave = jnp.asarray([0.5, 1.0, 2.5])
-        options = Options(save_states=save_states)
+        options = Options(save_propagators=save_propagators)
         propresult = sepropagator(H, tsave, solver=solver, options=options)
         propagators = propresult.propagators.to_jax()
         H1_array = H1.qarray.to_jax()
@@ -80,7 +80,7 @@ class TestSEPropagator(IntegratorTester):
         U1 = jax.scipy.linalg.expm(-1j * (H1_array * 3.0 + H2_array * (-5.0)) * 0.5)
         U2 = jax.scipy.linalg.expm(-1j * (H1_array * (-2.0) + H2_array * 1.0) * 1.0)
         U3 = jax.scipy.linalg.expm(-1j * H2_array * 1.0 * 0.5)
-        if save_states:
+        if save_propagators:
             true_propagators = jnp.stack((U0, U1, U3 @ U2 @ U1))
         else:
             true_propagators = (U3 @ U2 @ U1)[None]


### PR DESCRIPTION
Use tabs to document solver-specific options.

<details>
  <summary>Outdated PR description</summary>
Unfortunately it is not possible to combine `pymdownx` tabs with the mkdocstrings parser, `griffe`. So our idea of documenting the `Options` class with tabs for each quantum solver does not work, unless we use HTML directly in the docstring.

As such, I simply went with a
```
options: Generic options (supported: `save_states`, `progress_meter`, ...).
```
inside each quantum solver docstring, like we do for the `solver` attribute.

IMO this is very unsatisfying and it pushes me back towards the idea of having distinct classes (`dq.MESolveOptions`, ...). Down for your opinions. 
</details>