### PR TITLE
Replace discontinuity times `None` default value by empty array

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -41,10 +41,7 @@ def tree_str_inline(x: PyTree) -> str:
     return eqx.tree_pformat(x, indent=0).replace('\n', '').replace(',', ', ')
 
 
-def concatenate_sort(*args: Array | None) -> Array | None:
-    args = [x for x in args if x is not None]
-    if len(args) == 0:
-        return None
+def concatenate_sort(*args: Array) -> Array:
     return jnp.sort(jnp.concatenate(args))
 
 

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -56,13 +56,14 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
         if self.fixed_step:
             return dx.ConstantStepSize()
         else:
+            jump_ts = None if len(self.discontinuity_ts) == 0 else self.discontinuity_ts
             return dx.PIDController(
                 rtol=self.method.rtol,
                 atol=self.method.atol,
                 safety=self.method.safety_factor,
                 factormin=self.method.min_factor,
                 factormax=self.method.max_factor,
-                jump_ts=self.discontinuity_ts,
+                jump_ts=jump_ts,
             )
 
     @property

--- a/dynamiqs/integrators/core/expm_integrator.py
+++ b/dynamiqs/integrators/core/expm_integrator.py
@@ -61,8 +61,7 @@ class ExpmIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface):
         # find all times where the solution should be saved (self.ts) or at which the
         # generator changes (self.discontinuity_ts)
         disc_ts = self.discontinuity_ts
-        if disc_ts is not None:
-            disc_ts = disc_ts.clip(self.t0, self.t1)
+        disc_ts = disc_ts.clip(self.t0, self.t1)
         times = concatenate_sort(jnp.asarray([self.t0]), self.ts, disc_ts)  # (ntimes,)
 
         # === compute time differences (null for times outside [t0, t1])

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -68,7 +68,7 @@ class DiffusiveSolveIntegrator(
                 'Option `t0` is invalid for fixed step SSE or SME methods.'
             )
 
-        if self.discontinuity_ts is not None:
+        if len(self.discontinuity_ts) > 0:
             warnings.warns(
                 'The Hamiltonian or jump operators are time-dependent with '
                 'discontinuities, which will be ignored by the method.',

--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -19,7 +19,7 @@ class OptionsInterface(eqx.Module):
 class AbstractTimeInterface(eqx.Module):
     @property
     @abstractmethod
-    def discontinuity_ts(self) -> Array | None:
+    def discontinuity_ts(self) -> Array:
         pass
 
 
@@ -29,7 +29,7 @@ class SEInterface(AbstractTimeInterface):
     H: TimeQArray
 
     @property
-    def discontinuity_ts(self) -> Array | None:
+    def discontinuity_ts(self) -> Array:
         return self.H.discontinuity_ts
 
 
@@ -43,7 +43,7 @@ class MEInterface(AbstractTimeInterface):
         return [_L(t) for _L in self.Ls]  # (nLs, n, n)
 
     @property
-    def discontinuity_ts(self) -> Array | None:
+    def discontinuity_ts(self) -> Array:
         ts = [x.discontinuity_ts for x in [self.H, *self.Ls]]
         return concatenate_sort(*ts)
 
@@ -78,7 +78,7 @@ class DSMEInterface(AbstractTimeInterface):
         return [_L(t) for _L in self.Lms]  # (nLm, n, n)
 
     @property
-    def discontinuity_ts(self) -> Array | None:
+    def discontinuity_ts(self) -> Array:
         ts = [x.discontinuity_ts for x in [self.H, *self.Ls]]
         return concatenate_sort(*ts)
 


### PR DESCRIPTION
The typing makes more sense and it simplifies subsequent operations on this object. This follows up from work in #886, #933, #934.