### PR TITLE
Use `dataclasses.replace` to simplify code

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from functools import partial
 from typing import TYPE_CHECKING, get_args
 
@@ -27,16 +28,6 @@ class DenseQArray(QArray):
 
     __qarray_matmul_priority__ = 0
 
-    def _replace(
-        self,
-        dims: tuple[int, ...] | None = None,
-        vectorized: bool | None = None,
-        data: Array | None = None,
-    ) -> DenseQArray:
-        if data is None:
-            data = self.data
-        return super()._replace(dims=dims, vectorized=vectorized, data=data)
-
     @property
     def dtype(self) -> jnp.dtype:
         return self.data.dtype
@@ -52,19 +43,19 @@ class DenseQArray(QArray):
     @property
     def mT(self) -> QArray:
         data = self.data.mT
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def conj(self) -> QArray:
         data = self.data.conj()
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def _reshape_unchecked(self, *shape: int) -> QArray:
         data = jnp.reshape(self.data, shape)
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def broadcast_to(self, *shape: int) -> QArray:
         data = jnp.broadcast_to(self.data, shape)
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def ptrace(self, *keep: int) -> QArray:
         from ..utils.general import ptrace
@@ -73,11 +64,11 @@ class DenseQArray(QArray):
 
     def powm(self, n: int) -> QArray:
         data = jnp.linalg.matrix_power(self.data, n)
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def expm(self, *, max_squarings: int = 16) -> QArray:
         data = jax.scipy.linalg.expm(self.data, max_squarings=max_squarings)
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def norm(self) -> Array:
         from ..utils.general import norm
@@ -94,7 +85,7 @@ class DenseQArray(QArray):
         if in_last_two_dims(axis, self.ndim):
             return data
         else:
-            return self._replace(data=data)
+            return replace(self, data=data)
 
     def squeeze(self, axis: int | tuple[int, ...] | None = None) -> QArray | Array:
         data = self.data.squeeze(axis=axis)
@@ -103,11 +94,11 @@ class DenseQArray(QArray):
         if in_last_two_dims(axis, self.ndim):
             return data
         else:
-            return self._replace(data=data)
+            return replace(self, data=data)
 
     def _eig(self) -> tuple[Array, QArray]:
         evals, evecs = jax.lax.linalg.eig(self.data, compute_left_eigenvectors=False)
-        return evals, self._replace(data=evecs)
+        return evals, replace(self, data=evecs)
 
     def _eigh(self) -> tuple[Array, Array]:
         return jnp.linalg.eigh(self.data)
@@ -153,7 +144,7 @@ class DenseQArray(QArray):
         super().__mul__(y)
 
         data = y * self.data
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def __add__(self, y: QArrayLike) -> QArray:
         if isinstance(y, int | float) and y == 0:
@@ -168,7 +159,7 @@ class DenseQArray(QArray):
         else:
             return NotImplemented
 
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
         super().__matmul__(y)
@@ -182,7 +173,7 @@ class DenseQArray(QArray):
         if self.isbra() and y.isket():
             return data
 
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def __rmatmul__(self, y: QArrayLike) -> QArray:
         super().__rmatmul__(y)
@@ -194,7 +185,7 @@ class DenseQArray(QArray):
         else:
             return NotImplemented
 
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def __and__(self, y: QArray) -> QArray:
         super().__and__(y)
@@ -205,11 +196,11 @@ class DenseQArray(QArray):
         else:
             return NotImplemented
 
-        return self._replace(dims=dims, data=data)
+        return replace(self, dims=dims, data=data)
 
     def addscalar(self, y: ArrayLike) -> QArray:
         data = self.data + to_jax(y)
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def elmul(self, y: QArrayLike) -> QArray:
         from .sparsedia_qarray import SparseDIAQArray
@@ -220,15 +211,15 @@ class DenseQArray(QArray):
             return y.elmul(self)
 
         data = self.data * to_jax(y)
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def elpow(self, power: int) -> QArray:
         data = self.data**power
-        return self._replace(data=data)
+        return replace(self, data=data)
 
     def __getitem__(self, key: int | slice) -> QArray:
         data = self.data[key]
-        return self._replace(data=data)
+        return replace(self, data=data)
 
 
 def array_to_qobj_list(x: Array, dims: tuple[int, ...]) -> Qobj | list[Qobj]:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -236,18 +236,6 @@ class QArray(eqx.Module):
     # similar behaviour to __array_priority__ but for qarray matmul
     __qarray_matmul_priority__ = 0
 
