### PR TITLE
Restrict JAX version to <0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "numpy",
     "matplotlib",
     "tqdm",
-    "jax>=0.4.36", # >=0.4.36 for GPU eig support
+    "jax>=0.4.36,<0.7", # >=0.4.36 for GPU eig support, <0.7 to avoid breaking changes (temporary)
     "jaxtyping",
     "diffrax>=0.6.1",  # for complex support (0.5.0), progress meter (0.5.1), compatibility with jax 0.4.36 (0.6.1)
     "equinox",


### PR DESCRIPTION
See https://github.com/jax-ml/jax/releases/tag/jax-v0.7.0. Especially
> The minimum Python version is now 3.11.