### PR TITLE
Remove jaxlib dependency in toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "matplotlib",
     "tqdm",
     "jax",
-    "jaxlib",
     "jaxtyping",
     "diffrax>=0.5.1",  # for complex support (0.5.0) and progress meter (0.5.1)
     "equinox",


### PR DESCRIPTION
See e.g. https://github.com/patrick-kidger/equinox/blob/fe4121d96e3cb246d8acc1647c9c7a5b73d753dc/pyproject.toml#L26