### PR TITLE
Add an optional offset argument to dq.asqarray to make it jit-compatible

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -136,10 +136,10 @@ class DenseQArray(QArray):
     def asdense(self) -> DenseQArray:
         return self
 
-    def assparsedia(self) -> SparseDIAQArray:
+    def assparsedia(self, offsets: tuple[int, ...] | None = None) -> SparseDIAQArray:
         from .sparsedia_qarray import SparseDIAQArray
 
-        offsets, diags = array_to_sparsedia(self.data)
+        offsets, diags = array_to_sparsedia(self.data, offsets)
         return SparseDIAQArray(self.dims, self.vectorized, offsets, diags)
 
     def block_until_ready(self) -> QArray:

--- a/dynamiqs/qarrays/sparsedia_primitives.py
+++ b/dynamiqs/qarrays/sparsedia_primitives.py
@@ -137,9 +137,18 @@ def _vectorized_diag(diag: Array, offset: int) -> Array:
     return jnp.diag(diag[_sparsedia_slice(offset)], k=offset)
 
 
-def array_to_sparsedia(x: Array) -> tuple[tuple[int, ...], Array]:
-    concrete_or_error(None, x, '`array_to_sparsedia` does not support tracing.')
-    offsets = _find_offsets(x)
+def array_to_sparsedia(
+    x: Array, offsets: tuple[int, ...] | None
+) -> tuple[tuple[int, ...], Array]:
+    if offsets is None:
+        concrete_or_error(
+            None,
+            x,
+            'The `offsets` argument of `array_to_sparsedia` must be statically '
+            'specified to use `array_to_sparsedia` within JAX transformations.',
+        )
+        offsets = _find_offsets(x)
+
     diags = _construct_diags(offsets, x)
     return offsets, diags
 

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -32,9 +32,18 @@ __all__ = [
 
 
 def asqarray(
-    x: QArrayLike, dims: tuple[int, ...] | None = None, layout: Layout | None = None
+    x: QArrayLike,
+    dims: tuple[int, ...] | None = None,
+    layout: Layout | None = None,
+    *,
+    offsets: tuple[int, ...] | None = None,
 ) -> QArray:
     """Converts a qarray-like into a qarray.
+
+    Because the sparse DIA layout is data-dependent, the function is not compatible with
+    JIT and other JAX transformations when `layout==dq.dia`. The optional `offsets`
+    argument can be passed statically to retrieve compatibility with JAX
+    transformations.
 
     Args:
         x: Object to convert.
@@ -43,6 +52,9 @@ def asqarray(
             available, single Hilbert space `dims=(n,)` otherwise).
         layout _(dq.dense, dq.dia or None)_: Matrix layout. If `None`, the default
             layout is `dq.dense`, except for qarrays that are directly returned.
+        offsets _(tuple of ints or None)_: If specified, the diagonal offsets in the
+            input `x` object. This argument is used to make the function compatible with
+            JAX transformations.
 
     Returns:
         Qarray representation of the input.
@@ -78,7 +90,7 @@ def asqarray(
     if layout is dense:
         return _asdense(x, dims)
     else:
-        return _assparsedia(x, dims)
+        return _assparsedia(x, dims, offsets)
 
 
 def _asdense(x: QArrayLike, dims: tuple[int, ...] | None) -> DenseQArray:
@@ -94,7 +106,9 @@ def _asdense(x: QArrayLike, dims: tuple[int, ...] | None) -> DenseQArray:
     return DenseQArray(dims, False, x)
 
 
-def _assparsedia(x: QArrayLike, dims: tuple[int, ...] | None) -> SparseDIAQArray:
+def _assparsedia(
+    x: QArrayLike, dims: tuple[int, ...] | None, offsets: tuple[int, ...] | None
+) -> SparseDIAQArray:
     # TODO: improve this by directly extracting the diags and offsets in case
     # the Qobj is already in sparse DIA format (only for QuTiP 5)
     if isinstance(x, SparseDIAQArray):
@@ -103,7 +117,7 @@ def _assparsedia(x: QArrayLike, dims: tuple[int, ...] | None) -> SparseDIAQArray
     xdims = get_dims(x)
     x = to_jax(x)
     dims = init_dims(xdims, dims, x.shape)
-    offsets, diags = array_to_sparsedia(x)
+    offsets, diags = array_to_sparsedia(x, offsets)
     return SparseDIAQArray(dims, False, offsets, diags)
 
 


### PR DESCRIPTION
Similar to e.g. [`jnp.nonzero`](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.nonzero.html). 