### PR TITLE
Support `jump_ops` batching in jump and diffusive SSE solvers

### DIFF
--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -93,8 +93,8 @@ def dssesolve(
 
     Args:
         H _(qarray-like or time-qarray of shape (...H, n, n))_: Hamiltonian.
-        jump_ops _(list of qarray-like or time-qarray, each of shape (n, n))_: List of
-            jump operators.
+        jump_ops _(list of qarray-like or time-qarray, each of shape (...Lk, n, n))_:
+            List of jump operators.
         psi0 _(qarray-like of shape (...psi0, n, 1))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
@@ -183,32 +183,35 @@ def dssesolve(
 
     ## Running multiple simulations concurrently
 
-    The Hamiltonian `H` and the initial state `psi0` can be batched to
-    solve multiple SSEs concurrently. All other arguments (including the PRNG key)
-    are common to every batch. The resulting states, measurements and expectation values
-    are batched according to the leading dimensions of `H` and `psi0`. The
-    behaviour depends on the value of the `cartesian_batching` option.
+    The Hamiltonian `H`, the jump operators `jump_ops` and the initial state `psi0` can
+    be batched to solve multiple SSEs concurrently. All other arguments (including the
+    PRNG key) are common to every batch. The resulting states, measurements and
+    expectation values are batched according to the leading dimensions of `H`,
+    `jump_ops` and `psi0`. The behaviour depends on the value of the
+    `cartesian_batching` option.
 
     === "If `cartesian_batching = True` (default value)"
         The results leading dimensions are
         ```
-        ... = ...H, ...psi0
+        ... = ...H, ...L0, ...L1, (...), ...psi0
         ```
         For example if:
 
         - `H` has shape _(2, 3, n, n)_,
-        - `psi0` has shape _(4, n, 1)_,
+        - `jump_ops = [L0, L1]` has shape _[(4, 5, n, n), (6, n, n)]_,
+        - `psi0` has shape _(7, n, 1)_,
 
-        then `result.states` has shape _(2, 3, 4, ntrajs, ntsave, n, 1)_.
+        then `result.states` has shape _(2, 3, 4, 5, 6, 7, ntrajs, ntsave, n, 1)_.
 
     === "If `cartesian_batching = False`"
         The results leading dimensions are
         ```
-        ... = ...H = ...psi0  # (once broadcasted)
+        ... = ...H = ...L0 = ...L1 = (...) = ...psi0  # (once broadcasted)
         ```
         For example if:
 
         - `H` has shape _(2, 3, n, n)_,
+        - `jump_ops = [L0, L1]` has shape _[(3, n, n), (2, 1, n, n)]_,
         - `psi0` has shape _(3, n, 1)_,
 
         then `result.states` has shape _(2, 3, ntrajs, ntsave, n, 1)_.
@@ -216,11 +219,6 @@ def dssesolve(
     See the
     [Batching simulations](../../documentation/basics/batching-simulations.md)
     tutorial for more details.
-
-    Warning:
-        Batching on `jump_ops` is not yet supported, if this is needed don't
-        hesitate to
-        [open an issue on GitHub](https://github.com/dynamiqs/dynamiqs/issues/new).
     """  # noqa: E501
     # === convert arguments
     H = astimeqarray(H)
@@ -271,18 +269,19 @@ def _vectorized_dssesolve(
     f = jax.vmap(f, in_axes, out_axes)
 
     # === vectorize function
-    # vectorize input over H and psi0
-    in_axes = (H.in_axes, None, 0, None, None, None, None, None, None)
+    # vectorize input over H, Ls and psi0
+    in_axes = (H.in_axes, [L.in_axes for L in Ls], 0, *(None,) * 6)
 
     if options.cartesian_batching:
-        nvmap = (H.ndim - 2, 0, psi0.ndim - 2, 0, 0, 0, 0, 0, 0)
+        nvmap = (H.ndim - 2, [L.ndim - 2 for L in Ls], psi0.ndim - 2, 0, 0, 0, 0, 0, 0)
         f = cartesian_vmap(f, in_axes, out_axes, nvmap)
     else:
-        n = H.shape[-1]
-        bshape = jnp.broadcast_shapes(H.shape[:-2], psi0.shape[:-2])
+        bshape = jnp.broadcast_shapes(*[x.shape[:-2] for x in [H, *Ls, psi0]])
         nvmap = len(bshape)
         # broadcast all vectorized input to same shape
+        n = H.shape[-1]
         H = H.broadcast_to(*bshape, n, n)
+        Ls = [L.broadcast_to(*bshape, n, n) for L in Ls]
         psi0 = psi0.broadcast_to(*bshape, n, 1)
         # vectorize the function
         f = multi_vmap(f, in_axes, out_axes, nvmap)
@@ -341,7 +340,7 @@ def _check_dssesolve_args(
 
     # === check Ls shape
     for i, L in enumerate(Ls):
-        check_shape(L, f'jump_ops[{i}]', '(n, n)')
+        check_shape(L, f'jump_ops[{i}]', '(..., n, n)', subs={'...': f'...L{i}'})
 
     if len(Ls) == 0:
         logging.warning(

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -86,8 +86,8 @@ def jssesolve(
 
     Args:
         H _(qarray-like or time-qarray of shape (...H, n, n))_: Hamiltonian.
-        jump_ops _(list of qarray-like or time-qarray, each of shape (n, n))_: List of
-            jump operators.
+        jump_ops _(list of qarray-like or time-qarray, each of shape (...Lk, n, n))_:
+            List of jump operators.
         psi0 _(qarray-like of shape (...psi0, n, 1))_: Initial state.
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
@@ -191,32 +191,35 @@ def jssesolve(
 
     ## Running multiple simulations concurrently
 
-    The Hamiltonian `H` and the initial state `psi0` can be batched to
-    solve multiple SSEs concurrently. All other arguments (including the PRNG key)
-    are common to every batch. The resulting states, click times and expectation values
-    are batched according to the leading dimensions of `H` and `psi0`. The
-    behaviour depends on the value of the `cartesian_batching` option.
+    The Hamiltonian `H`, the jump operators `jump_ops` and the initial state `psi0` can
+    be batched to solve multiple SSEs concurrently. All other arguments (including the
+    PRNG key) are common to every batch. The resulting states, measurements and
+    expectation values are batched according to the leading dimensions of `H`,
+    `jump_ops` and `psi0`. The behaviour depends on the value of the
+    `cartesian_batching` option.
 
     === "If `cartesian_batching = True` (default value)"
         The results leading dimensions are
         ```
-        ... = ...H, ...psi0
+        ... = ...H, ...L0, ...L1, (...), ...psi0
         ```
         For example if:
 
         - `H` has shape _(2, 3, n, n)_,
-        - `psi0` has shape _(4, n, 1)_,
+        - `jump_ops = [L0, L1]` has shape _[(4, 5, n, n), (6, n, n)]_,
+        - `psi0` has shape _(7, n, 1)_,
 
-        then `result.states` has shape _(2, 3, 4, ntrajs, ntsave, n, 1)_.
+        then `result.states` has shape _(2, 3, 4, 5, 6, 7, ntrajs, ntsave, n, 1)_.
 
     === "If `cartesian_batching = False`"
         The results leading dimensions are
         ```
-        ... = ...H = ...psi0  # (once broadcasted)
+        ... = ...H = ...L0 = ...L1 = (...) = ...psi0  # (once broadcasted)
         ```
         For example if:
 
         - `H` has shape _(2, 3, n, n)_,
+        - `jump_ops = [L0, L1]` has shape _[(3, n, n), (2, 1, n, n)]_,
         - `psi0` has shape _(3, n, 1)_,
 
         then `result.states` has shape _(2, 3, ntrajs, ntsave, n, 1)_.
@@ -224,11 +227,6 @@ def jssesolve(
     See the
     [Batching simulations](../../documentation/basics/batching-simulations.md)
     tutorial for more details.
-
-    Warning:
-        Batching on `jump_ops` is not yet supported, if this is needed don't
-        hesitate to
-        [open an issue on GitHub](https://github.com/dynamiqs/dynamiqs/issues/new).
     """  # noqa: E501
     # === convert arguments
     H = astimeqarray(H)
@@ -275,7 +273,7 @@ def _vectorized_jssesolve(
     f = jax.vmap(f, in_axes, out_axes)
 
     # === vectorize function
-    # vectorize input over H, Ls and psi0.
+    # vectorize input over H, Ls and psi0
     in_axes = (H.in_axes, [L.in_axes for L in Ls], 0, *(None,) * 6)
 
     if options.cartesian_batching:


### PR DESCRIPTION
- Support `jump_ops` batching in `dq.dssesolve()`.
- Fix corresponding doc in `dq.jssesolve()`.