### PR TITLE
Remove normalization warning in `dq.wigner()` (not jit-compatible)

### DIFF
--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -116,9 +116,7 @@ def _warn_non_normalised(x: QArrayLike, argname: str):
     # issue a warning if the input qarray-like is not normalised
     def warn(norm: Array) -> None:
         warnings.warn(
-            f'Argument {argname} is not normalized (expected norm 1.0 but norm is'
-            f' {norm}).',
-            stacklevel=2,
+            f'Argument {argname} is not normalized (expected norm 1).', stacklevel=2
         )
 
     x = asqarray(x)

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
-import warnings
-
 import equinox as eqx
-import jax
 import jax.numpy as jnp
 from jax import Array
 
-from ._utils import _get_default_dtype
-from .qarrays.qarray import QArray, QArrayLike
-from .qarrays.utils import asqarray
+from .qarrays.qarray import QArray
 
 _is_perfect_square = lambda n: int(n**0.5) ** 2 == n
 
@@ -110,22 +105,3 @@ def check_hermitian(x: QArray, argname: str) -> QArray:
         jnp.logical_not(x.isherm(rtol=rtol, atol=atol)),
         f'Argument {argname} is not hermitian.',
     )
-
-
-def _warn_non_normalised(x: QArrayLike, argname: str):
-    # issue a warning if the input qarray-like is not normalised
-    def callback(x: QArray):
-        warnings.warn(
-            f'Argument {argname} is not normalized (expected norm 1, but is '
-            f'{x.norm():.3e}).',
-            stacklevel=2,
-        )
-
-    def warn(x: QArray) -> QArray:
-        jax.debug.callback(callback, x)
-        return x
-
-    x = asqarray(x)
-    atol = 1e-2 if _get_default_dtype() == jnp.float32 else 1e-6
-    cond = jnp.allclose(x.norm(), 1.0, rtol=0.0, atol=atol)
-    jax.lax.cond(cond, lambda x: x, warn, x)

--- a/dynamiqs/utils/wigner_utils.py
+++ b/dynamiqs/utils/wigner_utils.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 from jax import Array, lax
 from jaxtyping import ArrayLike
 
-from .._checks import _warn_non_normalised, check_shape
+from .._checks import check_shape
 from ..qarrays.qarray import QArrayLike
 from ..qarrays.utils import to_jax
 from .general import todm
@@ -51,7 +51,6 @@ def wigner(
     """  # noqa: E501
     state = to_jax(state)
     check_shape(state, 'state', '(..., n, 1)', '(..., n, n)')
-    _warn_non_normalised(state, 'state')
 
     # === convert state to density matrix
     state = to_jax(todm(state))


### PR DESCRIPTION
Follow-up to https://github.com/dynamiqs/dynamiqs/pull/914 to fix the following MWE:
```python
import dynamiqs as dq
import jax

jax.jit(dq.wigner)(dq.coherent(8, 1.0))
```
cc @cyril87885 