### PR TITLE
Fix bug that didn't allow for scalar outputs of modulated functions

### DIFF
--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -173,10 +173,10 @@ def modulated(
         else jnp.sort(jnp.asarray(discontinuity_ts))
     )
 
-    # make f a valid PyTree that is vmap-compatible
-    f = BatchedCallable(f)
+    # make f a valid PyTree that is vmap-compatible and convert its output to an array
+    pytree_f = BatchedCallable(lambda t: jnp.asarray(f(t)))
 
-    return ModulatedTimeQArray(f, qarray, discontinuity_ts)
+    return ModulatedTimeQArray(pytree_f, qarray, discontinuity_ts)
 
 
 def timecallable(


### PR DESCRIPTION
Old PR "Add support for scalar in ModulatedTimeArray" (https://github.com/dynamiqs/dynamiqs/pull/602) was reverted by "Convert TimeArray to QArrays" (https://github.com/dynamiqs/dynamiqs/pull/631)