### PR TITLE
Fix (again) matrix multiplication dense @ sparse

### DIFF
--- a/dynamiqs/qarrays/dense_qarray.py
+++ b/dynamiqs/qarrays/dense_qarray.py
@@ -162,7 +162,10 @@ class DenseQArray(QArray):
         return replace(self, data=data)
 
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
-        super().__matmul__(y)
+        out = super().__matmul__(y)
+        if out is NotImplemented:
+            return NotImplemented
+
         if isinstance(y, DenseQArray):
             data = self.data @ y.data
         elif isqarraylike(y):

--- a/dynamiqs/qarrays/sparsedia_qarray.py
+++ b/dynamiqs/qarrays/sparsedia_qarray.py
@@ -266,7 +266,9 @@ class SparseDIAQArray(QArray):
         return NotImplemented
 
     def __matmul__(self, y: QArrayLike) -> QArray:
-        super().__matmul__(y)
+        out = super().__matmul__(y)
+        if out is NotImplemented:
+            return NotImplemented
 
         if isinstance(y, SparseDIAQArray):
             offsets, diags = matmul_sparsedia_sparsedia(


### PR DESCRIPTION
Bug solved in #924 but re-introduced by #928.

Benchmark results for `H @ rho @ H` with H sparse dia (3 diagonals) on CPU (mac M1)
```
=== n = 16
41.8 μs ± 2.26 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
47.6 μs ± 9.13 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
=== n = 32
45.3 μs ± 7.93 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
45.3 μs ± 5.43 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
=== n = 64
65 μs ± 4.83 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
43.1 μs ± 3.62 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
=== n = 128
178 μs ± 8.64 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
60.9 μs ± 4.65 μs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
=== n = 256
929 μs ± 35.1 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
221 μs ± 31.3 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
=== n = 512
7.23 ms ± 856 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
728 μs ± 263 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

Benchmark results for `H @ rho @ H` with H sparse dia (3 diagonals) on GPU (L40S)
```
=== n = 256
262 μs ± 2.52 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
239 μs ± 3.82 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
=== n = 512
262 μs ± 941 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
217 μs ± 5.95 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
=== n = 1024
654 μs ± 14.4 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
225 μs ± 945 ns per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

<details>
  <summary>Benchmark code</summary>

```python
import dynamiqs as dq
import jax


@jax.jit
def matmul(H, rho):
    return H @ rho @ H


for n in [16, 32, 64, 128, 256, 512]:
    print(f'=== n = {n}')
    a = dq.destroy(n)
    H = a.dag() @ a + a + a.dag()

    key = jax.random.PRNGKey(42)
    rho = dq.random.dm(key, (n, n))

    H = H.asdense()
    %timeit -r1 -n1 -q matmul(H, rho).block_until_ready()
    %timeit matmul(H, rho).block_until_ready()

    H = H.assparsedia()
    %timeit -r1 -n1 -q matmul(H, rho).block_until_ready()
    %timeit matmul(H, rho).block_until_ready()
```

</details>