### PR TITLE
Fix typo to emit warnings

### DIFF
--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -373,7 +373,7 @@ def _check_dsmesolve_args(
         check_shape(L, f'jump_ops[{i}]', '(n, n)')
 
     if len(Ls) == 0 and rho0.isket():
-        warnings.warns(
+        warnings.warn(
             'Argument `jump_ops` is an empty list and argument `rho0` is a ket,'
             ' consider using `dq.sesolve()` to solve the Schrödinger equation.',
             stacklevel=2,

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -69,10 +69,10 @@ class DiffusiveSolveIntegrator(
             )
 
         if self.discontinuity_ts is not None:
-            warnings.warns(
+            warnings.warn(
                 'The Hamiltonian or jump operators are time-dependent with '
                 'discontinuities, which will be ignored by the method.',
-                stack_level=1,
+                stacklevel=1,
             )
 
     class Infos(eqx.Module):


### PR DESCRIPTION
The function `warnings.warns` doesn't exist, nor the `stack_level` argument.