### PR TITLE
Update diffrax dependency to account for jax compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "tqdm",
     "jax>=0.4.36", # >=0.4.36 for GPU eig support
     "jaxtyping",
-    "diffrax>=0.5.1",  # for complex support (0.5.0) and progress meter (0.5.1)
+    "diffrax>=0.6.1",  # for complex support (0.5.0), progress meter (0.5.1), compatibility with jax 0.4.36 (0.6.1)
     "equinox",
     "optimistix",  # for typing of root-finding in Event method
     "pillow",


### PR DESCRIPTION
Was causing install complications because `diffrax<0.6.1` versions are incompatible with `jax>=0.4.36` which we enforce.