### PR TITLE
Implement __array_priority__ for QArrays

### DIFF
--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -182,6 +182,10 @@ class QArray(eqx.Module):
     dims: tuple[int, ...] = eqx.field(static=True)
     vectorized: bool = eqx.field(static=True)
 
+    # Increase __array_priority__ to ensure that a qarray is always returned
+    # In JAX, it is set to 100 by default. In NumPy, it is set to 0.
+    __array_priority__ = 200
+
     def _replace(
         self,
         dims: tuple[int, ...] | None = None,


### PR DESCRIPTION
Fixes:
```python
import dynamiqs as dq
import numpy as np
import jax.numpy as jnp

x = dq.destroy(10)

print(type(2.0 * x)) # <class 'dynamiqs.qarrays.sparsedia_qarray.SparseDIAQArray'>
print(type(np.float64(2.0) * x)) # <class 'numpy.ndarray'>
print(type(jnp.float32(2.0) * x)) # <class 'dynamiqs.qarrays.sparsedia_qarray.SparseDIAQArray'>
```

See e.g. https://github.com/jax-ml/jax/blob/11b45a6f63b4f0d6ba4b0dd30a4da2c045bd376b/jax/_src/array.py#L735.