### PR TITLE
Add Euler-Jump solver to jump SSE and SME and fix some issues with Event solver

### DIFF
--- a/docs/documentation/advanced_examples/continuous-diffusive-measurement.md
+++ b/docs/documentation/advanced_examples/continuous-diffusive-measurement.md
@@ -3,7 +3,7 @@
 !!! Warning "Work in progress."
     This tutorial is under construction, this is a draft version.
 
-In this example, we simulate stochastic trajectories of quantum systems that are continuously measured by a diffusive detector. We explain how to use [`dq.dssesolve()`][dynamiqs.dssesolve] to simulate trajectories modelled by the diffusive SSE, and [`dq.dsmesolve()`][dynamiqs.dsmesolve] solvers to simulate trajectories modelled by the diffusive SME.
+In this example, we simulate stochastic trajectories of quantum systems that are continuously measured by a diffusive detector. We explain how to use [`dq.dssesolve()`][dynamiqs.dssesolve] to simulate trajectories modelled by the diffusive SSE, and [`dq.dsmesolve()`][dynamiqs.dsmesolve] to simulate trajectories modelled by the diffusive SME.
 
 ```python
 import jax
@@ -68,16 +68,17 @@ Iks = result.measurements[:, 0]
 ```python
 for Ik in Iks:
     plt.plot(tsave[:-1], Ik, lw=1.5)
-    plt.gca().set(
-        title=rf'Simulated measurements for 5 trajectories',
-        xlabel=r'$t$',
-        ylabel=r'$I^{[t,t+\Delta t)}$',
-    )
 
-renderfig('monitored-qubit-trajs')
+plt.gca().set(
+    title=rf'Simulated measurements for 5 trajectories',
+    xlabel=r'$t$',
+    ylabel=r'$I^{[t,t+\Delta t)}$',
+)
+
+renderfig('diffusive-monitored-qubit-trajs')
 ```
 
-![plot_monitored_qubit_trajs](../../figs_docs/monitored-qubit-trajs.png){.fig}
+![plot_diffusive_monitored_qubit_trajs](../../figs_docs/diffusive-monitored-qubit-trajs.png){.fig}
 
 ### Cumulative measurements
 
@@ -85,12 +86,13 @@ renderfig('monitored-qubit-trajs')
 for Ik in Iks:
     cumsum_Ik = jnp.cumsum(Ik)
     plt.plot(tsave[1:], cumsum_Ik, lw=1.5)
-    plt.axhline(0, ls='--', lw=1.0, color='gray')
-    plt.gca().set(
-        title=r'Integral of the measurement record',
-        xlabel=r'$t$',
-        ylabel=r'$Y_t=\int_0^t \mathrm{d}Y_s$',
-    )
+
+plt.axhline(0, ls='--', lw=1.0, color='gray')
+plt.gca().set(
+    title=r'Integral of the measurement record',
+    xlabel=r'$t$',
+    ylabel=r'$Y_t=\int_0^t \mathrm{d}Y_s$',
+)
 
 renderfig('monitored-qubit-cumsum-trajs')
 ```
@@ -104,14 +106,15 @@ expects_all = dq.expect(dq.sigmaz(), result.states).real
 
 for expects in expects_all:
     plt.plot(tsave, expects, lw=1.5)
-    plt.axhline(-1, ls='--', lw=1.0, color='gray')
-    plt.axhline(1, ls='--', lw=1.0, color='gray')
-    plt.gca().set(
-        title=r'Time evolution of $\sigma_z$ expectation value',
-        xlabel=r'$t$',
-        ylabel=r'$\langle \sigma_z \rangle_t=\langle \psi_t | \sigma_z | \psi_t \rangle$',
-        ylim=(-1.1, 1.1),
-    )
+
+plt.axhline(-1, ls='--', lw=1.0, color='gray')
+plt.axhline(1, ls='--', lw=1.0, color='gray')
+plt.gca().set(
+    title=r'Time evolution of $\sigma_z$ expectation value',
+    xlabel=r'$t$',
+    ylabel=r'$\langle \sigma_z \rangle_t=\langle \psi_t | \sigma_z | \psi_t \rangle$',
+    ylim=(-1.1, 1.1),
+)
 
 renderfig('monitored-qubit-sigmaz')
 ```
@@ -151,14 +154,15 @@ expects_all = dq.expect(dq.sigmaz(), result.states).real
 
 for expects in expects_all:
     plt.plot(tsave, expects, lw=1.5)
-    plt.axhline(-1, ls='--', lw=1.0, color='gray')
-    plt.axhline(1, ls='--', lw=1.0, color='gray')
-    plt.gca().set(
-        title=r'Time evolution of $\sigma_z$ expectation value',
-        xlabel=r'$t$',
-        ylabel=r'$\langle \sigma_z \rangle_t = \mathrm{Tr}[\sigma_z\rho_t]$',
-        ylim=(-1.1, 1.1),
-    )
+
+plt.axhline(-1, ls='--', lw=1.0, color='gray')
+plt.axhline(1, ls='--', lw=1.0, color='gray')
+plt.gca().set(
+    title=r'Time evolution of $\sigma_z$ expectation value',
+    xlabel=r'$t$',
+    ylabel=r'$\langle \sigma_z \rangle_t = \mathrm{Tr}[\sigma_z\rho_t]$',
+    ylim=(-1.1, 1.1),
+)
 
 renderfig('monitored-qubit-sigmaz-eta')
 ```
@@ -167,7 +171,7 @@ renderfig('monitored-qubit-sigmaz-eta')
 
 ## Quantum harmonic oscillator
 
-We consider a quantum harmonic oscillator starting from $\ket\alpha$, with Hamiltonian $H=\omega a^\dagger a$ and a single loss operator $L=\sqrt\kappa a$ which is continuously measured by heterodyne detection along the $X$ and $P$ quadratures with efficiency $\eta$, resulting in two a diffusive measurement records $I_X$ and $I_P$. For this example the measurement backaction is null.
+We consider a quantum harmonic oscillator starting from the coherent state $\ket\alpha$, with Hamiltonian $H=\omega a^\dagger a$ and a single loss operator $L=\sqrt\kappa a$ which is continuously measured by heterodyne detection along the $X$ and $P$ quadratures with efficiency $\eta$, resulting in two a diffusive measurement records $I_X$ and $I_P$. For this example the measurement backaction is null.
 
 ### Simulation
 
