### PR TITLE
Add global setting to set a default progress meter

### DIFF
--- a/docs/documentation/advanced_examples/kerr-oscillator.md
+++ b/docs/documentation/advanced_examples/kerr-oscillator.md
@@ -316,7 +316,7 @@ def compute_fidelity(amps):
     H = H0 + Hx + Hp
 
     # run simulation
-    options = dq.Options(progress_meter=None) # disable progress meter
+    options = dq.Options(progress_meter=False) # disable progress meter
     result = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=options)
 
     # fidelity is now defined as the overlap with |1> at the final time only

--- a/docs/documentation/basics/batching-simulations.md
+++ b/docs/documentation/basics/batching-simulations.md
@@ -228,7 +228,7 @@ H = omega * dq.sigmaz() + epsilon * dq.sigmax()  # (100, 30, 2, 2)
 # other simulation parameters
 psi0 = dq.basis(2, 0)
 tsave = jnp.linspace(0.0, 1.0, 50)
-options = dq.Options(progress_meter=None)
+options = dq.Options(progress_meter=False)
 
 # running the simulations successively
 def run_unbatched():

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -190,6 +190,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - set_precision
         - set_matmul_precision
         - set_layout
+        - set_progress_meter
 
 
 ### Vectorization

--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -238,6 +238,7 @@ def dsmesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+    options = options.initialise()
 
     # === check arguments
     _check_dsmesolve_args(H, Ls, etas, rho0, exp_ops)

--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -238,12 +238,12 @@ def dsmesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
-    options = options.initialise()
 
     # === check arguments
     _check_dsmesolve_args(H, Ls, etas, rho0, exp_ops)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'dsmesolve')
+    options = options.initialise()
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -229,12 +229,12 @@ def dssesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
-    options = options.initialise()
 
     # === check arguments
     _check_dssesolve_args(H, Ls, psi0, exp_ops)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'dssesolve')
