### PR TITLE
Adds diffrax integration method to mepropagator.

### DIFF
--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -9,7 +9,7 @@ from jaxtyping import Array, ArrayLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
-from ...method import Expm, Method
+from ...method import Dopri5, Dopri8, Euler, Expm, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options, check_options
 from ...qarrays.dense_qarray import DenseQArray
 from ...qarrays.qarray import QArrayLike
@@ -21,6 +21,14 @@ from .._utils import (
     cartesian_vmap,
     catch_xla_runtime_error,
     multi_vmap,
+)
+from ..core.diffrax_integrator import (
+    mepropagator_dopri5_integrator_constructor,
+    mepropagator_dopri8_integrator_constructor,
+    mepropagator_euler_integrator_constructor,
+    mepropagator_kvaerno3_integrator_constructor,
+    mepropagator_kvaerno5_integrator_constructor,
+    mepropagator_tsit5_integrator_constructor,
 )
 from ..core.expm_integrator import mepropagator_expm_integrator_constructor
 
@@ -215,7 +223,15 @@ def _mepropagator(
     options: Options,
 ) -> MEPropagatorResult:
     # === select integrator constructor
-    integrator_constructors = {Expm: mepropagator_expm_integrator_constructor}
+    integrator_constructors = {
+        Expm: mepropagator_expm_integrator_constructor,
+        Euler: mepropagator_euler_integrator_constructor,
+        Dopri5: mepropagator_dopri5_integrator_constructor,
+        Dopri8: mepropagator_dopri8_integrator_constructor,
+        Tsit5: mepropagator_tsit5_integrator_constructor,
+        Kvaerno3: mepropagator_kvaerno3_integrator_constructor,
+        Kvaerno5: mepropagator_kvaerno5_integrator_constructor,
+    }
     assert_method_supported(method, integrator_constructors.keys())
     integrator_constructor = integrator_constructors[type(method)]
 

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -12,6 +12,7 @@ from jaxtyping import PyTree, Scalar
 from ..._utils import obj_type_str
 from ...gradient import Autograd, CheckpointAutograd, ForwardAutograd
 from ...result import Result
+from ...utils.vectorization import slindbladian
 from .abstract_integrator import BaseIntegrator
 from .interfaces import AbstractTimeInterface, MEInterface, SEInterface, SolveInterface
 from .save_mixin import AbstractSaveMixin, PropagatorSaveMixin, SolveSaveMixin
@@ -264,4 +265,47 @@ mesolve_kvaerno3_integrator_constructor = partial(
 )
 mesolve_kvaerno5_integrator_constructor = partial(
     MESolveDiffraxIntegrator, diffrax_solver=dx.Kvaerno5(), fixed_step=False
+)
+
+
+class MELindbladianDiffraxIntegrator(DiffraxIntegrator, MEInterface):
+    """Integrator computing the propagator the Lindblad master equation with Diffrax."""
+
+    @property
+    def terms(self) -> dx.AbstractTerm:
+        # define vector field for Lindblad eqn in Liousville super-operator form
+        # d/dt rho(t) = \mathcal{L}(\rho(t))
+
+        def vector_field(t, y, _):  # noqa: ANN001, ANN202
+            L, H = self.L(t), self.H(t)
+            return slindbladian(H, L) @ y
+
+        return dx.ODETerm(vector_field)
+
+
+class MEPropagatorDiffraxIntegrator(
+    MELindbladianDiffraxIntegrator, PropagatorSaveMixin
+):
+    """Integrator computing the propagator of the Lindblad master equation
+    using the Diffrax library.
+    """
+
+
+mepropagator_euler_integrator_constructor = partial(
+    MEPropagatorDiffraxIntegrator, diffrax_solver=dx.Euler(), fixed_step=True
+)
+mepropagator_dopri5_integrator_constructor = partial(
+    MEPropagatorDiffraxIntegrator, diffrax_solver=dx.Dopri5(), fixed_step=False
+)
+mepropagator_dopri8_integrator_constructor = partial(
+    MEPropagatorDiffraxIntegrator, diffrax_solver=dx.Dopri8(), fixed_step=False
+)
+mepropagator_tsit5_integrator_constructor = partial(
+    MEPropagatorDiffraxIntegrator, diffrax_solver=dx.Tsit5(), fixed_step=False
+)
+mepropagator_kvaerno3_integrator_constructor = partial(
+    MEPropagatorDiffraxIntegrator, diffrax_solver=dx.Kvaerno3(), fixed_step=False
+)
+mepropagator_kvaerno5_integrator_constructor = partial(
+    MEPropagatorDiffraxIntegrator, diffrax_solver=dx.Kvaerno5(), fixed_step=False
 )

--- a/tests/mepropagator/test_mepropagator.py
+++ b/tests/mepropagator/test_mepropagator.py
@@ -1,0 +1,26 @@
+import jax.numpy as jnp
+import pytest
+
+from dynamiqs import dag, mepropagator, operator_to_vector, vector_to_operator
+from dynamiqs.method import Tsit5
+
+from ..integrator_tester import IntegratorTester
+from ..mesolve.open_system import dense_ocavity, otdqubit
+from ..order import TEST_LONG
+
+
+@pytest.mark.run(order=TEST_LONG)
+class TestMEPropagator(IntegratorTester):
+    @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
+    def test_correctness(self, system, ysave_atol: float = 1e-4):
+        params = system.params_default
+        H = system.H(params)
+        Ls = system.Ls(params)
+        y0 = system.y0(params)
+        rho0 = y0 @ dag(y0)
+        propresult = mepropagator(H, Ls, system.tsave, method=Tsit5())
+        true_ysave = system.states(system.tsave).to_jax()
+        prop_ysave = (
+            vector_to_operator(propresult.propagators @ operator_to_vector(rho0))
+        ).to_jax()
+        assert jnp.allclose(true_ysave, prop_ysave, atol=ysave_atol)


### PR DESCRIPTION
* Adds additional integrator constructors to _mepropagator() for diffrax methods
* Adds classes MELindbladianDiffraxIntegrator and MEPropagatorDiffraxIntegrator for handling callable time-dependent operators when solving the propagator of master equation in vectorized form
* Adds a unit test of the new methods