### PR TITLE
Lift deprecated upper JAX version constraint (<0.5.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "tqdm",
-    "jax>=0.4.36,<0.5.3", # >=0.4.36 for GPU eig support
+    "jax>=0.4.36", # >=0.4.36 for GPU eig support
     "jaxtyping",
     "diffrax>=0.6.1",  # for complex support (0.5.0), progress meter (0.5.1), compatibility with jax 0.4.36 (0.6.1)
     "equinox",


### PR DESCRIPTION
Closes #996.