+    options = options.initialise()
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -229,6 +229,7 @@ def dssesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+    options = options.initialise()
 
     # === check arguments
     _check_dssesolve_args(H, Ls, psi0, exp_ops)

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -157,12 +157,12 @@ def floquet(
     # === convert arguments
     H = astimeqarray(H)
     tsave = jnp.asarray(tsave)
-    options = options.initialise()
 
     # === check arguments
     tsave = check_times(tsave, 'tsave')
     H, T, tsave = _check_floquet_args(H, T, tsave)
     check_options(options, 'floquet')
+    options = options.initialise()
 
     # We implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -72,7 +72,7 @@ def floquet(
             ??? "Detailed options API"
                 ```
                 dq.Options(
-                    progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+                    progress_meter: AbstractProgressMeter | bool | None = None,
                     t0: ScalarLike | None = None,
                 )
                 ```
@@ -80,8 +80,11 @@ def floquet(
                 **Parameters**
 
                 - **progress_meter** - Progress meter indicating how far the solve has
-                    progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm)
-                    progress meter. Pass `None` for no output, see other options in
+                    progressed. Defaults to `None` which uses the global default
+                    progress meter (see
+                    [`dq.set_progress_meter()`][dynamiqs.set_progress_meter]). Set to
+                    `True` for a [tqdm](https://github.com/tqdm/tqdm) progress meter,
+                    and `False` for no output. See other options in
                     [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
                     If gradients are computed, the progress meter only displays during
                     the forward pass.
@@ -154,6 +157,7 @@ def floquet(
     # === convert arguments
     H = astimeqarray(H)
     tsave = jnp.asarray(tsave)
+    options = options.initialise()
 
     # === check arguments
     tsave = check_times(tsave, 'tsave')

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -243,6 +243,7 @@ def jssesolve(
     _check_jssesolve_args(H, Ls, psi0, exp_ops)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'jssesolve')
+    options = options.initialise()
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to JAX arrays

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -164,6 +164,7 @@ def mepropagator(
     H = astimeqarray(H)
     Ls = [astimeqarray(L) for L in jump_ops]
     tsave = jnp.asarray(tsave)
+    options = options.initialise()
 
     # === check arguments
     _check_mepropagator_args(H, Ls)

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -164,12 +164,12 @@ def mepropagator(
     H = astimeqarray(H)
     Ls = [astimeqarray(L) for L in jump_ops]
     tsave = jnp.asarray(tsave)
-    options = options.initialise()
 
     # === check arguments
     _check_mepropagator_args(H, Ls)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'mepropagator')
+    options = options.initialise()
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -221,12 +221,12 @@ def mesolve(
     tsave = jnp.asarray(tsave)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
-    options = options.initialise()
 
     # === check arguments
     _check_mesolve_args(H, Ls, rho0, exp_ops)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'mesolve')
+    options = options.initialise()
 
     # === convert rho0 to density matrix
     rho0 = rho0.todm()

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -108,7 +108,7 @@ def mesolve(
                 dq.Options(
                     save_states: bool = True,
                     cartesian_batching: bool = True,
-                    progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+                    progress_meter: AbstractProgressMeter | bool | None = None,
                     t0: ScalarLike | None = None,
                     save_extra: callable[[Array], PyTree] | None = None,
                 )
@@ -122,8 +122,11 @@ def mesolve(
                     separated batch dimensions, otherwise the batching is performed over
                     a single shared batched dimension.
                 - **progress_meter** - Progress meter indicating how far the solve has
-                    progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm)
-                    progress meter. Pass `None` for no output, see other options in
+                    progressed. Defaults to `None` which uses the global default
+                    progress meter (see
+                    [`dq.set_progress_meter()`][dynamiqs.set_progress_meter]). Set to
+                    `True` for a [tqdm](https://github.com/tqdm/tqdm) progress meter,
+                    and `False` for no output. See other options in
                     [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
                     If gradients are computed, the progress meter only displays during
                     the forward pass.
@@ -218,6 +221,7 @@ def mesolve(
     tsave = jnp.asarray(tsave)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+    options = options.initialise()
 
     # === check arguments
     _check_mesolve_args(H, Ls, rho0, exp_ops)

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -159,12 +159,12 @@ def sepropagator(
     # === convert arguments
     H = astimeqarray(H)
     tsave = jnp.asarray(tsave)
-    options = options.initialise()
 
     # === check arguments
     _check_sepropagator_args(H)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'sepropagator')
+    options = options.initialise()
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -81,7 +81,7 @@ def sepropagator(
                 ```
                 dq.Options(
                     save_propagators: bool = True,
-                    progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+                    progress_meter: AbstractProgressMeter | bool | None = None,
                     t0: ScalarLike | None = None,
                     save_extra: callable[[Array], PyTree] | None = None,
                 )
@@ -92,8 +92,11 @@ def sepropagator(
                 - **save_propagators** - If `True`, the propagator is saved at every
                     time in `tsave`, otherwise only the final propagator is returned.
                 - **progress_meter** - Progress meter indicating how far the solve has
-                    progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm)
-                    progress meter. Pass `None` for no output, see other options in
+                    progressed. Defaults to `None` which uses the global default
+                    progress meter (see
+                    [`dq.set_progress_meter()`][dynamiqs.set_progress_meter]). Set to
+                    `True` for a [tqdm](https://github.com/tqdm/tqdm) progress meter,
+                    and `False` for no output. See other options in
                     [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
                     If gradients are computed, the progress meter only displays during
                     the forward pass.
@@ -156,6 +159,7 @@ def sepropagator(
     # === convert arguments
     H = astimeqarray(H)
     tsave = jnp.asarray(tsave)
+    options = options.initialise()
 
     # === check arguments
     _check_sepropagator_args(H)

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -84,7 +84,7 @@ def sesolve(
                 dq.Options(
                     save_states: bool = True,
                     cartesian_batching: bool = True,
-                    progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),
+                    progress_meter: AbstractProgressMeter | bool | None = None,
                     t0: ScalarLike | None = None,
                     save_extra: callable[[Array], PyTree] | None = None,
                 )
@@ -98,8 +98,11 @@ def sesolve(
                     separated batch dimensions, otherwise the batching is performed over
                     a single shared batched dimension.
                 - **progress_meter** - Progress meter indicating how far the solve has
-                    progressed. Defaults to a [tqdm](https://github.com/tqdm/tqdm)
-                    progress meter. Pass `None` for no output, see other options in
+                    progressed. Defaults to `None` which uses the global default
+                    progress meter (see
+                    [`dq.set_progress_meter()`][dynamiqs.set_progress_meter]). Set to
+                    `True` for a [tqdm](https://github.com/tqdm/tqdm) progress meter,
+                    and `False` for no output. See other options in
                     [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
                     If gradients are computed, the progress meter only displays during
                     the forward pass.
@@ -189,6 +192,7 @@ def sesolve(
     tsave = jnp.asarray(tsave)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+    options = options.initialise()
 
     # === check arguments
     _check_sesolve_args(H, psi0, exp_ops)

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -192,12 +192,12 @@ def sesolve(
     tsave = jnp.asarray(tsave)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
-    options = options.initialise()
 
     # === check arguments
     _check_sesolve_args(H, psi0, exp_ops)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'sesolve')
+    options = options.initialise()
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -64,7 +64,6 @@ class Options(eqx.Module):
             t0=self.t0,
             save_extra=self.save_extra,
             nmaxclick=self.nmaxclick,
-            smart_sampling=self.smart_sampling,
         )
 
 

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -5,8 +5,9 @@ import jax.tree_util as jtu
 from jaxtyping import PyTree, ScalarLike
 
 from ._utils import tree_str_inline
-from .progress_meter import AbstractProgressMeter, NoProgressMeter, TqdmProgressMeter
+from .progress_meter import AbstractProgressMeter
 from .qarrays.qarray import QArray
+from .utils.global_settings import get_progress_meter
 
 __all__ = ['Options']
 
@@ -15,7 +16,7 @@ class Options(eqx.Module):
     save_states: bool = True
     save_propagators: bool = True
     cartesian_batching: bool = True
-    progress_meter: AbstractProgressMeter | None = TqdmProgressMeter()
+    progress_meter: AbstractProgressMeter | bool | None = None
     t0: ScalarLike | None = None
     save_extra: callable[[QArray], PyTree] | None = None
     nmaxclick: int = 10_000
@@ -26,15 +27,12 @@ class Options(eqx.Module):
         save_states: bool = True,
         save_propagators: bool = True,
         cartesian_batching: bool = True,
-        progress_meter: AbstractProgressMeter | None = TqdmProgressMeter(),  # noqa: B008
+        progress_meter: AbstractProgressMeter | bool | None = None,
         t0: ScalarLike | None = None,
         save_extra: callable[[QArray], PyTree] | None = None,
         nmaxclick: int = 10_000,
         smart_sampling: bool = False,
     ):
-        if progress_meter is None:
-            progress_meter = NoProgressMeter()
-
         self.save_states = save_states
         self.save_propagators = save_propagators
         self.cartesian_batching = cartesian_batching
@@ -48,6 +46,29 @@ class Options(eqx.Module):
 
     def __str__(self) -> str:
         return tree_str_inline(self)
+
+    def initialise(self) -> Options:
+        # We need to call this before entering JIT-compiled functions. Why? Because
+        # `progress_meter` is defined at runtime by the default value set in the global
+        # settings. Now things become a bit tricky:
+        # - We can't get the default value to set it in the `__init__`, because the
+        #   default argument to many functions is `Options()`, so it would be set
+        #   forever to the default `progress_meter` value at the time of the function
+        #   import.
+        # - A simple workaround would be to use a property to get the `progress_meter`
+        #   dynamically, but then changing the default value would not change the
+        #   `options` object attributes, and we would cache hit the JIT-compiled
+        #   function for any previous existing `options` object.
+        return Options(
+            save_states=self.save_states,
+            save_propagators=self.save_propagators,
+            cartesian_batching=self.cartesian_batching,
+            progress_meter=get_progress_meter(self.progress_meter),
+            t0=self.t0,
+            save_extra=self.save_extra,
+            nmaxclick=self.nmaxclick,
+            smart_sampling=self.smart_sampling,
+        )
 
 
 def check_options(options: Options, solver_name: str):

--- a/dynamiqs/utils/global_settings.py
+++ b/dynamiqs/utils/global_settings.py
@@ -4,9 +4,18 @@ from typing import Literal
 
 import jax
 
+from ..progress_meter import AbstractProgressMeter, NoProgressMeter, TqdmProgressMeter
 from ..qarrays.layout import dense, dia, set_global_layout
 
-__all__ = ['set_device', 'set_layout', 'set_matmul_precision', 'set_precision']
+__all__ = [
+    'set_device',
+    'set_layout',
+    'set_matmul_precision',
+    'set_precision',
+    'set_progress_meter',
+]
+
+_DEFAULT_PROGRESS_METER: AbstractProgressMeter = TqdmProgressMeter()
 
 
 def set_device(device: Literal['cpu', 'gpu', 'tpu'], index: int = 0):
@@ -135,3 +144,33 @@ def set_layout(layout: Literal['dense', 'dia']):
         )
 
     set_global_layout(layouts[layout])
+
+
+def set_progress_meter(progress_meter: AbstractProgressMeter | bool):
+    """Configure the default progress meter.
+
+    Args:
+        progress_meter: Default progress meter. Set to `True` for a [tqdm](https://github.com/tqdm/tqdm)
+            progress meter, and `False` for no output. See other options in
+            [dynamiqs/progress_meter.py](https://github.com/dynamiqs/dynamiqs/blob/main/dynamiqs/progress_meter.py).
+    """
+    global _DEFAULT_PROGRESS_METER  # noqa: PLW0603
+
+    if progress_meter is True:
+        progress_meter = TqdmProgressMeter()
+    elif progress_meter is False:
+        progress_meter = NoProgressMeter()
+
+    _DEFAULT_PROGRESS_METER = progress_meter
+
+
+def get_progress_meter(
+    progress_meter: AbstractProgressMeter | bool | None,
+) -> AbstractProgressMeter:
+    if progress_meter is None:
+        return _DEFAULT_PROGRESS_METER
+    elif progress_meter is True:
+        return TqdmProgressMeter()
+    elif progress_meter is False:
+        return NoProgressMeter()
+    return progress_meter

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -264,6 +264,7 @@ nav:
               - set_precision: python_api/utils/global_settings/set_precision.md
               - set_matmul_precision: python_api/utils/global_settings/set_matmul_precision.md
               - set_layout: python_api/utils/global_settings/set_layout.md
+              - set_progress_meter: python_api/utils/global_settings/set_progress_meter.md
           - Vectorization:
               - operator_to_vector: python_api/utils/vectorization/operator_to_vector.md
               - vector_to_operator: python_api/utils/vectorization/vector_to_operator.md


### PR DESCRIPTION
Very useful when running benchmarks. Note that this changes the current API: `None` is now the default, and no output is `False`. If you have a better idea than the `initialise()` workaround I'm down.