### PR TITLE
Fix Ruff A005 by making random a folder instead of a module

### DIFF
--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -28,7 +28,7 @@ doc_sections = {
     'utils/global_settings': (['dynamiqs/utils/global_settings.py'], 'dq'),
     'utils/vectorization': (['dynamiqs/utils/vectorization.py'], 'dq'),
     'utils/optimal_control': (['dynamiqs/utils/optimal_control.py'], 'dq'),
-    'random': (['dynamiqs/random.py'], 'dq.random'),
+    'random': (['dynamiqs/random/'], 'dq.random'),
     'plot': (['dynamiqs/plot/'], 'dq.plot'),
 }
 

--- a/dynamiqs/plot/hinton.py
+++ b/dynamiqs/plot/hinton.py
@@ -179,7 +179,9 @@ def hinton(
         >>> _, axs = dq.plot.grid(2)
         >>> x = np.random.uniform(-1.0, 1.0, (10, 10))
         >>> dq.plot.hinton(x, ax=next(axs), vmin=-1.0, vmax=1.0)
-        >>> dq.plot.hinton(jnp.abs(x), ax=next(axs), cmap='Greys', vmax=1.0, ecolor='black')
+        >>> dq.plot.hinton(
+        ...     jnp.abs(x), ax=next(axs), cmap='Greys', vmax=1.0, ecolor='black'
+        ... )
         >>> renderfig('plot_hinton_real')
 
         ![plot_hinton_real](../../figs_code/plot_hinton_real.png){.fig-half}
@@ -189,7 +191,7 @@ def hinton(
         >>> renderfig('plot_hinton_large')
 
         ![plot_hinton_large](../../figs_code/plot_hinton_large.png){.fig}
-    """  # noqa: E501
+    """
     x = to_jax(x)
     check_shape(x, 'x', '(n, n)')
 

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -244,7 +244,7 @@ class SparseDIAQArray(QArray):
             )
 
         # replace with a centered dot of the same length as the matched string
-        replace_with_dot = lambda match: f"{'⋅':^{len(match.group(0))}}"
+        replace_with_dot = lambda match: f'{"⋅":^{len(match.group(0))}}'
         data_str = re.sub(pattern, replace_with_dot, str(self.to_jax()))
         return super().__repr__() + f', ndiags={self.ndiags}\n{data_str}'
 

--- a/dynamiqs/random/__init__.py
+++ b/dynamiqs/random/__init__.py
@@ -1,0 +1,3 @@
+from .core import *
+
+__all__ = ['complex', 'dm', 'herm', 'ket', 'psd', 'real']

--- a/dynamiqs/random/core.py
+++ b/dynamiqs/random/core.py
@@ -4,8 +4,8 @@ import jax
 from jax import Array
 from jaxtyping import PRNGKeyArray
 
-from .qarrays.qarray import QArray
-from .utils.general import dag, unit
+from ..qarrays.qarray import QArray
+from ..utils.general import dag, unit
 
 __all__ = ['complex', 'dm', 'herm', 'ket', 'psd', 'real']
 


### PR DESCRIPTION
Fixes (new with Ruff 0.9.1)
```
>>> ruff check
dynamiqs/random.py:1:1: A005 Module `random` shadows a Python standard-library module
Found 1 error.
```