### PR TITLE
Expose `dq.plot.wigner_data()` to plot pre-computed wigner functions

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -244,6 +244,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - wigner
         - wigner_mosaic
         - wigner_gif
+        - wigner_data
         - pwc_pulse
         - fock
         - fock_evolution

--- a/dynamiqs/plot/__init__.py
+++ b/dynamiqs/plot/__init__.py
@@ -18,4 +18,5 @@ __all__ = [
     'wigner',
     'wigner_gif',
     'wigner_mosaic',
+    'wigner_data',
 ]

--- a/dynamiqs/plot/wigner.py
+++ b/dynamiqs/plot/wigner.py
@@ -30,10 +30,19 @@ def wigner_data(
     cross: bool = False,
     clear: bool = False,
 ):
-    r"""Plot the Wigner function for pre-computed Wigner data.
+    r"""Plot a pre-computed Wigner function.
+
+    Warning:
+        Documentation redaction in progress.
 
     Note:
-        See [`dq.plot.wigner()`][dynamiqs.plot.wigner] for more details.
+        Choose a diverging colormap `cmap` for better results.
+
+    See also:
+        - [`dq.wigner()`][dynamiqs.wigner]: compute the Wigner distribution of a ket or
+            density matrix.
+        - [`dq.plot.wigner()`][dynamiqs.plot.wigner]: plot the Wigner function of a
+            state.
     """
     w = to_jax(wigner)
     check_shape(w, 'wigner', '(n, n)')
@@ -107,6 +116,8 @@ def wigner(
         different from the default behaviour of `qutip.plot_wigner()`.
 
     See also:
+        - [`dq.wigner()`][dynamiqs.wigner]: compute the Wigner distribution of a ket or
+            density matrix.
         - [`dq.plot.wigner_data()`][dynamiqs.plot.wigner_data]: plot a pre-computed
             Wigner function.
 

--- a/dynamiqs/plot/wigner.py
+++ b/dynamiqs/plot/wigner.py
@@ -13,11 +13,11 @@ from ..qarrays.utils import asqarray, to_jax
 from ..utils import wigner as compute_wigner
 from .utils import add_colorbar, colors, gif_indices, gifit, grid, optional_ax
 
-__all__ = ['wigner', 'wigner_gif', 'wigner_mosaic']
+__all__ = ['wigner_data', 'wigner', 'wigner_gif', 'wigner_mosaic']
 
 
 @optional_ax
-def _plot_wigner_data(
+def wigner_data(
     wigner: ArrayLike,
     xmax: float,
     ymax: float,
@@ -30,8 +30,18 @@ def _plot_wigner_data(
     cross: bool = False,
     clear: bool = False,
 ):
+    r"""Plot the Wigner function for pre-computed Wigner data.
+
+    Note:
+        See [`dq.plot.wigner()`][dynamiqs.plot.wigner] for more details.
+    """
     w = to_jax(wigner)
     check_shape(w, 'wigner', '(n, n)')
+    if w.dtype not in (jnp.float32, jnp.float64):
+        raise TypeError(
+            f'Wigner data must be of type `float`, not `{w.dtype}`. Consider using'
+            f' `dq.plot.wigner(x)` to plot the Wigner function of a quantum state `x`.'
+        )
 
     # set plot norm
     vmin = -vmax
@@ -96,6 +106,10 @@ def wigner(
         coordinates $(x,y)=(\mathrm{Re}(\alpha),\mathrm{Im}(\alpha))$, which is
         different from the default behaviour of `qutip.plot_wigner()`.
 
+    See also:
+        - [`dq.plot.wigner_data()`][dynamiqs.plot.wigner_data]: plot a pre-computed
+            Wigner function.
+
     Examples:
         >>> psi = dq.coherent(16, 2.0)
         >>> dq.plot.wigner(psi)
@@ -127,7 +141,7 @@ def wigner(
     ymax = xmax if ymax is None else ymax
     _, _, w = compute_wigner(state, xmax, ymax, npixels)
 
-    _plot_wigner_data(
+    wigner_data(
         w,
         xmax,
         ymax,
@@ -216,7 +230,7 @@ def wigner_mosaic(
 
     # plot individual wigner
     for i, ax in enumerate(axs):
-        _plot_wigner_data(
+        wigner_data(
             wig[i],
             ax=ax,
             xmax=xmax,
@@ -288,7 +302,7 @@ def wigner_gif(
     indices = gif_indices(len(states), nframes)
     _, _, wig = compute_wigner(states[indices], xmax, ymax, npixels)
 
-    return gifit(_plot_wigner_data)(
+    return gifit(wigner_data)(
         wig,
         w=w,
         h=ymax / xmax * w,

--- a/dynamiqs/utils/wigner_utils.py
+++ b/dynamiqs/utils/wigner_utils.py
@@ -48,6 +48,12 @@ def wigner(
             - **yvec** _(array of shape (npixels,) or (nyvec,))_ -- $y$ coordinates, or
                 `yvec` if specified.
             - **w** _(array of shape (..., npixels, npixels) or (..., nyvec, nxvec))_ -- Wigner distribution.
+
+    See also:
+        - [`dq.plot.wigner()`][dynamiqs.plot.wigner]: plot the Wigner function of a
+            state.
+        - [`dq.plot.wigner_data()`][dynamiqs.plot.wigner_data]: plot a pre-computed
+            Wigner function.
     """  # noqa: E501
     state = to_jax(state)
     check_shape(state, 'state', '(..., n, 1)', '(..., n, n)')

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -291,6 +291,7 @@ nav:
               - wigner: python_api/plot/wigner.md
               - wigner_mosaic: python_api/plot/wigner_mosaic.md
               - wigner_gif: python_api/plot/wigner_gif.md
+              - wigner_data: python_api/plot/wigner_data.md
               - pwc_pulse: python_api/plot/pwc_pulse.md
               - fock: python_api/plot/fock.md
               - fock_evolution: python_api/plot/fock_evolution.md


### PR DESCRIPTION
I added a safeguard for people who are looking for `dq.plot.wigner()`.

```python
>>> import dynamiqs as dq
>>> rho = dq.coherent_dm(4, 1.0)
>>> dq.plot.wigner_data(rho, 2.0, 2.0)
TypeError: Wigner data must be of type `float`, not `complex64`. Consider using `dq.plot.wigner()` directly to pass a quantum state.
>>> x, y, w = dq.wigner(rho)
>>> dq.plot.wigner_data(w, x[-1], y[-1])
```