### PR TITLE
Fix wrongly implemented __truediv__ in QArrays

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -10,7 +10,6 @@ from jax import Array, Device
 from jaxtyping import ArrayLike
 from qutip import Qobj
 
-from .._utils import _is_batched_scalar
 from .layout import Layout, dense
 from .qarray import QArray, QArrayLike, _in_last_two_dims, _to_jax, isqarraylike
 from .sparsedia_primitives import array_to_sparsedia
@@ -152,20 +151,6 @@ class DenseQArray(QArray):
         super().__mul__(y)
 
         data = y * self.data
-        return self._replace(data=data)
-
-    def __truediv__(self, y: QArrayLike) -> QArray:
-        super().__truediv__(y)
-
-        if _is_batched_scalar(y):
-            data = self.data / y
-        elif isinstance(y, DenseQArray):
-            data = self.data / y.data
-        elif isqarraylike(y):
-            data = self.data / _to_jax(y)
-        else:
-            return NotImplemented
-
         return self._replace(data=data)
 
     def __add__(self, y: QArrayLike) -> QArray:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -454,12 +454,12 @@ class QArray(eqx.Module):
     def __rmul__(self, y: QArrayLike) -> QArray:
         return self * y
 
-    def __truediv__(self, y: QArrayLike) -> QArray:
+    def __truediv__(self, y: ArrayLike) -> QArray:
         return self * (1 / y)
 
     def __rtruediv__(self, y: QArrayLike) -> QArray:
         raise NotImplementedError(
-            'Division by a qarray with the `/` operator is not supported. '
+            'Division by a qarray with the `/` operator is not supported.'
         )
 
     def __iter__(self):

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -175,8 +175,8 @@ class QArray(eqx.Module):
     #   - returning a JAX array or other: norm, trace, sum, squeeze, _eig, _eigh,
     #                                     _eigvals, _eigvalsh, devices, isherm
     #   - conversion/utils methods: to_qutip, to_jax, __array__, block_until_ready
-    #   - special methods: __mul__, __truediv__, __add__, __matmul__, __rmatmul__,
-    #                         __and__, addscalar, elmul, elpow, __getitem__
+    #   - special methods: __mul__, __add__, __matmul__, __rmatmul__, __and__,
+    #                      addscalar, elmul, elpow, __getitem__
 
     dims: tuple[int, ...] = eqx.field(static=True)
     vectorized: bool = eqx.field(static=True)
@@ -454,12 +454,13 @@ class QArray(eqx.Module):
     def __rmul__(self, y: QArrayLike) -> QArray:
         return self * y
 
-    @abstractmethod
     def __truediv__(self, y: QArrayLike) -> QArray:
-        pass
+        return self * (1 / y)
 
     def __rtruediv__(self, y: QArrayLike) -> QArray:
-        return self * 1 / y
+        raise NotImplementedError(
+            'Division by a qarray with the `/` operator is not supported. '
+        )
 
     def __iter__(self):
         for i in range(self.shape[0]):

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -254,9 +254,6 @@ class SparseDIAQArray(QArray):
         diags = y * self.diags
         return self._replace(diags=diags)
 
-    def __truediv__(self, y: QArrayLike) -> QArray:
-        raise NotImplementedError
-
     def __add__(self, y: QArrayLike) -> QArray:
         super().__add__(y)
 


### PR DESCRIPTION
```python
import dynamiqs as dq
import jax.numpy as jnp

dq.sigmaz() / jnp.sqrt(2) # this should work
jnp.sqrt(2) / dq.sigmaz() # this should not work
```