### PR TITLE
Add `dq.plot.xyz()` to plot Pauli operators expectation values for a qubit

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -244,6 +244,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - fock
         - fock_evolution
         - hinton
+        - xyz
         - gifit
         - grid
         - mplstyle

--- a/dynamiqs/plot/__init__.py
+++ b/dynamiqs/plot/__init__.py
@@ -2,12 +2,14 @@ from .colormaps import *
 from .fock import *
 from .hinton import *
 from .misc import *
+from .qubit import *
 from .utils import *
 from .wigner import *
 
 __all__ = [
     'fock',
     'fock_evolution',
+    'xyz',
     'gifit',
     'grid',
     'hinton',

--- a/dynamiqs/plot/qubit.py
+++ b/dynamiqs/plot/qubit.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import jax.numpy as jnp
+from jax.typing import ArrayLike
+from matplotlib.axes import Axes
+
+from .._checks import check_shape
+from ..qarrays.qarray import QArrayLike
+from ..qarrays.utils import to_jax
+from ..utils.general import expect
+from ..utils.operators import sigmax, sigmay, sigmaz
+from .utils import optional_ax
+
+__all__ = ['xyz']
+
+
+@optional_ax
+def xyz(
+    states: QArrayLike,
+    *,
+    ax: Axes | None = None,
+    times: ArrayLike | None = None,
+    hlines: bool = True,
+):
+    r"""Plot the expectation values of the Pauli operators $\sigma_x$, $\sigma_y$ and
+    $\sigma_z$ for a qubit as functions of time.
+
+    Warning:
+        Documentation redaction in progress.
+
+    Examples:
+        >>> H = dq.sigmax() + dq.sigmay()
+        >>> jump_ops = [jnp.sqrt(0.2) * dq.sigmam()]
+        >>> psi0 = dq.excited()
+        >>> tsave = jnp.linspace(0, 10.0, 1001)
+        >>> result = states = dq.mesolve(H, jump_ops, psi0, tsave)
+        >>> dq.plot.xyz(result.states, times=tsave)
+        >>> renderfig('plot_xyz')
+
+        ![plot_xyz](../../figs_code/plot_xyz.png){.fig}
+    """
+    states = to_jax(states)
+    times = jnp.asarray(times) if times is not None else None
+    check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
+
+    x = jnp.arange(len(states)) if times is None else times
+    sx, sy, sz = sigmax(), sigmay(), sigmaz()
+    y = expect([sx, sy, sz], states).real  # (3, nstates)
+    y = y.T  # (nstates, 3)
+    label = [rf'$\langle \sigma_{k}\rangle$' for k in ['x', 'y', 'z']]
+    ax.plot(x, y, label=label)
+    ax.set(ylim=(-1.0 - 0.06, 1.0 + 0.06))
+    ax.legend()
+
+    if hlines:
+        ax.axhline(-1.0, ls='--', color='gray', lw=1.0)
+        ax.axhline(1.0, ls='--', color='gray', lw=1.0)

--- a/dynamiqs/plot/qubit.py
+++ b/dynamiqs/plot/qubit.py
@@ -22,8 +22,8 @@ def xyz(
     times: ArrayLike | None = None,
     hlines: bool = True,
 ):
-    r"""Plot the expectation values of the Pauli operators $\sigma_x$, $\sigma_y$ and
-    $\sigma_z$ for a qubit as functions of time.
+    r"""Plot the expectation value of the Pauli operators of a qubit $\sigma_x$,
+    $\sigma_y$ and $\sigma_z$ as a function of time.
 
     Warning:
         Documentation redaction in progress.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -290,6 +290,7 @@ nav:
               - fock: python_api/plot/fock.md
               - fock_evolution: python_api/plot/fock_evolution.md
               - hinton: python_api/plot/hinton.md
+              - xyz: python_api/plot/xyz.md
               - gifit: python_api/plot/gifit.md
               - grid: python_api/plot/grid.md
               - mplstyle: python_api/plot/mplstyle.md


### PR DESCRIPTION
I use this all the time. 😇

![Screenshot 2025-02-05 at 11 59 16](https://github.com/user-attachments/assets/51e8bae0-9a6a-4030-9281-deb862c29a73)
