### PR TITLE
Fix paper citation date and authors order

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ If you have found this library useful in your academic research, you can cite:
 ```bibtex
 @unpublished{guilmin2025dynamiqs,
   title  = {Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems},
-  author = {Pierre Guilmin and Ronan Gautier and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss},
+  author = {Pierre Guilmin and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss and Ronan Gautier},
   year   = {2025},
   url    = {https://github.com/dynamiqs/dynamiqs}
 }
 ```
 
-> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.
+> P. Guilmin, A. Bocquet, E. Genois, D. Weiss, R. Gautier. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.

--- a/README.md
+++ b/README.md
@@ -207,12 +207,12 @@ We warmly welcome all contributions. If you're a junior developer or physicist, 
 If you have found this library useful in your academic research, you can cite:
 
 ```bibtex
-@unpublished{guilmin2024dynamiqs,
+@unpublished{guilmin2025dynamiqs,
   title  = {Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems},
   author = {Pierre Guilmin and Ronan Gautier and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss},
-  year   = {2024},
+  year   = {2025},
   url    = {https://github.com/dynamiqs/dynamiqs}
 }
 ```
 
-> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2024), in preparation.
+> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -200,12 +200,12 @@ We warmly welcome all contributions. If you're a junior developer or physicist, 
 If you have found this library useful in your academic research, you can cite:
 
 ```bibtex
-@unpublished{guilmin2024dynamiqs,
+@unpublished{guilmin2025dynamiqs,
   title  = {Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems},
   author = {Pierre Guilmin and Ronan Gautier and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss},
-  year   = {2024},
+  year   = {2025},
   url    = {https://github.com/dynamiqs/dynamiqs}
 }
 ```
 
-> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2024), in preparation.
+> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -202,10 +202,10 @@ If you have found this library useful in your academic research, you can cite:
 ```bibtex
 @unpublished{guilmin2025dynamiqs,
   title  = {Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems},
-  author = {Pierre Guilmin and Ronan Gautier and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss},
+  author = {Pierre Guilmin and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss and Ronan Gautier},
   year   = {2025},
   url    = {https://github.com/dynamiqs/dynamiqs}
 }
 ```
 
-> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.
+> P. Guilmin, A. Bocquet, E. Genois, D. Weiss, R. Gautier. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.

--- a/docs/community/citing.md
+++ b/docs/community/citing.md
@@ -3,12 +3,12 @@
 If you have found this library useful in your academic research, you can cite:
 
 ```bibtex
-@unpublished{guilmin2024dynamiqs,
+@unpublished{guilmin2025dynamiqs,
   title  = {Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems},
   author = {Pierre Guilmin and Ronan Gautier and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss},
-  year   = {2024},
+  year   = {2025},
   url    = {https://github.com/dynamiqs/dynamiqs}
 }
 ```
 
-> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2024), in preparation.
+> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.

--- a/docs/community/citing.md
+++ b/docs/community/citing.md
@@ -5,10 +5,10 @@ If you have found this library useful in your academic research, you can cite:
 ```bibtex
 @unpublished{guilmin2025dynamiqs,
   title  = {Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems},
-  author = {Pierre Guilmin and Ronan Gautier and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss},
+  author = {Pierre Guilmin and Adrien Bocquet and {\'{E}}lie Genois and Daniel Weiss and Ronan Gautier},
   year   = {2025},
   url    = {https://github.com/dynamiqs/dynamiqs}
 }
 ```
 
-> P. Guilmin, R. Gautier, A. Bocquet, E. Genois, D. Weiss. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.
+> P. Guilmin, A. Bocquet, E. Genois, D. Weiss, R. Gautier. Dynamiqs: an open-source Python library for GPU-accelerated and differentiable simulation of quantum systems (2025), in preparation.


### PR DESCRIPTION
This PR fixes the citation date (because, well, we're in 2025 😅). And the reordering acknowledges all the work done by @gautierronan for the library, both in the code and externally. It also gives a more prominent second author position to @abocquet, recognizing his significant contributions.

Let's wait for approval from all authors before merging.