### PR TITLE
Feature: quantum relative entropy

### DIFF
--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -1085,13 +1085,12 @@ def entropy_relative(rho: QArrayLike, sigma: QArrayLike) -> Array:
     nrvals = jnp.where(rvals < 0, 0, rvals)
     nsvals = jnp.where(svals < 0, 0, svals)
 
-    S = jnp.nan_to_num(
+    return jnp.nan_to_num(
         nrvals
         * (jnp.log(nrvals) - (P * jnp.expand_dims(jnp.log(nsvals), (-2))).sum(-1)),
         posinf=jnp.inf,
         neginf=-jnp.inf,
     ).sum(-1)
-    return S
 
 
 def bloch_coordinates(x: QArrayLike) -> Array:

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -1064,7 +1064,7 @@ def entropy_relative(rho: QArrayLike, sigma: QArrayLike) -> Array:
         >>> Array(inf, dtype=float64)
         >>> dq.entropy_relative(sigma, rho)
         >>> Array(0.69314718, dtype=float64)
-    """
+    """  # noqa: E501
     rho = asqarray(rho)
     sigma = asqarray(sigma)
     check_shape(rho, 'x', '(..., n, 1)', '(..., n, n)')

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -105,9 +105,6 @@ def test_ket_dm_fidelity_batching():
     assert dq.fidelity(psi, rho).shape == (b1, b2)
 
 
-"""Begin"""
-
-
 @pytest.mark.run(order=TEST_INSTANT)
 def test_ket_entropy_relative_correctness():
     n = 8
@@ -194,9 +191,6 @@ def test_ket_dm_entropy_relative_batching():
     rho = qobj_to_array(rho)
     assert dq.entropy_relative(rho, psi).shape == (b1, b2)
     assert dq.entropy_relative(psi, rho).shape == (b1, b2)
-
-
-"""End"""
 
 
 @pytest.mark.run(order=TEST_INSTANT)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -105,6 +105,100 @@ def test_ket_dm_fidelity_batching():
     assert dq.fidelity(psi, rho).shape == (b1, b2)
 
 
+"""Begin"""
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_ket_entropy_relative_correctness():
+    n = 8
+
+    # qutip
+    psi = qt.rand_ket(n, seed=42)
+    phi = qt.rand_ket(n, seed=43)
+    qt_fid = qt.entropy_relative(psi, phi)
+
+    # Dynamiqs
+    psi = qobj_to_array(psi)
+    phi = qobj_to_array(phi)
+    dq_fid = dq.entropy_relative(psi, phi).item()
+
+    # compare
+    assert qt_fid == pytest.approx(dq_fid)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_ket_entropy_relative_batching():
+    b1, b2, n = 3, 5, 8
+    psi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
+    phi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, 1)
+    psi = qobj_to_array(psi)
+    phi = qobj_to_array(phi)
+    assert dq.entropy_relative(psi, phi).shape == (b1, b2)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_dm_entropy_relative_correctness():
+    n = 8
+
+    # qutip
+    rho = qt.rand_dm(n, n, seed=42)
+    sigma = qt.rand_dm(n, n, seed=43)
+    qt_fid = qt.entropy_relative(rho, sigma)
+
+    # Dynamiqs
+    rho = qobj_to_array(rho)
+    sigma = qobj_to_array(sigma)
+    dq_fid = dq.entropy_relative(rho, sigma).item()
+
+    # compare
+    assert qt_fid == pytest.approx(dq_fid, abs=1e-5)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_dm_entropy_relative_batching():
+    b1, b2, n = 3, 5, 8
+    rho = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
+    sigma = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
+    rho = qobj_to_array(rho)
+    sigma = qobj_to_array(sigma)
+    assert dq.entropy_relative(rho, sigma).shape == (b1, b2)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_ket_dm_entropy_relative_correctness():
+    n = 8
+
+    # qutip
+    psi = qt.rand_ket(n, seed=42)
+    rho = qt.rand_dm(n, n, seed=43)
+    qt_fid_ket_dm = qt.entropy_relative(psi, rho)
+    qt_fid_dm_ket = qt.entropy_relative(rho, psi)
+
+    # Dynamiqs
+    psi = qobj_to_array(psi)
+    rho = qobj_to_array(rho)
+    dq_fid_ket_dm = dq.entropy_relative(psi, rho).item()
+    dq_fid_dm_ket = dq.entropy_relative(rho, psi).item()
+
+    # compare
+    assert qt_fid_ket_dm == pytest.approx(dq_fid_ket_dm, abs=1e-6)
+    assert qt_fid_dm_ket == pytest.approx(dq_fid_dm_ket, abs=1e-6)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_ket_dm_entropy_relative_batching():
+    b1, b2, n = 3, 5, 8
+    psi = [[qt.rand_ket(n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n)
+    rho = [[qt.rand_dm(n, n) for _ in range(b2)] for _ in range(b1)]  # (b1, b2, n, n)
+    psi = qobj_to_array(psi)
+    rho = qobj_to_array(rho)
+    assert dq.entropy_relative(rho, psi).shape == (b1, b2)
+    assert dq.entropy_relative(psi, rho).shape == (b1, b2)
+
+
+"""End"""
+
+
 @pytest.mark.run(order=TEST_INSTANT)
 def test_hadamard():
     # one qubit


### PR DESCRIPTION
A new function `entropy_relative` is introduced that computes the relative entropy between two states.

It is computed as
$$S(\rho \| \sigma) = \mathrm{Tr}\rho (\log \rho - \log \sigma)$$
Note that $S(\rho \| \sigma)$ is not symmetric.

If two states are classically related, (i.e. $\rho$ and $\sigma$ commute), the quantum relative entropy reduces to the classical Kulback-Leibler divergence.

Example: 
```python
>>> rho = (dq.fock_dm(2, 0) + dq.fock_dm(2, 1)).unit()
>>> sigma = dq.fock_dm(2, 0)
>>> dq.entropy_relative(rho, sigma)
>>> Array(inf, dtype=float64)
>>> dq.entropy_relative(sigma, rho)
>>> Array(0.69314718, dtype=float64)
```

The function should be fully batchable.

Computations for kets are non-ideal as they are converted to density matrices.