### PR TITLE
Fix printing patterns for SparseDIAQArray in scientific format

### DIFF
--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -232,10 +232,10 @@ class SparseDIAQArray(QArray):
         # === array representation with dots instead of zeros
         if jnp.issubdtype(self.dtype, jnp.complexfloating):
             # match '0. +0.j' with any number of spaces
-            pattern = r'(?<!\d)0\.\s*(\+|\-)0\.j'
+            pattern = r'(?<!\d)0\.(?:0+)?(?:e[+-]0+)?\s*[+-]\s*0\.(?:0+)?(?:e[+-]0+)?j'
         elif jnp.issubdtype(self.dtype, jnp.floating):
             # match '0.' with any number of spaces
-            pattern = r'(?<!\d)0\.\s*'
+            pattern = r'(?<!\d)0\.(?:0+)?(?:e[+-]0+)?\s*'
         elif jnp.issubdtype(self.dtype, jnp.integer):
             # match '0' with any number of spaces
             pattern = r'(?<!\d)0\s*'


### PR DESCRIPTION
MWE:
```python
import dynamiqs as dq
import jax.numpy as jnp

print(dq.asqarray(
    jnp.array([[1.05e-4, 0], [0, 9.9e1]], dtype=jnp.complex64),
    layout=dq.dia,
))

print(dq.asqarray(
    jnp.array([[1.05e-4j, 0], [0, 9.9e1j]], dtype=jnp.complex64),
    layout=dq.dia,
))

print(dq.asqarray(
    jnp.array([[1.05e-4 + 1.05e-2j, 0], [0, 9.9e1+1.5e3j]], dtype=jnp.complex64),
    layout=dq.dia,
))

print(dq.asqarray(
    jnp.array([[1.05e-4, 0], [0, 9.9e1]], dtype=jnp.float32),
    layout=dq.dia,
))
```

Before:
```python
QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
[[1.05e-04+0.j 0.00e+00+0.j]
 [0.00e+00+0.j 9.90e+01+0.j]]
QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
[[0.+1.05e-04j 0.+0.00e+00j]
 [0.+0.00e+00j 0.+9.90e+01j]]
QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
[[1.05e-04+1.05e-02j 0.00e+00+0.00e+00j]
 [0.00e+00+0.00e+00j 9.90e+01+1.50e+03j]]
QArray: shape=(2, 2), dims=(2,), dtype=float32, layout=dia, ndiags=1
[[1.05e-04 ⋅ 00e+00]
 [⋅ 00e+00 9.90e+01]]
```

After:
```python
QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
[[1.05e-04+0.j      ⋅      ]
 [     ⋅       9.90e+01+0.j]]
QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
[[0.+1.05e-04j      ⋅      ]
 [     ⋅       0.+9.90e+01j]]
QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
[[1.05e-04+1.05e-02j         ⋅         ]
 [        ⋅          9.90e+01+1.50e+03j]]
QArray: shape=(2, 2), dims=(2,), dtype=float32, layout=dia, ndiags=1
[[1.05e-04    ⋅    ]
 [    ⋅    9.90e+01]]
```