### PR TITLE
Add steady-state solver

### DIFF
--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -20,6 +20,7 @@ class Options(eqx.Module):
     t0: ScalarLike | None = None
     save_extra: callable[[QArray], PyTree] | None = None
     nmaxclick: int = 10_000
+    steady_state: bool = False
 
     def __init__(
         self,
@@ -30,6 +31,7 @@ class Options(eqx.Module):
         t0: ScalarLike | None = None,
         save_extra: callable[[QArray], PyTree] | None = None,
         nmaxclick: int = 10_000,
+        steady_state: bool = False,
     ):
         self.save_states = save_states
         self.save_propagators = save_propagators
@@ -37,6 +39,7 @@ class Options(eqx.Module):
         self.progress_meter = progress_meter
         self.t0 = t0
         self.nmaxclick = nmaxclick
+        self.steady_state = steady_state
 
         # make `save_extra` a valid Pytree with `Partial`
         self.save_extra = jtu.Partial(save_extra) if save_extra is not None else None
@@ -64,6 +67,7 @@ class Options(eqx.Module):
             t0=self.t0,
             save_extra=self.save_extra,
             nmaxclick=self.nmaxclick,
+            steady_state=self.steady_state,
         )
 
 
@@ -82,6 +86,7 @@ def check_options(options: Options, solver_name: str):
             'progress_meter',
             't0',
             'save_extra',
+            'steady_state',
         ),
         'sepropagator': ('save_propagators', 'progress_meter', 't0', 'save_extra'),
         'mepropagator': ('save_propagators', 'cartesian_batching', 't0', 'save_extra'),

--- a/tests/mesolve/open_system.py
+++ b/tests/mesolve/open_system.py
@@ -97,6 +97,9 @@ class OCavity(OpenSystem):
     def state(self, t: float) -> QArray:
         return dq.coherent_dm(self.n, self._alpha(t))
 
+    def steady_state(self) -> QArray:
+        return dq.coherent_dm(self.n, 0.0)
+
     def expect(self, t: float) -> Array:
         alpha_t = self._alpha(t)
         exp_x = alpha_t.real
@@ -242,3 +245,10 @@ dia_ocavity = OCavity(
 
 tsave = np.linspace(0.0, 1.0, 11)
 otdqubit = OTDQubit(eps=3.0, omega=10.0, gamma=1.0, tsave=tsave)
+
+# steady state solutions
+tsave_steady = np.logspace(-3.0, 5.0, num=11)
+# tsave_steady = np.linspace(0.0, 1e5, 11)
+dense_ocavity_steady = OCavity(
+    n=8, delta=1.0 * Hz, alpha0=0.5, kappa=1.0 * Hz, tsave=tsave_steady, layout=dense
+)

--- a/tests/mesolve/test_steady_state_event.py
+++ b/tests/mesolve/test_steady_state_event.py
@@ -1,0 +1,22 @@
+import jax.numpy as jnp
+import pytest
+
+from dynamiqs.method import Tsit5
+from dynamiqs.options import Options
+
+from ..integrator_tester import IntegratorTester
+from ..order import TEST_LONG
+from .open_system import dense_ocavity_steady
+
+
+@pytest.mark.run(order=TEST_LONG)
+class TestMESolveSteadyState(IntegratorTester):
+    @pytest.mark.parametrize('system', [dense_ocavity_steady])
+    def test_correctness(self, system):
+        options = Options(steady_state=True)
+        result = system.run(Tsit5(), options=options)
+        states = result.states.to_jax()
+        final_state = states[-1]
+        assert jnp.allclose(
+            final_state, system.steady_state().to_jax(), atol=1e-3, rtol=1e-3
+        )


### PR DESCRIPTION
This commit adds an option to halt on detecting a steady state event during mesolve. It modifies the OCavity OpenSystem with a steady_state method, and adds a unit test checking that the solver halts. Because diffrax returns infs for all tsave after a steady state event, the last valid value is copied forward in time.