### PR TITLE
Restrict JAX version to <0.5.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "tqdm",
-    "jax>=0.4.36", # >=0.4.36 for GPU eig support
+    "jax>=0.4.36,<0.5.3", # >=0.4.36 for GPU eig support
     "jaxtyping",
     "diffrax>=0.6.1",  # for complex support (0.5.0), progress meter (0.5.1), compatibility with jax 0.4.36 (0.6.1)
     "equinox",


### PR DESCRIPTION
To avoid infinite warnings in tests.

```
>>> pytest -n=auto tests
============================= test session starts ==============================
platform linux -- Python 3.10.16, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/runner/work/dynamiqs/dynamiqs
configfile: pytest.ini
plugins: sugar-1.0.0, jaxtyping-0.3.0, ordering-0.6, xdist-3.6.1
created: 2/2 workers
2 workers [342 items]
...................................s.................................... [ 21%]
...........s..........s........................s........................ [ 42%]
........................................................................ [ 63%]
........................................................................ [ 84%]
......................................................                   [100%]
=============================== warnings summary ===============================
.venv/lib/python3.10/site-packages/colorspacious/comparison.py:11
.venv/lib/python3.10/site-packages/colorspacious/comparison.py:11
  /home/runner/work/dynamiqs/dynamiqs/.venv/lib/python3.10/site-packages/colorspacious/comparison.py:11: DeprecationWarning: invalid escape sequence '\D'
    """Computes the :math:`\Delta E` distance between pairs of colors.
tests/qarrays/test_sparse_dia_qarray.py::TestSparseDIAQArray::test_scalaradd[batch]
tests/qarrays/test_sparse_dia_qarray.py::TestSparseDIAQArray::test_scalaradd[batch_broadcast]
tests/qarrays/test_sparse_dia_qarray.py::TestSparseDIAQArray::test_scalaradd[simple]
  /home/runner/work/dynamiqs/dynamiqs/.venv/lib/python3.10/site-packages/equinox/_module.py:1096: UserWarning: A sparse qarray has been converted to dense layout due to element-wise addition with a scalar.
    return self.__func__(self.__self__, *args, **kwargs)
tests/floquet/test_batching.py: 558 warnings
tests/floquet/test_adaptive.py: [14](https://github.com/dynamiqs/dynamiqs/actions/runs/14085553981/job/39451466409?pr=946#step:6:15)88 warnings
tests/jssesolve/test_batching.py: 4356 warnings
tests/mesolve/test_adaptive.py: 3064 warnings
tests/mesolve/test_batching.py: 2438 warnings
tests/mesolve/test_euler.py: 1771 warnings
tests/jssesolve/test_jssesolve.py: 374 warnings
tests/mesolve/test_rouchon.py: 3542 warnings
tests/sepropagator/test_sepropagator.py: 736 warnings
tests/sesolve/test_adaptive.py: 3064 warnings
tests/sesolve/test_batching.py: 1326 warnings
tests/sesolve/test_euler.py: [17](https://github.com/dynamiqs/dynamiqs/actions/runs/14085553981/job/39451466409?pr=946#step:6:18)71 warnings
  /home/runner/work/dynamiqs/dynamiqs/.venv/lib/python3.10/site-packages/equinox/_ad.py:634: DeprecationWarning: shape requires ndarray or scalar arguments, got <class 'jax._src.api.ShapeDtypeStruct'> at position 0. In a future JAX release this will be an error.
    assert jnp.shape(o1) == jnp.shape(o2)
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========== 338 passed, 4 skipped, 24493 warnings in 593.72s (0:09:53) ==========
```