-    def _replace(
-        self,
-        dims: tuple[int, ...] | None = None,
-        vectorized: bool | None = None,
-        **kwargs,
-    ) -> QArray:
-        if dims is None:
-            dims = self.dims
-        if vectorized is None:
-            vectorized = self.vectorized
-        return type(self)(dims=dims, vectorized=vectorized, **kwargs)
-
     def __check_init__(self):
         # === ensure dims is a tuple of ints
         if not isinstance(self.dims, tuple) or not all(

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import warnings
+from dataclasses import replace
 
 import equinox as eqx
 import jax
@@ -46,21 +47,6 @@ class SparseDIAQArray(QArray):
 
     __qarray_matmul_priority__ = 10
 
-    def _replace(
-        self,
-        dims: tuple[int, ...] | None = None,
-        vectorized: bool | None = None,
-        offsets: tuple[int, ...] | None = None,
-        diags: Array | None = None,
-    ) -> SparseDIAQArray:
-        if offsets is None:
-            offsets = self.offsets
-        if diags is None:
-            diags = self.diags
-        return super()._replace(
-            dims=dims, vectorized=vectorized, offsets=offsets, diags=diags
-        )
-
     def __check_init__(self):
         # check diags and offsets have the right type and shape before compressing them
         if not isinstance(self.offsets, tuple):
@@ -101,7 +87,7 @@ class SparseDIAQArray(QArray):
     @property
     def mT(self) -> QArray:
         offsets, diags = transpose_sparsedia(self.offsets, self.diags)
-        return self._replace(offsets=offsets, diags=diags)
+        return replace(self, offsets=offsets, diags=diags)
 
     @property
     def ndiags(self) -> int:
@@ -109,11 +95,11 @@ class SparseDIAQArray(QArray):
 
     def conj(self) -> QArray:
         diags = self.diags.conj()
-        return self._replace(diags=diags)
+        return replace(self, diags=diags)
 
     def _reshape_unchecked(self, *shape: int) -> QArray:
         offsets, diags = reshape_sparsedia(self.offsets, self.diags, shape)
-        return self._replace(offsets=offsets, diags=diags)
+        return replace(self, offsets=offsets, diags=diags)
 
     def broadcast_to(self, *shape: int) -> QArray:
         if shape[-2:] != self.shape[-2:]:
@@ -123,14 +109,14 @@ class SparseDIAQArray(QArray):
             )
 
         offsets, diags = broadcast_sparsedia(self.offsets, self.diags, shape)
-        return self._replace(offsets=offsets, diags=diags)
+        return replace(self, offsets=offsets, diags=diags)
 
     def ptrace(self, *keep: int) -> QArray:
         raise NotImplementedError
 
     def powm(self, n: int) -> QArray:
         offsets, diags = powm_sparsedia(self.offsets, self.diags, n)
