### PR TITLE
Fix GPU support for eig following jax 0.4.36 release

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -19,11 +19,6 @@ def obj_type_str(x: Any) -> str:
     return type_str(type(x))
 
 
-def on_cpu(x: Array) -> bool:
-    # TODO: this is a temporary solution, it won't work when we have multiple devices
-    return x.devices().pop().device_kind == 'cpu'
-
-
 def _get_default_dtype() -> jnp.float32 | jnp.float64:
     default_dtype = jnp.array(0.0).dtype
     return jnp.float64 if default_dtype == jnp.float64 else jnp.float32

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -51,11 +51,6 @@ def floquet(
         \Phi_{m}(t) = \exp(i\epsilon_{m}t)U(t_0, t_0+t)\Phi_{m}(t_0).
     $$
 
-    Warning:
-        `floquet` is not yet GPU compatible because `jax.numpy.linalg.eig` is only
-        implemented on the CPU backend, [see here](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.linalg.eig.html).
-        However, a GPU implementation of eig is currently in the works, [see here](https://github.com/jax-ml/jax/pull/24663).
-
     Note-: Batching over drive periods
         The current API does not yet natively support batching over multiple drive
         periods, for instance if you wanted to batch over Hamiltonians with different

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "tqdm",
-    "jax",
+    "jax>=0.4.36", # for GPU eig support
     "jaxlib",
     "jaxtyping",
     "diffrax>=0.5.1",  # for complex support (0.5.0) and progress meter (0.5.1)


### PR DESCRIPTION
Also fixes the fact that `dq.fidelity` was not JIT-compatible