### PR TITLE
Improve spacing of Latex equations in docstrings

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -244,7 +244,11 @@ p {
 }
 
 .katex-display {
-    margin: 0.75em 0;
+    margin: 0.8em 0 !important;
+}
+
+.katex {
+    line-height: 1.05 !important;
 }
 
 .md-typeset .doc-heading {
@@ -260,7 +264,7 @@ p {
 }
 
 .md-typeset .doc-contents p {
-  margin-top: 1em;
+  margin-top: 0.75em;
   margin-bottom: 0.2em;
 }
 


### PR DESCRIPTION
Small improvements in rendering style, mainly to have an appropriate line spacing when there are latex equations on multiple lines in docstrings.