-        return self._replace(offsets=offsets, diags=diags)
+        return replace(self, offsets=offsets, diags=diags)
 
     def expm(self, *, max_squarings: int = 16) -> QArray:
         warnings.warn(
@@ -157,7 +143,7 @@ class SparseDIAQArray(QArray):
                 return self.to_jax().sum(axis)
         else:
             diags = self.diags.sum(axis)
-            return self._replace(diags=diags)
+            return replace(self, diags=diags)
 
     def squeeze(self, axis: int | tuple[int, ...] | None = None) -> QArray | Array:
         # return array if last two dimensions are modified, qarray otherwise
@@ -168,7 +154,7 @@ class SparseDIAQArray(QArray):
                 return self.to_jax().squeeze(axis)
         else:
             diags = self.diags.squeeze(axis)
-            return self._replace(diags=diags)
+            return replace(self, diags=diags)
 
     def _eig(self) -> tuple[Array, QArray]:
         warnings.warn(
@@ -256,7 +242,7 @@ class SparseDIAQArray(QArray):
         super().__mul__(y)
 
         diags = y * self.diags
-        return self._replace(diags=diags)
+        return replace(self, diags=diags)
 
     def __add__(self, y: QArrayLike) -> QArray:
         if isinstance(y, int | float) and y == 0:
@@ -268,7 +254,7 @@ class SparseDIAQArray(QArray):
             offsets, diags = add_sparsedia_sparsedia(
                 self.offsets, self.diags, y.offsets, y.diags
             )
-            return self._replace(offsets=offsets, diags=diags)
+            return replace(self, offsets=offsets, diags=diags)
         elif isqarraylike(y):
             warnings.warn(
                 'A sparse qarray has been converted to dense layout due to element-wise'
@@ -286,7 +272,7 @@ class SparseDIAQArray(QArray):
             offsets, diags = matmul_sparsedia_sparsedia(
                 self.offsets, self.diags, y.offsets, y.diags
             )
-            return self._replace(offsets=offsets, diags=diags)
+            return replace(self, offsets=offsets, diags=diags)
         elif isqarraylike(y):
             y = to_jax(y)
             data = matmul_sparsedia_array(self.offsets, self.diags, y)
@@ -310,7 +296,7 @@ class SparseDIAQArray(QArray):
                 self.offsets, self.diags, y.offsets, y.diags
             )
             dims = self.dims + y.dims
-            return self._replace(dims=dims, offsets=offsets, diags=diags)
+            return replace(self, dims=dims, offsets=offsets, diags=diags)
         elif isinstance(y, DenseQArray):
             return self.asdense() & y
 
@@ -340,11 +326,11 @@ class SparseDIAQArray(QArray):
         else:
             offsets, diags = mul_sparsedia_array(self.offsets, self.diags, to_jax(y))
 
-        return self._replace(offsets=offsets, diags=diags)
+        return replace(self, offsets=offsets, diags=diags)
 
     def elpow(self, power: int) -> QArray:
         diags = self.diags**power
-        return self._replace(diags=diags)
+        return replace(self, diags=diags)
 
     def __getitem__(self, key: int | slice | tuple) -> QArray:
         if key in (slice(None, None, None), Ellipsis):
@@ -352,7 +338,7 @@ class SparseDIAQArray(QArray):
 
         _check_key_in_batch_dims(key, self.ndim)
         diags = self.diags[key]
-        return self._replace(diags=diags)
+        return replace(self, diags=diags)
 
 
 def _check_key_in_batch_dims(key: int | slice | tuple, ndim: int):

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import replace
+
 import numpy as np
 
 from .._checks import check_shape
@@ -52,7 +54,7 @@ def operator_to_vector(x: QArrayLike) -> QArray:
     check_shape(x, 'x', '(..., n, n)')
     bshape = x.shape[:-2]
     x = x.mT._reshape_unchecked(*bshape, -1, 1)
-    return x._replace(vectorized=True)
+    return replace(x, vectorized=True)
 
 
 def vector_to_operator(x: QArrayLike) -> QArray:
@@ -89,9 +91,9 @@ def vector_to_operator(x: QArrayLike) -> QArray:
     check_shape(x, 'x', '(..., n^2, 1)')
     bshape = x.shape[:-2]
     n = int(np.sqrt(x.shape[-2]))
-    x = x._replace(dims=(n,))
+    x = replace(x, dims=(n,))
     x = x._reshape_unchecked(*bshape, n, n).mT
-    return x._replace(vectorized=False)
+    return replace(x, vectorized=False)
 
 
 def spre(x: QArrayLike) -> QArray:
@@ -117,7 +119,7 @@ def spre(x: QArrayLike) -> QArray:
     check_shape(x, 'x', '(..., n, n)')
     n = x.shape[-1]
     xpre = eye(n) & x
-    return xpre._replace(dims=x.dims, vectorized=True)
+    return replace(xpre, dims=x.dims, vectorized=True)
 
 
 def spost(x: QArrayLike) -> QArray:
@@ -143,7 +145,7 @@ def spost(x: QArrayLike) -> QArray:
     check_shape(x, 'x', '(..., n, n)')
     n = x.shape[-1]
     xpost = x.mT & eye(n)
-    return xpost._replace(dims=x.dims, vectorized=True)
+    return replace(xpost, dims=x.dims, vectorized=True)
 
 
 def sprepost(x: QArrayLike, y: QArrayLike) -> QArray:
@@ -171,7 +173,7 @@ def sprepost(x: QArrayLike, y: QArrayLike) -> QArray:
     check_shape(x, 'x', '(..., n, n)')
     check_shape(y, 'y', '(..., n, n)')
     xyprepost = y.mT & x
-    return xyprepost._replace(dims=x.dims, vectorized=True)
+    return replace(xyprepost, dims=x.dims, vectorized=True)
 
 
 def sdissipator(L: QArrayLike) -> QArray:


### PR DESCRIPTION
~~@gautierronan if you have an idea to make this work for static fields, we could also save a lot of code repetition by removing the qarrays `_replace()` method.~~ -> we use `dataclasses.replace`.