### PR TITLE
Make `method` a non-static argument for all solvers

### DIFF
--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -266,7 +266,7 @@ def dsmesolve(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('tsave', 'method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('tsave', 'gradient', 'options'))
 def _vectorized_dsmesolve(
     H: TimeQArray,
     Lcs: list[TimeQArray],

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -246,7 +246,7 @@ def dssesolve(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('tsave', 'method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('tsave', 'gradient', 'options'))
 def _vectorized_dssesolve(
     H: TimeQArray,
     Ls: list[TimeQArray],

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -170,7 +170,7 @@ def floquet(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('gradient', 'options'))
 def _vectorized_floquet(
     H: TimeQArray,
     T: float,

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -316,7 +316,7 @@ def _vectorized_clicks_jssesolve(
     core_args = (H, Ls, psi0, tsave)
     other_args = (exp_ops, method, gradient, options)
 
-    def true_fn() -> JSSESolveResult:
+    if method.smart_sampling:
         # consume the first key for the no-click trajectory
         noclick_args = (keys[0], True, 0.0)
         noclick_result = _jssesolve_single_trajectory(
@@ -338,12 +338,9 @@ def _vectorized_clicks_jssesolve(
         return jax.tree.map_with_path(
             _concatenate_results, noclick_result, click_result
         )
-
-    def false_fn() -> JSSESolveResult:
+    else:
         click_args = (keys, False, 0.0)
         return f(*core_args, *click_args, *other_args)
-
-    return jax.lax.cond(method.smart_sampling, true_fn, false_fn)
 
 
 def _jssesolve_single_trajectory(

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -316,7 +316,7 @@ def _vectorized_clicks_jssesolve(
     core_args = (H, Ls, psi0, tsave)
     other_args = (exp_ops, method, gradient, options)
 
-    if method.smart_sampling:
+    def true_fn() -> JSSESolveResult:
         # consume the first key for the no-click trajectory
         noclick_args = (keys[0], True, 0.0)
         noclick_result = _jssesolve_single_trajectory(
@@ -338,9 +338,12 @@ def _vectorized_clicks_jssesolve(
         return jax.tree.map_with_path(
             _concatenate_results, noclick_result, click_result
         )
-    else:
+
+    def false_fn() -> JSSESolveResult:
         click_args = (keys, False, 0.0)
         return f(*core_args, *click_args, *other_args)
+
+    return jax.lax.cond(method.smart_sampling, true_fn, false_fn)
 
 
 def _jssesolve_single_trajectory(

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -256,7 +256,7 @@ def jssesolve(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('gradient', 'options'))
 def _vectorized_jssesolve(
     H: TimeQArray,
     Ls: list[TimeQArray],

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -205,7 +205,7 @@ def mepropagator(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('gradient', 'options'))
 def _vectorized_mepropagator(
     H: TimeQArray,
     Ls: list[TimeQArray],

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -238,7 +238,7 @@ def mesolve(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('gradient', 'options'))
 def _vectorized_mesolve(
     H: TimeQArray,
     Ls: list[TimeQArray],

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -172,7 +172,7 @@ def sepropagator(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('gradient', 'options'))
 def _vectorized_sepropagator(
     H: TimeQArray,
     tsave: Array,

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -205,7 +205,7 @@ def sesolve(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('gradient', 'options'))
 def _vectorized_sesolve(
     H: TimeQArray,
     psi0: QArray,

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -477,7 +477,7 @@ class Event(_DEMethod):
 
     noclick_method: Method = Tsit5()
     root_finder: AbstractRootFinder | None = eqx.field(static=True, default=None)
-    smart_sampling: bool = False
+    smart_sampling: bool = eqx.field(static=True, default=False)
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
         Autograd,

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -194,6 +194,9 @@ class Rouchon1(_DEFixedStep):
         CheckpointAutograd,
         ForwardAutograd,
     )
+
+    # todo: fix static dt (similar issue as static tsave in dssesolve)
+    dt: float = eqx.field(static=True)
     normalize: bool = eqx.field(static=True, default=True)
 
     # dummy init to have the signature in the documentation

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -191,7 +191,7 @@ class Rouchon1(_DEFixedStep):
         CheckpointAutograd,
         ForwardAutograd,
     )
-    normalize: bool
+    normalize: bool = eqx.field(static=True, default=True)
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float, normalize: bool = True):
@@ -476,7 +476,7 @@ class Event(_DEMethod):
     """
 
     noclick_method: Method = Tsit5()
-    root_finder: AbstractRootFinder | None = None
+    root_finder: AbstractRootFinder | None = eqx.field(static=True, default=None)
     smart_sampling: bool = False
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -162,6 +162,9 @@ class EulerMaruyama(_DEFixedStep):
         [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] (default).
     """
 
+    # todo: fix static dt (similar issue as static tsave in dssesolve)
+    dt: float = eqx.field(static=True)
+
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd,)
 
     # dummy init to have the signature in the documentation

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -162,10 +162,10 @@ class EulerMaruyama(_DEFixedStep):
         [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] (default).
     """
 
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd,)
+
     # todo: fix static dt (similar issue as static tsave in dssesolve)
     dt: float = eqx.field(static=True)
-
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd,)
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -113,7 +113,7 @@ class _DEAdaptiveStep(_DEMethod):
     safety_factor: float = 0.9
     min_factor: float = 0.2
     max_factor: float = 5.0
-    max_steps: int = 100_000
+    max_steps: int = eqx.field(static=True, default=100_000)
 
 
 # === public methods options

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import equinox as eqx
-import jax
 import jax.numpy as jnp
 from jax import Array
 from jaxtyping import PRNGKeyArray, PyTree
@@ -235,34 +234,28 @@ class JSSESolveResult(SolveResult):
 
     @property
     def mean_states(self) -> QArray:
-        def true_fn() -> QArray:
+        if self.method.smart_sampling:
             noclick_prob = self.final_state_norm[..., 0, None, None, None] ** 2
             states_noclick = self.states[..., 0, :, :, :].todm()
             states_click = self.states[..., 1:, :, :, :].todm().mean(axis=-4)
             return unit(
                 noclick_prob * states_noclick + (1 - noclick_prob) * states_click
             )
-
-        def false_fn() -> QArray:
+        else:
             return self.states.todm().mean(axis=-4)
-
-        return jax.lax.cond(self.method.smart_sampling, true_fn, false_fn)
 
     @property
     def mean_expects(self) -> Array:
         if self.expects is None:
             return None
 
-        def true_fn() -> Array:
+        if self.method.smart_sampling:
             noclick_prob = self.final_state_norm[..., 0, None, None] ** 2
             expects_noclick = self.expects[..., 0, :, :]
             expects_click = self.expects[..., 1:, :, :].mean(axis=-3)
             return noclick_prob * expects_noclick + (1 - noclick_prob) * expects_click
-
-        def false_fn() -> Array:
+        else:
             return self.expects.mean(axis=-3)
-
-        return jax.lax.cond(self.method.smart_sampling, true_fn, false_fn)
 
 
 class JSMESolveResult(SolveResult):


### PR DESCRIPTION
This is a small but important PR, allowing the `method` input not to be static anymore. This is required for the implementation of the `JumpMonteCarlo` method since its argument `keys` is non-hashable (PRNGKeyArray) but stored inside `method`.

Note that it also fixes the "bug" where solvers are jitted again when changing the arguments inside `method`, e.g. when changing from `method=dq.method.Tsit5(atol=1e-6)` to `method=dq.method.Tsit5(atol=1e-5)`.