### PR TITLE
Fix significant performance issue of fixed-step stochastic jump solver

### DIFF
--- a/docs/documentation/advanced_examples/continuous-jump-measurement.md
+++ b/docs/documentation/advanced_examples/continuous-jump-measurement.md
@@ -30,10 +30,10 @@ jump_ops = [dq.sigmam(), dq.sigmap()]
 psi0 = dq.excited()
 
 # define save times
-tsave = np.linspace(0, 1.0, 101)
+tsave = np.linspace(0, 2.0, 101)
 
 # define a certain number of PRNG key, one for each trajectory
-key = jax.random.PRNGKey(20)
+key = jax.random.PRNGKey(42)
 ntrajs = 3
 keys = jax.random.split(key, ntrajs)
 

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -195,7 +195,9 @@ class JumpState(SDEState):
     """State for the jump SSE/SME fixed step integrators."""
 
     state: QArray  # state (integrated from initial to current time)
-    clicks: Array  # click times of shape (nsteps)
+    # click indicator of shape (nsteps): 0 = no click, i + 1 = click of the i-th jump
+    # operator
+    clicks: Array
     step_idx: int  # step index
 
 
@@ -225,7 +227,8 @@ class JumpSolveFixedStepIntegrator(StochasticSolveFixedStepIntegrator):
     def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
         saved = super().postprocess_saved(saved, ylast.state)
 
-        # convert array of click value at each time to array of clicktimes, for example:
+        # convert array of click indicators at each step to array of clicktimes, for
+        # example:
         #   times = [0, 10, 20, 30, 40, 50]
         #   clicks = [0, 1, 0, 1, 0, 2]
         #   => clicktimes = [[10, 30, nan, ...], [50, nan, nan, ...]]


### PR DESCRIPTION
This fixes a major performance issue with our fixed-step jump solvers. On CPU, the replacement of `jax.lax.cond` by `jax.lax.select` (see e.g. https://github.com/jax-ml/jax/issues/7934) leads to a x100 speedup for trajectories simulation of a qubit.

| Number of trajectories | Duration before the PR         | Duration after the PR | Speedup |
|---------------|---------------------|----------------|-|
| 1,000    |      12.7 s ± 1.36 s  | 119 ms ± 8.87 ms    | x106            |
| 10,000           | 158 s (1 run)      |       1.1 s ± 186 ms          |  x144 |
| 100,000           | ??     | 13.1 s ± 1.54 s per loop        | ??|

The new perfs on GPU are quite impressive:
| Number of trajectories | Duration after the PR (GPU) |
|---------------|---------------------|
| 1,000 | 27.5 ms ± 258 μs per loop |
| 10,000 | 50 ms ± 137 μs per loop |
| 100,000 | 185 ms ± 609 μs per loop |

<details>
  <summary>Benchmark code</summary>

```python
import dynamiqs as dq
import numpy as np
import jax

H = dq.zeros(2)
jump_ops = [dq.sigmam(), dq.sigmap()]
psi0 = dq.excited()
tsave = np.linspace(0, 2.0, 101)
key = jax.random.PRNGKey(42)
method = dq.method.EulerJump(dt=1e-3)
for ntrajs in [int(1e3), int(1e4)]:
    keys = jax.random.split(key, ntrajs)

    def foo():
        return dq.jssesolve(
            H, jump_ops, psi0, tsave, keys, method=method
        ).states.block_until_ready()

    %timeit -r1 -n1 -q foo()
    %timeit foo()
```

</details>

There is another speedup to implement for `jssesolve` vs `jsmesolve`, the same as #911. I can do it once this PR is merged.