### PR TITLE
Add `__repr__` to composite qarrays

### DIFF
--- a/dynamiqs/qarrays/composite_qarray.py
+++ b/dynamiqs/qarrays/composite_qarray.py
@@ -91,6 +91,10 @@ class CompositeQArray(QArray):
         terms = [tuple(factor.mT for factor in term) for term in self.terms]
         return replace(self, terms=terms)
 
+    @property
+    def nterms(self) -> int:
+        return len(self.terms)
+
     def conj(self) -> QArray:
         terms = [tuple(factor.conj() for factor in term) for term in self.terms]
         return replace(self, terms=terms)
@@ -201,6 +205,12 @@ class CompositeQArray(QArray):
     def block_until_ready(self) -> QArray:
         _ = self._first_factor.block_until_ready()
         return self
+
+    def __repr__(self) -> str:
+        return (
+            f'QArray: shape={self.shape}, dims={self.dims}, dtype={self.dtype}, '
+            f'type=composite, nterms={self.nterms}'
+        )
 
     def __mul__(self, y: ArrayLike) -> QArray:
         super().__mul__(y)


### PR DESCRIPTION
This is temporary, we need to revamp our use of the terminology "layout" in all the doc. I've avoided using it here to avoid confusion, and opted for "type" for now.