@@ -225,17 +229,19 @@ ax0, ax1 = list(axs)
 
 for Ik_x in Iks_x[:3]:
     ax0.plot(tsave[:-1], Ik_x / np.sqrt(2), lw=1.5)
-    ax0.set(
-        title=rf'Simulated measurements for 3 trajectories',
-        ylabel=r'$I_X^{[t,t+\Delta t)}/\sqrt{2}$',
-    )
+
+ax0.set(
+    title=rf'Simulated measurements for 3 trajectories',
+    ylabel=r'$I_X^{[t,t+\Delta t)}/\sqrt{2}$',
+)
 
 for Ik_p in Iks_p[:3]:
     ax1.plot(tsave[:-1], Ik_p / np.sqrt(2), lw=1.5)
-    ax1.set(
-        xlabel=r'$t$',
-        ylabel=r'$I_P^{[t,t+\Delta t)}/\sqrt{2}$',
-    )
+
+ax1.set(
+    xlabel=r'$t$',
+    ylabel=r'$I_P^{[t,t+\Delta t)}/\sqrt{2}$',
+)
 
 renderfig('monitored-oscillator-IxIp')
 ```

--- a/docs/documentation/advanced_examples/continuous-jump-measurement.md
+++ b/docs/documentation/advanced_examples/continuous-jump-measurement.md
@@ -1,0 +1,198 @@
+# Continuous jump measurement
+
+!!! Warning "Work in progress."
+    This tutorial is under construction, this is a draft version.
+
+In this example, we simulate stochastic trajectories of quantum systems that are continuously measured by a jump detector. We explain how to use [`dq.jssesolve()`][dynamiqs.jssesolve] to simulate trajectories modelled by the jump SSE, and [`dq.jsmesolve()`][dynamiqs.jsmesolve] to simulate trajectories modelled by the jump SME.
+
+```python
+import jax
+import jax.numpy as jnp
+import numpy as np
+from matplotlib import pyplot as plt
+import dynamiqs as dq
+
+dq.plot.mplstyle(dpi=150)  # set custom matplotlib style
+```
+
+## Qubit
+
+We consider a qubit starting from $\ket{\psi_0}=\ket1$, with no unitary dynamic $H=0$ and two loss operators $L_-=\sigma_-$ and $L_+=\sigma_+$ which are continuously measured by jump detectors. We expect stochastic trajectories jumping between the excited and ground state.
+
+Let's begin with a perfectly efficient detector. We start with a pure state, and we measure all loss channels with perfect efficiency, so we don't loose any information about the system's state. As a result, it remains pure at all times. We use [`dq.jssesolve()`][dynamiqs.jssesolve] to simulate these quantum trajectories.
+
+### Simulation
+
+```python
+# define Hamiltonian, jump operators, initial state
+H = dq.zeros(2)
+jump_ops = [dq.sigmam(), dq.sigmap()]
+psi0 = dq.excited()
+
+# define save times
+tsave = np.linspace(0, 1.0, 101)
+
+# define a certain number of PRNG key, one for each trajectory
+key = jax.random.PRNGKey(20)
+ntrajs = 3
+keys = jax.random.split(key, ntrajs)
+
+# simulate trajectories
+method = dq.method.EulerJump(dt=1e-3)
+result = dq.jssesolve(H, jump_ops, psi0, tsave, keys, method=method)
+print(result)
+```
+
+```text title="Output"
+==== JSSESolveResult ====
+Method     : EulerJump
+Infos      : 1000 steps | infos shape (3,)
+States     : QArray complex64 (3, 101, 2, 1) | 7.9 Kb
+Clicktimes : Array float32 (3, 2, 10000) | 390.6 Kb
+```
+
+```pycon
+>>> result.states.shape  # (ntrajs, ntsave, n, 1)
+(3, 101, 2, 1)
+>>> result.clicktimes.shape  # (ntrajs, nLm, nmaxclick)
+(3, 2, 10000)
+```
+
+### Individual state trajectories
+
+```python
+_, axs = dq.plot.grid(ntrajs, ntrajs, w=5, h=3, sharexy=True)
+
+for i in range(ntrajs):
+    ax = next(axs)
+    dq.plot.xyz(result.states[i], times=tsave, ax=ax)
+    ax.set(
+        title=f'Trajectory {i+1}: {result.nclicks[i].sum()} clicks',
+        xlabel=r'time $t$',
+        ylabel='Pauli expectation values',
+    )
+
+renderfig('jump-monitored-qubit-trajs')
+```
+
+![plot_jump_monitored_qubit_trajs](../../figs_docs/jump-monitored-qubit-trajs.png){.fig}
+
+### Imperfect detection
+
+If the detection is imperfect, the system state is a density matrix. We use [`dq.jsmesolve()`][dynamiqs.jsmesolve] to simulate these quantum trajectories. For jump measurement we can model two classes of imperfections: false clicks (accounted by the dark count rate $\theta$) and missed clicks (accounted by the efficiency $\eta$).
+
+```python
+# define dark count rates
+thetas = [0.0, 0.0]
+# define efficiencies
+etas = [0.5, 0.5]
+
+# simulate trajectories
+result = dq.jsmesolve(H, jump_ops, thetas, etas, psi0, tsave, keys, method=method)
+print(result)
+```
+
+```text title="Output"
+==== JSMESolveResult ====
+Method     : EulerJump
+Infos      : 1000 steps | infos shape (3,)
+States     : QArray complex64 (3, 101, 2, 2) | 9.5 Kb
+Clicktimes : Array float32 (3, 2, 10000) | 234.4 Kb
+```
+
+```pycon
+>>> result.states.shape  # (ntrajs, ntsave, n, n)
+(3, 101, 2, 2)
+>>> result.clicktimes.shape  # (ntrajs, nLm, nmaxclick)
+(3, 2, 10000)
+```
+
+```python
+_, axs = dq.plot.grid(ntrajs, ntrajs, w=5, h=3, sharexy=True)
+
+for i in range(ntrajs):
+    ax = next(axs)
+    dq.plot.xyz(result.states[i], times=tsave, ax=ax)
+    ax.set(
+        title=f'Trajectory {i+1}: {result.nclicks[i].sum()} clicks',
+        xlabel=r'time $t$',
+        ylabel='Pauli expectation values',
+    )
+
+renderfig('jump-monitored-qubit-eta-trajs')
+```
+
+![plot_jump_monitored_qubit_eta_trajs](../../figs_docs/jump-monitored-qubit-eta-trajs.png){.fig}
+
+
+## Quantum harmonic oscillator
+
+We consider a quantum harmonic oscillator starting from the Fock state $\ket{n_0}$, with Hamiltonian $H=0$ and a single loss operator $L=\sqrt\kappa a$ which is continuously measured by photodetection.
+
+### Simulation
+
+```python
+# define Hamiltonian, jump operators, initial state
+n = 16
+a = dq.destroy(n)
+kappa = 1.0
+n0 = 10
+H = dq.zeros(n)
+jump_ops = [jnp.sqrt(kappa) * a]
+psi0 = dq.fock(n, n0)
+
+# define save times
+tsave = np.linspace(0, 2.0, 101)
+
+# define a certain number of PRNG key, one for each trajectory
+key = jax.random.PRNGKey(42)
+ntrajs = 100
+keys = jax.random.split(key, ntrajs)
+
+# simulate trajectories
+method = dq.method.EulerJump(dt=1e-3)
+options = dq.Options(save_states=False)
+exp_ops = [a.dag() @ a]
+result = dq.jssesolve(H, jump_ops, psi0, tsave, keys, method=method, options=options, exp_ops=exp_ops)
+print(result)
+```
+
+```text title="Output"
+==== JSMESolveResult ====
+Method     : EulerJump
+Infos      : 1000 steps | infos shape (1000,)
+States     : QArray complex64 (100, 16, 1) | 2.0 Mb
+Expects    : Array complex64 (100, 1, 101) | 789.1 Kb
+Clicktimes : Array float32 (100, 1, 10000) | 38.1 Mb
+```
+
+### Individual trajectories vs average trajectory vs Lindblad solution
+
+```python
+exps_adaga = result.expects[:, 0, :].real
+```
+
+```python
+kw = dict(lw=1.5, alpha=0.8)
+
+# individual trajectories
+for i, exp in enumerate(exps_adaga[:4]):
+    plt.plot(tsave, exp, label=f'Trajectory {i+1}', **kw)
+
+# average trajectory
+plt.plot(tsave, exps_adaga.mean(0), label=f'Average trajectory', color='gray', **kw)
+
+# Lindblad solution
+result_lindblad = dq.mesolve(H, jump_ops, psi0, tsave, options=options, exp_ops=exp_ops)
+plt.plot(tsave, result_lindblad.expects[0].real, ls='--', label=f'Lindblad', color='gray', **kw)
+
+plt.gca().set(
+    xlabel=r'time $t$',
+    ylabel=r'$\langle a^\dagger a \rangle_t$',
+)
+plt.legend()
+
+renderfig('jump-monitored-oscillator-trajs')
+```
+
+![plot_jump_monitored_oscillator_trajs](../../figs_docs/jump-monitored-oscillator-trajs.png){.fig}

--- a/docs/documentation/index.md
+++ b/docs/documentation/index.md
@@ -27,4 +27,5 @@ Familiarize yourself with Dynamiqs. Learn how to simulate quantum systems, defin
 Explore advanced examples and tutorials to deepen your understanding of Dynamiqs.
 
 - [Driven-dissipative Kerr oscillator](advanced_examples/kerr-oscillator.md)
+- [Continuous jump measurement](advanced_examples/continuous-jump-measurement.md)
 - [Continuous diffusive measurement](advanced_examples/continuous-diffusive-measurement.md)

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -61,6 +61,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - Kvaerno3
         - Kvaerno5
         - Euler
+        - EulerJump
         - EulerMaruyama
         - Rouchon1
         - Expm

--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -280,22 +280,13 @@ def _vectorized_dsmesolve(
     gradient: Gradient | None,
     options: Options,
 ) -> DSMESolveResult:
-    f = _dsmesolve_single_trajectory
-
-    # === vectorize function over stochastic trajectories
-    # the input is vectorized over `key`
-    in_axes = (None, None, None, None, None, None, 0, None, None, None, None)
-    # the result is vectorized over `_saved`, `infos` and `keys`
-    out_axes = DSMESolveResult.out_axes()
-    f = jax.vmap(f, in_axes, out_axes)
-
-    # === vectorize function
     # vectorize input over H and rho0
-    in_axes = (H.in_axes, None, None, None, 0, None, None, None, None, None, None)
+    in_axes = (H.in_axes, None, None, None, 0, *(None,) * 6)
+    out_axes = DSMESolveResult.out_axes()
 
     if options.cartesian_batching:
         nvmap = (H.ndim - 2, 0, 0, 0, rho0.ndim - 2, 0, 0, 0, 0, 0, 0)
-        f = cartesian_vmap(f, in_axes, out_axes, nvmap)
+        f = cartesian_vmap(_dsmesolve_many_trajectories, in_axes, out_axes, nvmap)
     else:
         bshape = jnp.broadcast_shapes(H.shape[:-2], rho0.shape[:-2])
         nvmap = len(bshape)
@@ -304,9 +295,28 @@ def _vectorized_dsmesolve(
         H = H.broadcast_to(*bshape, n, n)
         rho0 = rho0.broadcast_to(*bshape, n, n)
         # vectorize the function
-        f = multi_vmap(f, in_axes, out_axes, nvmap)
+        f = multi_vmap(_dsmesolve_many_trajectories, in_axes, out_axes, nvmap)
 
-    # === apply vectorized function
+    return f(H, Lcs, Lms, etas, rho0, tsave, keys, exp_ops, method, gradient, options)
+
+
+def _dsmesolve_many_trajectories(
+    H: TimeQArray,
+    Lcs: list[TimeQArray],
+    Lms: list[TimeQArray],
+    etas: Array,
+    rho0: QArray,
+    tsave: Array,
+    keys: PRNGKeyArray,
+    exp_ops: list[QArray] | None,
+    method: Method,
+    gradient: Gradient | None,
+    options: Options,
+) -> DSMESolveResult:
+    # vectorize input over keys
+    in_axes = (None, None, None, None, None, None, 0, None, None, None, None)
+    out_axes = DSMESolveResult(None, None, None, None, 0, 0, 0)
+    f = jax.vmap(_dsmesolve_single_trajectory, in_axes, out_axes)
     return f(H, Lcs, Lms, etas, rho0, tsave, keys, exp_ops, method, gradient, options)
 
 

--- a/dynamiqs/integrators/apis/jsmesolve.py
+++ b/dynamiqs/integrators/apis/jsmesolve.py
@@ -267,7 +267,7 @@ def jsmesolve(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=('tsave', 'method', 'gradient', 'options'))
+@partial(jax.jit, static_argnames=('tsave', 'gradient', 'options'))
 def _vectorized_jsmesolve(
     H: TimeQArray,
     Lcs: list[TimeQArray],

--- a/dynamiqs/integrators/apis/jsmesolve.py
+++ b/dynamiqs/integrators/apis/jsmesolve.py
@@ -1,13 +1,30 @@
 from __future__ import annotations
 
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+from jax import Array
 from jaxtyping import ArrayLike, PRNGKeyArray
 
+from ..._checks import check_hermitian, check_qarray_is_dense, check_shape, check_times
 from ...gradient import Gradient
-from ...method import Method
-from ...options import Options
-from ...qarrays.qarray import QArrayLike
-from ...result import JSMESolveResult
+from ...method import EulerJump, Method
+from ...options import Options, check_options
+from ...qarrays.qarray import QArray, QArrayLike
+from ...qarrays.utils import asqarray
+from ...result import DSMESolveResult, JSMESolveResult
 from ...time_qarray import TimeQArray
+from .._utils import (
+    assert_method_supported,
+    astimeqarray,
+    cartesian_vmap,
+    catch_xla_runtime_error,
+    multi_vmap,
+)
+from ..core.fixed_step_stochastic_integrator import (
+    jsmesolve_euler_jump_integrator_constructor,
+)
 
 
 def jsmesolve(
@@ -25,10 +42,6 @@ def jsmesolve(
     options: Options = Options(),  # noqa: B008
 ) -> JSMESolveResult:
     r"""Solve the jump stochastic master equation (SME).
-
-    Warning:
-        This function has not been implemented yet. The following API is indicative
-        of the planned implementation.
 
     The jump SME describes the evolution of a quantum system measured by
     a jump detector (for example photodetection in quantum optics). This function
@@ -93,7 +106,7 @@ def jsmesolve(
         exp_ops _(list of array-like, each of shape (n, n), optional)_: List of
             operators for which the expectation value is computed.
         method: Method for the integration. No defaults for now, you have to specify a
-            method (supported: [`EulerMaruyama`][dynamiqs.method.EulerMaruyama]).
+            method (supported: [`EulerJump`][dynamiqs.method.EulerJump]).
         gradient: Algorithm used to compute the gradient. The default is
             method-dependent, refer to the documentation of the chosen method for more
             details.
@@ -149,7 +162,7 @@ def jsmesolve(
                     expectation values, if specified by `exp_ops`.
                 - **clicktimes** _(array of shape (..., ntrajs, nLm, nmaxclick))_ - Times
                     at which the detectors clicked. Variable-length array padded with
-                    `None` up to `nmaxclick`.
+                    `jnp.nan` up to `nmaxclick`.
                 - **extra** _(PyTree or None)_ - Extra data saved with `save_extra()` if
                     specified in `options`.
                 - **keys** _(PRNG key array of shape (ntrajs,))_ - PRNG keys used to
@@ -214,4 +227,206 @@ def jsmesolve(
         needed don't hesitate to
         [open an issue on GitHub](https://github.com/dynamiqs/dynamiqs/issues/new).
     """  # noqa: E501
-    return NotImplemented
+    # === convert arguments
+    H = astimeqarray(H)
+    Ls = [astimeqarray(L) for L in jump_ops]
+    thetas = jnp.asarray(thetas)
+    etas = jnp.asarray(etas)
+    rho0 = asqarray(rho0)
+    tsave = jnp.asarray(tsave)
+    keys = jnp.asarray(keys)
+    if exp_ops is not None:
+        exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+
+    # === check arguments
+    _check_jsmesolve_args(H, Ls, thetas, etas, rho0, exp_ops)
+    tsave = check_times(tsave, 'tsave')
+    check_options(options, 'jsmesolve')
+    options = options.initialise()
+
+    if method is None:
+        raise ValueError('Argument `method` must be specified.')
+
+    # === convert rho0 to density matrix
+    rho0 = rho0.todm()
+    rho0 = check_hermitian(rho0, 'rho0')
+
+    # === split jump operators
+    # split between purely dissipative (eta = 0) and measured (eta != 0)
+    Lcs = [L for L, eta in zip(Ls, etas, strict=True) if eta == 0]
+    Lms = [L for L, eta in zip(Ls, etas, strict=True) if eta != 0]
+    thetas = thetas[etas != 0]
+    etas = etas[etas != 0]
+
+    # we implement the jitted vectorization in another function to pre-convert QuTiP
+    # objects (which are not JIT-compatible) to JAX arrays
+    tsave = tuple(tsave.tolist())  # todo: fix static tsave
+    return _vectorized_jsmesolve(
+        H, Lcs, Lms, thetas, etas, rho0, tsave, keys, exp_ops, method, gradient, options
+    )
+
+
+@catch_xla_runtime_error
+@partial(jax.jit, static_argnames=('tsave', 'method', 'gradient', 'options'))
+def _vectorized_jsmesolve(
+    H: TimeQArray,
+    Lcs: list[TimeQArray],
+    Lms: list[TimeQArray],
+    thetas: Array,
+    etas: Array,
+    rho0: QArray,
+    tsave: Array,
+    keys: PRNGKeyArray,
+    exp_ops: list[QArray] | None,
+    method: Method,
+    gradient: Gradient | None,
+    options: Options,
+) -> DSMESolveResult:
+    f = _jsmesolve_single_trajectory
+
+    # === vectorize function over stochastic trajectories
+    # the input is vectorized over `key`
+    in_axes = (None, None, None, None, None, None, None, 0, None, None, None, None)
+    # the result is vectorized over `_saved`, `infos` and `keys`
+    out_axes = JSMESolveResult.out_axes()
+    f = jax.vmap(f, in_axes, out_axes)
+
+    # === vectorize function
+    # vectorize input over H and rho0
+    in_axes = (H.in_axes, None, None, None, None, 0, None, None, None, None, None, None)
+
+    if options.cartesian_batching:
+        nvmap = (H.ndim - 2, 0, 0, 0, 0, rho0.ndim - 2, 0, 0, 0, 0, 0, 0)
+        f = cartesian_vmap(f, in_axes, out_axes, nvmap)
+    else:
+        bshape = jnp.broadcast_shapes(H.shape[:-2], rho0.shape[:-2])
+        nvmap = len(bshape)
+        # broadcast all vectorized input to same shape
+        n = H.shape[-1]
+        H = H.broadcast_to(*bshape, n, n)
+        rho0 = rho0.broadcast_to(*bshape, n, n)
+        # vectorize the function
+        f = multi_vmap(f, in_axes, out_axes, nvmap)
+
+    # === apply vectorized function
+    return f(
+        H, Lcs, Lms, thetas, etas, rho0, tsave, keys, exp_ops, method, gradient, options
+    )
+
+
+def _jsmesolve_single_trajectory(
+    H: TimeQArray,
+    Lcs: list[TimeQArray],
+    Lms: list[TimeQArray],
+    thetas: Array,
+    etas: Array,
+    rho0: QArray,
+    tsave: Array,
+    key: PRNGKeyArray,
+    exp_ops: list[QArray] | None,
+    method: Method,
+    gradient: Gradient | None,
+    options: Options,
+) -> JSMESolveResult:
+    # === select integrator constructor
+    integrator_constructors = {EulerJump: jsmesolve_euler_jump_integrator_constructor}
+    assert_method_supported(method, integrator_constructors.keys())
+    integrator_constructor = integrator_constructors[type(method)]
+
+    # === check gradient is supported
+    method.assert_supports_gradient(gradient)
+
+    # === init integrator
+    integrator = integrator_constructor(
+        ts=tsave,
+        y0=rho0,
+        method=method,
+        gradient=gradient,
+        result_class=JSMESolveResult,
+        options=options,
+        H=H,
+        Lcs=Lcs,
+        Lms=Lms,
+        thetas=thetas,
+        etas=etas,
+        Es=exp_ops,
+        key=key,
+    )
+
+    # === run solver
+    result = integrator.run()
+
+    # === return result
+    return result  # noqa: RET504
+
+
+def _check_jsmesolve_args(  # noqa: C901
+    H: TimeQArray,
+    Ls: list[TimeQArray],
+    thetas: Array,
+    etas: Array,
+    rho0: QArray,
+    exp_ops: list[QArray] | None,
+):
+    # === check H shape
+    check_shape(H, 'H', '(..., n, n)', subs={'...': '...H'})
+
+    # === check Ls shape
+    for i, L in enumerate(Ls):
+        check_shape(L, f'jump_ops[{i}]', '(n, n)')
+
+    if len(Ls) == 0:
+        if rho0.isket():
+            raise ValueError(
+                'Argument `jump_ops` is an empty list and argument `rho0` is a ket,'
+                ' consider using `dq.sesolve()` to solve the Schrödinger equation.'
+            )
+        raise ValueError(
+            'Argument `jump_ops` is an empty list, consider using `dq.mesolve()` to'
+            ' solve the Schrödinger equation for density matrices.'
+        )
+
+    # === check thetas
+    check_shape(thetas, 'thetas', '(n,)', subs={'n': 'len(jump_ops)'})
+
+    if not len(thetas) == len(Ls):
+        raise ValueError(
+            'Argument `thetas` should be of the same length as argument `jump_ops`, but'
+            f' len(thetas)={len(thetas)} and len(jump_ops)={len(Ls)}.'
+        )
+
+    if jnp.any(thetas < 0):
+        raise ValueError(
+            'Argument `thetas` should only contain values greater than 0, but'
+            f' is {thetas}.'
+        )
+
+    # === check etas
+    check_shape(etas, 'etas', '(n,)', subs={'n': 'len(jump_ops)'})
+
+    if not len(etas) == len(Ls):
+        raise ValueError(
+            'Argument `etas` should be of the same length as argument `jump_ops`, but'
+            f' len(etas)={len(etas)} and len(jump_ops)={len(Ls)}.'
+        )
+
+    if jnp.all(etas == 0):
+        raise ValueError(
+            'Argument `etas` contains only null values, consider using `dq.mesolve()`'
+            ' to solve the Lindblad master equation.'
+        )
+
+    if not (jnp.all(etas >= 0) and jnp.all(etas <= 1)):
+        raise ValueError(
+            'Argument `etas` should only contain values between 0 and 1, but'
+            f' is {etas}.'
+        )
+
+    # === check rho0 shape and layout
+    check_shape(rho0, 'rho0', '(..., n, 1)', '(..., n, n)', subs={'...': '...rho0'})
+    check_qarray_is_dense(rho0, 'rho0')
+
+    # === check exp_ops shape
+    if exp_ops is not None:
+        for i, E in enumerate(exp_ops):
+            check_shape(E, f'exp_ops[{i}]', '(n, n)')

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 from abc import abstractmethod
 from functools import partial
+from ssl import Options
 
 import diffrax as dx
 import equinox as eqx
@@ -10,8 +11,9 @@ from jax import Array
 from jaxtyping import PyTree, Scalar
 
 from ..._utils import obj_type_str
-from ...gradient import Autograd, CheckpointAutograd, ForwardAutograd
-from ...result import Result
+from ...gradient import Autograd, CheckpointAutograd, ForwardAutograd, Gradient
+from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Method, Tsit5
+from ...result import Result, Saved
 from ...utils.vectorization import slindbladian
 from .abstract_integrator import BaseIntegrator
 from .interfaces import AbstractTimeInterface, MEInterface, SEInterface, SolveInterface
@@ -145,6 +147,66 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
                 stats['num_accepted_steps'],
                 stats['num_rejected_steps'],
             )
+
+
+def basic_diffeqsolve(
+    ts: Array,
+    y0: PyTree,
+    terms: dx.AbstractTerm,
+    method: Method,
+    gradient: Gradient,
+    options: Options,
+    discontinuity_ts: Array,
+    event: dx.Event | None = None,
+    save: callable | None = None,
+) -> dx.Solution:
+    # === define custom diffrax integrator
+    class BasicDiffraxIntegrator(DiffraxIntegrator):
+        @property
+        def terms(self) -> dx.AbstractTerm:
+            return terms
+
+        @property
+        def discontinuity_ts(self) -> Array:
+            return discontinuity_ts
+
+        def save(self, y: PyTree) -> Saved:
+            pass
+
+        def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+            pass
+
+    # === set Diffrax solver
+    diffrax_solver, fixed_step = {
+        Euler: (dx.Euler(), True),
+        Dopri5: (dx.Dopri5(), False),
+        Dopri8: (dx.Dopri8(), False),
+        Tsit5: (dx.Tsit5(), False),
+        Kvaerno3: (dx.Kvaerno3(), False),
+        Kvaerno5: (dx.Kvaerno5(), False),
+    }[type(method)]
+
+    # === init integrator
+    integrator = BasicDiffraxIntegrator(
+        ts=ts,
+        y0=y0,
+        method=method,
+        gradient=gradient,
+        result_class=None,
+        options=options,
+        diffrax_solver=diffrax_solver,
+        fixed_step=fixed_step,
+    )
+
+    if save is None:
+        save = lambda y: y
+    fn = lambda t, y, args: save(y)  # noqa: ARG005
+    subsaveat_a = dx.SubSaveAt(ts=ts, fn=fn)  # save solution regularly
+    subsaveat_b = dx.SubSaveAt(t1=True)  # save last state
+    saveat = dx.SaveAt(subs=[subsaveat_a, subsaveat_b])
+
+    # === run integrator
+    return integrator.diffeqsolve(ts[0], ts[-1], y0, saveat, event=event)
 
 
 class SEDiffraxIntegrator(DiffraxIntegrator, SEInterface):

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import warnings
 from abc import abstractmethod
 from functools import partial
-from ssl import Options
 
 import diffrax as dx
 import equinox as eqx
@@ -13,6 +12,7 @@ from jaxtyping import PyTree, Scalar
 from ..._utils import obj_type_str
 from ...gradient import Autograd, CheckpointAutograd, ForwardAutograd, Gradient
 from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Method, Tsit5
+from ...options import Options
 from ...result import Result, Saved
 from ...utils.vectorization import slindbladian
 from .abstract_integrator import BaseIntegrator

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -149,7 +149,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             )
 
 
-def basic_diffeqsolve(
+def call_diffeqsolve(
     ts: Array,
     y0: PyTree,
     terms: dx.AbstractTerm,

--- a/dynamiqs/integrators/core/event_integrator.py
+++ b/dynamiqs/integrators/core/event_integrator.py
@@ -14,7 +14,7 @@ from ...qarrays.utils import stack
 from ...result import JSSESolveResult, JumpSolveSaved, Result, Saved, SolveSaved
 from ...utils.general import expect
 from .abstract_integrator import StochasticBaseIntegrator
-from .diffrax_integrator import basic_diffeqsolve
+from .diffrax_integrator import call_diffeqsolve
 from .interfaces import JSSEInterface, SolveInterface
 from .save_mixin import SolveSaveMixin
 
@@ -96,7 +96,7 @@ class JSSESolveEventIntegrator(
             + sum([-0.5 * _L.dag() @ (_L @ y) for _L in self.L(t)])
         )
 
-        return basic_diffeqsolve(
+        return call_diffeqsolve(
             ts,
             psi0,
             terms,

--- a/dynamiqs/integrators/core/event_integrator.py
+++ b/dynamiqs/integrators/core/event_integrator.py
@@ -17,7 +17,13 @@ from ...utils.general import dag, expect, norm, unit
 from .abstract_integrator import StochasticBaseIntegrator
 from .diffrax_integrator import DiffraxIntegrator
 from .interfaces import JSSEInterface, SolveInterface
-from .save_mixin import JumpSolveSaveMixin
+
+
+class JSSESolveEventIntegrator:
+    pass
+
+
+jssesolve_event_integrator_constructor = JSSESolveEventIntegrator
 
 
 class JSSEInnerState(eqx.Module):
@@ -49,7 +55,7 @@ class JSSESolveEventIntegrator(
     DiffraxIntegrator,
     JSSEInterface,
     SolveInterface,
-    JumpSolveSaveMixin,
+    # JumpSolveSaveMixin,
 ):
     """Integrator computing the time evolution of the Jump SSE using Diffrax events."""
 

--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -56,13 +56,12 @@ class DSSEInterface(MEInterface):
     """Interface for the diffusive SSE."""
 
 
-class DSMEInterface(AbstractTimeInterface):
-    """Interface for the diffusive SME."""
+class SMEInterface(AbstractTimeInterface):
+    """Interface for the jump or diffusive SME."""
 
     H: TimeQArray
     Lcs: list[TimeQArray]  # (nLc, n, n)
     Lms: list[TimeQArray]  # (nLm, n, n)
-    etas: Array  # (nLm,)
 
     @property
     def Ls(self) -> list[TimeQArray]:
@@ -81,6 +80,19 @@ class DSMEInterface(AbstractTimeInterface):
     def discontinuity_ts(self) -> Array:
         ts = [x.discontinuity_ts for x in [self.H, *self.Ls]]
         return concatenate_sort(*ts)
+
+
+class JSMEInterface(SMEInterface):
+    """Interface for the jump SME."""
+
+    thetas: Array  # (nLm,)
+    etas: Array  # (nLm,)
+
+
+class DSMEInterface(SMEInterface):
+    """Interface for the diffusive SME."""
+
+    etas: Array  # (nLm,)
 
 
 class SolveInterface(eqx.Module):

--- a/dynamiqs/integrators/core/save_mixin.py
+++ b/dynamiqs/integrators/core/save_mixin.py
@@ -4,16 +4,10 @@ from abc import abstractmethod
 
 import equinox as eqx
 import jax.numpy as jnp
-from jaxtyping import Array, PyTree
+from jaxtyping import PyTree
 
-from ...result import (
-    DiffusiveSolveSaved,
-    JumpSolveSaved,
-    PropagatorSaved,
-    Saved,
-    SolveSaved,
-)
-from ...utils.general import expect, unit
+from ...result import PropagatorSaved, Saved, SolveSaved
+from ...utils.general import expect
 from .interfaces import OptionsInterface
 
 
@@ -72,37 +66,3 @@ class SolveSaveMixin(AbstractSaveMixin):
                 lambda x: x.ysave, saved, ylast, is_leaf=lambda x: x is None
             )
         return self.reorder_Esave(saved)
-
-
-class JumpSolveSaveMixin(SolveSaveMixin):
-    """Mixin to assist jump SSE/SME integrators computing time evolution with data
-    saving.
-    """
-
-    def save(self, y: PyTree) -> Saved:
-        # force state normalisation before saving
-        return super().save(unit(y))
-
-    def postprocess_saved(
-        self, saved: SolveSaved, ylast: PyTree, clicktimes: Array
-    ) -> JumpSolveSaved:
-        saved = super().postprocess_saved(saved, unit(ylast))
-        return JumpSolveSaved(
-            saved.ysave, saved.extra, saved.Esave, clicktimes, ylast.norm()
-        )
-
-
-class DiffusiveSolveSaveMixin(SolveSaveMixin):
-    """Mixin to assist diffusive SSE/SME integrators computing time evolution with data
-    saving.
-    """
-
-    def save(self, y: PyTree) -> Saved:
-        saved = super().save(y.state)
-        return DiffusiveSolveSaved(saved.ysave, saved.extra, saved.Esave, y.Y)
-
-    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
-        saved = super().postprocess_saved(saved, ylast.state)
-        # reorder Isave after jax.lax.scan stacking (ntsave, nLm) -> (nLm, ntsave)
-        Isave = saved.Isave.swapaxes(-1, -2)
-        return eqx.tree_at(lambda x: x.Isave, saved, Isave)

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -12,6 +12,7 @@ __all__ = [
     'Dopri5',
     'Dopri8',
     'Euler',
+    'EulerJump',
     'EulerMaruyama',
     'Expm',
     'Kvaerno3',
@@ -142,6 +143,27 @@ class Euler(_DEFixedStep):
         CheckpointAutograd,
         ForwardAutograd,
     )
+
+    # dummy init to have the signature in the documentation
+    def __init__(self, dt: float):
+        super().__init__(dt)
+
+
+class EulerJump(_DEFixedStep):
+    r"""Euler-Jump method (fixed step size SDE method).
+
+    Args:
+        dt: Fixed time step.
+
+    Note-: Supported gradients
+        This method supports differentiation with
+        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd] (default).
+    """
+
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (Autograd,)
+
+    # todo: fix static dt (similar issue as static tsave in dssesolve)
+    dt: float = eqx.field(static=True)
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import equinox as eqx
 from optimistix import AbstractRootFinder
@@ -491,16 +491,21 @@ class Event(_DEMethod):
         root_finder: Root finder to refine the click times, defaults to `None`
             (precision determined by the integration step size).
         smart_sampling: If `True`, the no-click trajectory is sampled only once, and
-            `result.states` contains only trajectories with one or more clicks. Use
-            `result.noclick_states` to access the no-click trajectory, and
-            `result.noclick_prob` for its associated probability.
+            `result.states` contains only trajectories with one or more clicks.
+            Information about the no-click trajectory are stored in `result.infos`:
+
+            - `result.infos.noclick_states` _(qarray of shape (..., nsave, n, 1))_ -
+                No-click trajectory.
+            - `result.infos.noclick_prob` _(array of shape (...))_ - Probability of
+                the no-click trajectory.
+            - `result.infos.noclick_expects` _(array of shape
+                (..., len(exp_ops), ntsave) or None)_ - No-click trajectory expectation
+                values.
 
     Note-: Supported gradients
         This method supports differentiation with
-        [`dq.gradient.Autograd`][dynamiqs.gradient.Autograd],
         [`dq.gradient.CheckpointAutograd`][dynamiqs.gradient.CheckpointAutograd]
-        (default)
-        and [`dq.gradient.ForwardAutograd`][dynamiqs.gradient.ForwardAutograd].
+        (default).
     """
 
     noclick_method: Method = Tsit5()
@@ -523,7 +528,3 @@ class Event(_DEMethod):
         self.noclick_method = noclick_method
         self.root_finder = root_finder
         self.smart_sampling = smart_sampling
-
-    # inherit attributes from the noclick_method
-    def __getattr__(self, attr: str) -> Any:
-        return getattr(self.noclick_method, attr)

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -10,7 +10,6 @@ from .method import Method
 from .options import Options
 from .qarrays.qarray import QArray
 from .qarrays.utils import to_jax
-from .utils.general import unit
 
 __all__ = [
     'FloquetResult',
@@ -60,7 +59,6 @@ class SolveSaved(Saved):
 
 class JumpSolveSaved(SolveSaved):
     clicktimes: Array
-    final_state_norm: Array
 
 
 class DiffusiveSolveSaved(SolveSaved):
@@ -197,9 +195,15 @@ class MEPropagatorResult(PropagatorResult):
     pass
 
 
-class JSSESolveResult(SolveResult):
+class StochasticSolveResult(SolveResult):
     keys: PRNGKeyArray
 
+    @classmethod
+    def out_axes(cls) -> SolveResult:
+        return cls(None, None, None, None, 0, 0, 0)
+
+
+class JumpSolveResult(StochasticSolveResult):
     @property
     def clicktimes(self) -> Array:
         return self._saved.clicktimes
@@ -208,63 +212,20 @@ class JSSESolveResult(SolveResult):
     def nclicks(self) -> Array:
         return jnp.count_nonzero(~jnp.isnan(self.clicktimes), axis=-1)
 
-    @property
-    def final_state_norm(self) -> Array:
-        return self._saved.final_state_norm
-
-    def noclick_states(self) -> QArray:
-        return self.states[..., 0, :, :, :]
-
-    @property
-    def noclick_prob(self) -> Array:
-        # todo: fix
-        return None
-
     def _str_parts(self) -> dict[str, str | None]:
         d = super()._str_parts()
-        return d | {
-            'Clicktimes': _array_str(self.clicktimes),
-            'Number of clicks': _array_str(self.nclicks),
-            'No click probability': _array_str(self.noclick_prob),
-        }
-
-    @classmethod
-    def out_axes(cls) -> SolveResult:
-        return cls(None, None, None, None, 0, 0, 0)
-
-    @property
-    def mean_states(self) -> QArray:
-        if self.method.smart_sampling:
-            noclick_prob = self.final_state_norm[..., 0, None, None, None] ** 2
-            states_noclick = self.states[..., 0, :, :, :].todm()
-            states_click = self.states[..., 1:, :, :, :].todm().mean(axis=-4)
-            return unit(
-                noclick_prob * states_noclick + (1 - noclick_prob) * states_click
-            )
-        else:
-            return self.states.todm().mean(axis=-4)
-
-    @property
-    def mean_expects(self) -> Array:
-        if self.expects is None:
-            return None
-
-        if self.method.smart_sampling:
-            noclick_prob = self.final_state_norm[..., 0, None, None] ** 2
-            expects_noclick = self.expects[..., 0, :, :]
-            expects_click = self.expects[..., 1:, :, :].mean(axis=-3)
-            return noclick_prob * expects_noclick + (1 - noclick_prob) * expects_click
-        else:
-            return self.expects.mean(axis=-3)
+        return d | {'Clicktimes': _array_str(self.clicktimes)}
 
 
-class JSMESolveResult(SolveResult):
+class JSSESolveResult(JumpSolveResult):
     pass
 
 
-class DiffusiveSolveResult(SolveResult):
-    keys: PRNGKeyArray
+class JSMESolveResult(JumpSolveResult):
+    pass
 
+
+class DiffusiveSolveResult(StochasticSolveResult):
     @property
     def measurements(self) -> Array:
         return self._saved.Isave
@@ -272,10 +233,6 @@ class DiffusiveSolveResult(SolveResult):
     def _str_parts(self) -> dict[str, str | None]:
         d = super()._str_parts()
         return d | {'Measurements': _array_str(self.measurements)}
-
-    @classmethod
-    def out_axes(cls) -> SolveResult:
-        return cls(None, None, None, None, 0, 0, 0)
 
 
 class DSSESolveResult(DiffusiveSolveResult):

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -200,7 +200,7 @@ class StochasticSolveResult(SolveResult):
 
     @classmethod
     def out_axes(cls) -> SolveResult:
-        return cls(None, None, None, None, 0, 0, 0)
+        return cls(None, None, None, None, 0, 0, None)
 
 
 class JumpSolveResult(StochasticSolveResult):

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -220,7 +220,6 @@ class JumpSolveResult(StochasticSolveResult):
     def mean_states(self) -> QArray:
         # todo: document
         if self.method.smart_sampling:
-            noclick_prob = 0
             noclick_prob = self.infos.noclick_prob[..., None, None, None]
             return unit(
                 noclick_prob * self.infos.noclick_states.todm()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -147,6 +147,7 @@ nav:
           - Computing gradients: documentation/basics/computing-gradients.md
       - Advanced examples:
           - Driven-dissipative Kerr oscillator: documentation/advanced_examples/kerr-oscillator.md
+          - Continuous jump measurement: documentation/advanced_examples/continuous-jump-measurement.md
           - Continuous diffusive measurement: documentation/advanced_examples/continuous-diffusive-measurement.md
   - Python API:
       - python_api/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,6 +176,7 @@ nav:
               - Kvaerno3: python_api/method/Kvaerno3.md
               - Kvaerno5: python_api/method/Kvaerno5.md
               - Euler: python_api/method/Euler.md
+              - EulerJump: python_api/method/EulerJump.md
               - EulerMaruyama: python_api/method/EulerMaruyama.md
               - Rouchon1: python_api/method/Rouchon1.md
               - Expm: python_api/method/Expm.md

--- a/tests/jssesolve/test_jssesolve.py
+++ b/tests/jssesolve/test_jssesolve.py
@@ -35,9 +35,9 @@ def test_against_mesolve_oscillator(smart_sampling, atol=1e-2):
     meresult = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=me_options)
 
     # compare results on average
-    assert jnp.allclose(meresult.expects, jsseresult.mean_expects, atol=atol)
+    assert jnp.allclose(meresult.expects, jsseresult.mean_expects(), atol=atol)
     assert jnp.allclose(
-        meresult.states.to_jax(), jsseresult.mean_states.to_jax(), atol=atol
+        meresult.states.to_jax(), jsseresult.mean_states().to_jax(), atol=atol
     )
 
 
@@ -70,7 +70,7 @@ def test_against_mesolve_qubit(smart_sampling, atol=1e-2):
     meresult = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=me_options)
 
     # compare results on average
-    assert jnp.allclose(meresult.expects, jsseresult.mean_expects, atol=atol)
+    assert jnp.allclose(meresult.expects, jsseresult.mean_expects(), atol=atol)
     assert jnp.allclose(
-        meresult.states.to_jax(), jsseresult.mean_states.to_jax(), atol=atol
+        meresult.states.to_jax(), jsseresult.mean_states().to_jax(), atol=atol
     )


### PR DESCRIPTION
Sorry for this massive PR. 🙈 I suggest directly reading the new files rather than the diffs.

**Changes**
- Added an Euler-Jump solver to `dq.jssesolve()` and `dq.jsmesolve()` (by generalising and reusing the existing fixed-step stochastic integrator for diffusive SSE/SME). I temporarily removed the `Event` solver for this change and then re-added it; see details just below.
- Added a tutorial on continuous jump measurement.
- Simplified the vectorization over trajectories by separating vectorization over `H`, `jump_ops`, or `psi0/rho0` and vectorization over `keys`.
- Re-added the `Event` solver. The logic remains mostly the same, albeit with some modifications, and I fixed a few issues:
  - Fixed the `result` object API (we now return `noclick_prob` of the good shape, and we don't return `final_state_norm`).
  - Fixed the progress meter (previously displaying multiple times during the solve and breaking the vmap).
  - The logic of the `Event` solver is now well separated from the `dq.jssesolve()` API, and isolated in the `event_integrator.py` file. This allows someone to implement a Gillespie solver without having to change everything, for example.
  - Instead of being a diffrax integrator, the event integrator is just using diffrax integrators (multiple, at different times). I believe this better decouples the logic.
  - When `smart_sampling=True`, we now solve the no-click trajectory without using any event handling, we don't consume a random key (the trajectory is deterministic), and the result is not part of `result.states` but is stored as something specific to the `Event` method, in `result.infos`.

**Points of attention for the review**
- I updated the doc for supported gradients. Correct me if I'm wrong, but I think the code only supports bwd checkpointed, not fwd mode.
- I believe there was a bug in the previous implementation, because `nclicks` was shared by all jump channels, but we should have one index per channel for `clicktimes` of shape `(..., ntrajs, len(jump_ops), nmaxclick)`. See for example [here](https://github.com/dynamiqs/dynamiqs/blob/fdc2e26b9d862ca49184b99d21a7930973f1bc58/dynamiqs/integrators/core/event_integrator.py#L95-L97) in the previous code.

**What's next?**
I have noted several possible improvements and simplifications we could make. I'll write a linear issue at some point. The most important IMO is that the method is unusable without a root finder now (when `root_finder=None`). The reason is that if the no jump evolution is trivial to solve, the adaptive solver will take gigantic steps, leading to extremely imprecise jump times. We should add a way to specify the stepsize controller `dtmax`, so users can control the precision of the click times in that scenario.

**Final words**
Thanks again @dkweiss31 and @gautierronan for the massive work on the `Event` method (#748 and #943), this would have never happened without it! Happy reviewing. 😊