### PR TITLE
Adds forward mode support from diffrax

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -74,6 +74,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         members:
         - Autograd
         - CheckpointAutograd
+        - ForwardAutograd
 
 ## Utilities
 

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -80,9 +80,11 @@ class ForwardAutograd(Gradient):
       or [`jax.jacfwd`](https://docs.jax.dev/en/latest/_autosummary/jax.jacfwd.html)).
 
     Note:
-        This is the most efficient when there are more outputs than inputs in the
-        function. For instance, it's the preferred method when computing the Jacobian
-        of the simulation of a Lindbladian parametrized with a few values.
+        This is the most efficient when the function has more outputs than inputs. For
+        instance, it's the preferred method when simulating a Lindbladian parameterized
+        with a few values and computing the Jacobian of a function returning the
+        expectation values of many observables (or the same observable at many different
+        times).
 
     Warning:
         This cannot be backward-mode autodifferentiated (e.g. using

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -4,7 +4,7 @@ import equinox as eqx
 
 from ._utils import tree_str_inline
 
-__all__ = ['Autograd', 'CheckpointAutograd']
+__all__ = ['Autograd', 'CheckpointAutograd', 'ForwardAutograd']
 
 
 class Gradient(eqx.Module):
@@ -71,3 +71,39 @@ class CheckpointAutograd(Gradient):
     # dummy init to have the signature in the documentation
     def __init__(self, ncheckpoints: int | None = None):
         self.ncheckpoints = ncheckpoints
+
+
+class ForwardAutograd(Gradient):
+    """Forward-mode automatic differentiation.
+
+    Enables support for forward-mode automatic differentiation
+    (like [`jax.jvp`](https://docs.jax.dev/en/latest/_autosummary/jax.jvp.html)
+      or [`jax.jacfwd`](https://docs.jax.dev/en/latest/_autosummary/jax.jacfwd.html)).
+
+    Note:
+        This is the most efficient when there are more outputs than inputs in the
+        function. For instance, it's the preferred method when computing the Jacobian
+        of the simulation of a Lindbladian parametrized with a few values.
+
+    Warning:
+        This cannot be backward-mode autodifferentiated (e.g. using
+        [`jax.jacrev`](https://docs.jax.dev/en/latest/_autosummary/jax.jacrev.html)).
+        Try using
+        [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd] if that
+        is something you need.
+
+    Warning:
+        By default
+         [`jax.grad`](https://jax.readthedocs.io/en/latest/_autosummary/jax.grad.html)
+        uses reverse mode. Use [`jax.jacfwd`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jacfwd.html)
+        to compute the gradient in forward mode.
+
+    Note:
+        For Diffrax-based methods, this falls back to the
+        [`diffrax.ForwardMode`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.ForwardMode)
+        option.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self):
+        pass

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -48,7 +48,6 @@ class CheckpointAutograd(Gradient):
         ). Try using [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] if that
         is something you need.
 
-
     Note:
         For Diffrax-based methods, this falls back to the
         [`diffrax.RecursiveCheckpointAdjoint`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.RecursiveCheckpointAdjoint)

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -10,7 +10,7 @@ from jax import Array
 from jaxtyping import PyTree, Scalar
 
 from ..._utils import obj_type_str
-from ...gradient import Autograd, CheckpointAutograd
+from ...gradient import Autograd, CheckpointAutograd, ForwardAutograd
 from ...result import Result
 from .abstract_integrator import BaseIntegrator
 from .interfaces import AbstractTimeInterface, MEInterface, SEInterface, SolveInterface
@@ -86,6 +86,8 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             return dx.RecursiveCheckpointAdjoint()
         elif isinstance(self.gradient, CheckpointAutograd):
             return dx.RecursiveCheckpointAdjoint(self.gradient.ncheckpoints)
+        elif isinstance(self.gradient, ForwardAutograd):
+            return dx.ForwardMode()
         elif isinstance(self.gradient, Autograd):
             return dx.DirectAdjoint()
         else:

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -6,7 +6,7 @@ import equinox as eqx
 from optimistix import AbstractRootFinder
 
 from ._utils import tree_str_inline
-from .gradient import Autograd, CheckpointAutograd, Gradient
+from .gradient import Autograd, CheckpointAutograd, ForwardAutograd, Gradient
 
 __all__ = [
     'Dopri5',
@@ -131,12 +131,17 @@ class Euler(_DEFixedStep):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
@@ -175,12 +180,17 @@ class Rouchon1(_DEFixedStep):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
     normalize: bool
 
     # dummy init to have the signature in the documentation
@@ -217,12 +227,17 @@ class Dopri5(_DEAdaptiveStep):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -253,12 +268,17 @@ class Dopri8(_DEAdaptiveStep):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -289,12 +309,17 @@ class Tsit5(_DEAdaptiveStep):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -336,12 +361,17 @@ class Kvaerno3(_DEAdaptiveStep):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -383,12 +413,17 @@ class Kvaerno5(_DEAdaptiveStep):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -434,16 +469,21 @@ class Event(_DEMethod):
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] and
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default).
+        (default)
+        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
     """
 
     noclick_method: Method = Tsit5()
     root_finder: AbstractRootFinder | None = None
     smart_sampling: bool = False
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd, CheckpointAutograd)
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Autograd,
+        CheckpointAutograd,
+        ForwardAutograd,
+    )
 
     # dummy init to have the signature in the documentation
     def __init__(

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -183,6 +183,7 @@ nav:
           - Gradients (dq.gradient):
               - Autograd: python_api/gradient/Autograd.md
               - CheckpointAutograd: python_api/gradient/CheckpointAutograd.md
+              - ForwardAutograd: python_api/gradient/ForwardAutograd.md
       - Utilities:
           - Operators:
               - eye: python_api/utils/operators/eye.md

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd, CheckpointAutograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd, ForwardAutograd
 from dynamiqs.method import Tsit5
 
 from ..integrator_tester import IntegratorTester
@@ -17,6 +17,8 @@ class TestMESolveAdaptive(IntegratorTester):
         self._test_correctness(system, Tsit5())
 
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
-    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    @pytest.mark.parametrize(
+        'gradient', [Autograd(), CheckpointAutograd(), ForwardAutograd()]
+    )
     def test_gradient(self, system, gradient):
         self._test_gradient(system, Tsit5(), gradient)

--- a/tests/mesolve/test_euler.py
+++ b/tests/mesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd, CheckpointAutograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd, ForwardAutograd
 from dynamiqs.method import Euler
 
 from ..integrator_tester import IntegratorTester
@@ -16,7 +16,9 @@ class TestMESolveEuler(IntegratorTester):
         self._test_correctness(system, method, esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
-    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    @pytest.mark.parametrize(
+        'gradient', [Autograd(), CheckpointAutograd(), ForwardAutograd()]
+    )
     def test_gradient(self, system, gradient):
         method = Euler(dt=1e-4)
         self._test_gradient(system, method, gradient, rtol=1e-2, atol=1e-2)

--- a/tests/mesolve/test_rouchon.py
+++ b/tests/mesolve/test_rouchon.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd, CheckpointAutograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd, ForwardAutograd
 from dynamiqs.method import Rouchon1
 
 from ..integrator_tester import IntegratorTester
@@ -18,7 +18,9 @@ class TestMESolveRouchon1(IntegratorTester):
 
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
     @pytest.mark.parametrize('normalize', [True, False])
-    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    @pytest.mark.parametrize(
+        'gradient', [Autograd(), CheckpointAutograd(), ForwardAutograd()]
+    )
     def test_gradient(self, system, normalize, gradient):
         method = Rouchon1(dt=1e-4, normalize=normalize)
         self._test_gradient(system, method, gradient, rtol=1e-3, atol=1e-3)

--- a/tests/sesolve/test_adaptive.py
+++ b/tests/sesolve/test_adaptive.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd, CheckpointAutograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd, ForwardAutograd
 from dynamiqs.method import Tsit5
 
 from ..integrator_tester import IntegratorTester
@@ -17,6 +17,8 @@ class TestSESolveAdaptive(IntegratorTester):
         self._test_correctness(system, Tsit5())
 
     @pytest.mark.parametrize('system', [dense_cavity, dia_cavity, tdqubit])
-    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    @pytest.mark.parametrize(
+        'gradient', [Autograd(), CheckpointAutograd(), ForwardAutograd()]
+    )
     def test_gradient(self, system, gradient):
         self._test_gradient(system, Tsit5(), gradient)

--- a/tests/sesolve/test_euler.py
+++ b/tests/sesolve/test_euler.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dynamiqs.gradient import Autograd, CheckpointAutograd
+from dynamiqs.gradient import Autograd, CheckpointAutograd, ForwardAutograd
 from dynamiqs.method import Euler
 
 from ..integrator_tester import IntegratorTester
@@ -16,7 +16,9 @@ class TestSESolveEuler(IntegratorTester):
         self._test_correctness(system, method, esave_atol=1e-3)
 
     @pytest.mark.parametrize('system', [dense_cavity, dia_cavity, tdqubit])
-    @pytest.mark.parametrize('gradient', [Autograd(), CheckpointAutograd()])
+    @pytest.mark.parametrize(
+        'gradient', [Autograd(), CheckpointAutograd(), ForwardAutograd()]
+    )
     def test_gradient(self, system, gradient):
         method = Euler(dt=1e-4)
         self._test_gradient(system, method, gradient, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
We needed forward mode differentiation for a project. This uses `diffrax.ForwardMode`. 

It could be mentioned in the documentation that it's probably the most efficient in most quantum simulation. Or made the default mode. We usually have a Lindbladian parametrized with a few values (<~100) and the output is higher dimensional (a density matrix of dim 100x100 or e.g. >~100 observables in time). 