### PR TITLE
Add `Rouchon1` solver for `dq.dsmesolve()`

### DIFF
--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -63,6 +63,9 @@ class DSMEInterface(AbstractTimeInterface):
     def L(self, t: Scalar) -> list[QArray]:
         return [_L(t) for _L in self.Ls]  # (nLs, n, n)
 
+    def Lc(self, t: Scalar) -> list[QArray]:
+        return [_L(t) for _L in self.Lcs]  # (nLc, n, n)
+
     def Lm(self, t: Scalar) -> list[QArray]:
         return [_L(t) for _L in self.Lms]  # (nLm, n, n)
 

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 from diffrax._custom_types import RealScalarLike, Y
 from diffrax._local_interpolation import LocalLinearInterpolation
 
+from ...qarrays.qarray import QArray
 from ...utils.general import dag
 from ...utils.operators import eye_like
 from .diffrax_integrator import MESolveDiffraxIntegrator
@@ -53,6 +54,43 @@ class Rouchon1DXSolver(RouchonDXSolver):
         return 1
 
 
+def _cholesky_normalize(M0: QArray, LdL: QArray, dt: float, rho: QArray) -> jax.Array:
+    # To normalize the scheme, we compute S = M0d @ M0 + M1d @ M1 and replace
+    #   M0 by ~M0 = M0 @ S^{-1/2}
+    #   M1 by ~M1 = M1 @ S^{-1/2}
+    # such that
+    #   ~M0d @ ~M0 + ~M1d @ ~M1 = Sd^{-1/2} (M0d @ M0 + M1d @ M1) S^{-1/2}
+    #                           = Sd^{-1/2} S S^{-1/2}
+    #                           = I
+    #
+    # For efficiency, we use a Cholesky decomposition instead of computing
+    # S^{-1/2} explicitly. We write S = T @ Td with T lower triangular, and we
+    # replace
+    #   M0 by ~M0 = M0 @ Td^{-1}
+    #   M1 by ~M1 = M1 @ Td^{-1}
+    # such that
+    #   ~M0d @ ~M0 + ~M1d @ ~M1 = T^{-1} @ (M0d @ M0 + M1d @ M1) @ Td^{-1}
+    #                           = T^{-1} @ T @ Td @ Td^{-1}
+    #                           = I
+    #
+    # In practice we directly replace rho_k by Td^{-1} @ rho_k @ T^{-1/2}
+    # instead of computing all ~Mks.
+
+    # dt may be a traced array, so we need to be careful with the sum
+    S = M0.dag() @ M0 + (LdL * dt if LdL != 0.0 else 0.0)
+
+    T = jnp.linalg.cholesky(S.to_jax())  # T lower triangular
+
+    # we want Td^{-1} @ y0 @ T^{-1}
+    rho = rho.to_jax()
+    # solve Td @ x = rho => x = Td^{-1} @ rho
+    rho = jax.lax.linalg.triangular_solve(
+        T, rho, lower=True, transpose_a=True, conjugate_a=True
+    )
+    # solve x @ T = rho => x = rho @ T^{-1}
+    return jax.lax.linalg.triangular_solve(T, rho, lower=True, left_side=True)
+
+
 class MESolveRouchon1Integrator(MESolveDiffraxIntegrator):
     """Integrator computing the time evolution of the Lindblad master equation using the
     Rouchon 1 solver.
@@ -67,26 +105,7 @@ class MESolveRouchon1Integrator(MESolveDiffraxIntegrator):
             #   M0 = I - (iH + 0.5 Ld @ L) dt
             #   M1 = L sqrt(dt)
             #
-            # To normalize the scheme, we compute S = M0d @ M0 + M1d @ M1 and replace
-            #   M0 by ~M0 = M0 @ S^{-1/2}
-            #   M1 by ~M1 = M1 @ S^{-1/2}
-            # such that
-            #   ~M0d @ ~M0 + ~M1d @ ~M1 = Sd^{-1/2} (M0d @ M0 + M1d @ M1) S^{-1/2}
-            #                           = Sd^{-1/2} S S^{-1/2}
-            #                           = I
-            #
-            # For efficiency, we use a Cholesky decomposition instead of computing
-            # S^{-1/2} explicitly. We write S = T @ Td with T lower triangular, and we
-            # replace
-            #   M0 by ~M0 = M0 @ Td^{-1}
-            #   M1 by ~M1 = M1 @ Td^{-1}
-            # such that
-            #   ~M0d @ ~M0 + ~M1d @ ~M1 = T^{-1} @ (M0d @ M0 + M1d @ M1) @ Td^{-1}
-            #                           = T^{-1} @ T @ Td @ Td^{-1}
-            #                           = I
-            #
-            # In practice we directly replace rho_k by Td^{-1} @ rho_k @ T^{-1/2}
-            # instead of computing all ~Mks.
+            # See comment of `_cholesky_normalize()` for the normalisation.
 
             delta_t = t1 - t0
             rho = y0
@@ -98,21 +117,7 @@ class MESolveRouchon1Integrator(MESolveDiffraxIntegrator):
             Ms = [jnp.sqrt(delta_t) * _L for _L in L]
 
             if self.solver.normalize:
-                # delta_t is a traced array, so we need to be careful with the sum
-                S = M0.dag() @ M0 + (LdL * delta_t if LdL != 0.0 else 0.0)
-
-                T = jnp.linalg.cholesky(S.to_jax())  # T lower triangular
-
-                # we want Td^{-1} @ y0 @ T^{-1}
-                rho = rho.to_jax()
-                # solve Td @ x = rho => x = Td^{-1} @ rho
-                rho = jax.lax.linalg.triangular_solve(
-                    T, rho, lower=True, transpose_a=True, conjugate_a=True
-                )
-                # solve x @ T = rho => x = rho @ T^{-1}
-                rho = jax.lax.linalg.triangular_solve(
-                    T, rho, lower=True, left_side=True
-                )
+                rho = _cholesky_normalize(M0, LdL, delta_t, rho)
 
             return M0 @ rho @ dag(M0) + sum([_M @ rho @ dag(_M) for _M in Ms])
 

--- a/dynamiqs/solver.py
+++ b/dynamiqs/solver.py
@@ -163,7 +163,7 @@ class EulerMaruyama(_DEFixedStep):
 
 
 class Rouchon1(_DEFixedStep):
-    r"""First-order Rouchon method (fixed step size ODE solver).
+    r"""First-order Rouchon method (fixed step size ODE/SDE solver).
 
     Args:
         dt: Fixed time step.


### PR DESCRIPTION
See https://arxiv.org/pdf/2208.07416 section 3.4. "Kraus maps and numerical schemes for diffusive SME".

Example use case:

```python
import jax.numpy as jnp
import dynamiqs as dq

n = 16
a = dq.destroy(n)
H = dq.zeros(n)
L = a @ a
jump_ops = [L]
etas = [0.8]
psi0 = dq.coherent_dm(n, 2.0)
tsave = jnp.linspace(0, 1.0, 11)
key = jax.random.key(42)
keys = jax.random.split(key, 1000)

# lindblad
rhos = dq.mesolve(H, jump_ops, psi0, tsave).states
dq.plot.wigner_mosaic(rhos, n=5, xmax=3)

# euler SME average trajectory
solver = dq.solver.EulerMaruyama(dt=0.1)
rhos = dq.dsmesolve(H, jump_ops, etas, psi0, tsave, keys, solver=solver).states
rhos = rhos.unit()
dq.plot.wigner_mosaic(rhos.to_jax().mean(0), n=5, xmax=3)

# rouchon SME average trajectory
solver = dq.solver.Rouchon1(dt=0.1)
rhos = dq.dsmesolve(H, jump_ops, etas, psi0, tsave, keys, solver=solver).states
dq.plot.wigner_mosaic(rhos.to_jax().mean(0), n=5, xmax=3)
```

![8d5250f7-b5b5-414c-bf58-4ad69cebe0ad](https://github.com/user-attachments/assets/95d33af3-1b85-4191-bb72-11860b373786)
![fc4294d0-bd09-4a76-9392-6e3eec25c335](https://github.com/user-attachments/assets/7b9dfa8b-e255-4f47-8d38-a65588663ad4)
![c6d6397c-ec1b-4965-852a-028704eff9f6](https://github.com/user-attachments/assets/b0b11dd2-7a22-49c7-967e-8a1b15f9d1dc)

