### PR TITLE
Remove jax<0.5.1 requirement in dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "tqdm",
-    "jax>=0.4.36,<0.5.1", # >=0.4.36 for GPU eig support, <0.5.1 temporary fix (todo)
+    "jax>=0.4.36", # >=0.4.36 for GPU eig support
     "jaxtyping",
     "diffrax>=0.5.1",  # for complex support (0.5.0) and progress meter (0.5.1)
     "equinox",


### PR DESCRIPTION
Fixed by latest equinox release, https://github.com/patrick-kidger/equinox/releases/tag/v0.11.12