### PR TITLE
Use uv for the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          # test cache
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          # test cache
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
+          python-version: "3.10"
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv and set Python 3.10
+      - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: 3.10
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --extra --dev
+        run: uv sync --extra dev
 
       - name: List installed dependencies
         run: uv pip list

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies
         run: uv sync --extra --dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,32 +16,22 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10']
-        # os: [ubuntu-latest, macOS-latest, windows-latest]
-        os: [ubuntu-latest]
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+      - name: Install uv and set Python 3.10
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
+          python-version: 3.10
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+        run: uv sync --extra --dev
 
       - name: List installed dependencies
-        run: python -m pip list
+        run: uv pip list
 
       - name: Run CI checks
-        run: task ci
+        run: uv run task ci

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
+          python-version: "3.10"
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
 

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -21,10 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv and set Python 3.10
+      - name: Install uv and Python
         uses: astral-sh/setup-uv@v5
         with:
-          python-version: 3.10
           enable-cache: true
 
       - name: Install dependencies

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -28,7 +28,7 @@ jobs:
           cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies
-        run: uv sync --extra --dev
+        run: uv sync --extra dev
 
       - name: List installed dependencies
         run: uv pip list

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -25,6 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
 
       - name: Install dependencies
         run: uv sync --extra --dev

--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -19,29 +19,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v4
+      - name: Install uv and set Python 3.10
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.10"
-          cache: "pip"
-          cache-dependency-path: "pyproject.toml"
+          python-version: 3.10
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e ".[dev]"
+        run: uv sync --extra --dev
 
       - name: List installed dependencies
-        run: python -m pip list
+        run: uv pip list
 
       - name: Run doctest
-        run: task doctest
+        run: uv run task doctest
 
       - name: Publish website
         run: |
           git fetch origin gh-pages --depth=1
           git config user.name ci-bot
           git config user.email ci-bot@example.com
-          mike deploy --push dev
+          uv run mike deploy --push dev

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ docs/figs_docs/**
 
 # temporary directiry
 .tmp/**
+
+# uv lock file
+uv.lock


### PR DESCRIPTION
The "Install dependencies" step is now 1s instead of 30s (for a cache hit), and just 6s to install dependencies when we change `pyproject.toml`. 😊