### PR TITLE
Fix asqarray compatibility with qutip v5.2.0 auto_tidyup_dims

### DIFF
--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -99,7 +99,9 @@ def get_dims(x: QArrayLike) -> tuple[int, ...] | None:
             dims = np.max(x.dims, axis=0)
         else:
             # Use the longer dimension list (typically the ket space)
-            dims = np.array(x.dims[0] if len(x.dims[0]) >= len(x.dims[1]) else x.dims[1])
+            dims = np.array(
+                x.dims[0] if len(x.dims[0]) >= len(x.dims[1]) else x.dims[1]
+            )
         return tuple(dims.tolist())
     else:
         return None

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -93,16 +93,9 @@ def get_dims(x: QArrayLike) -> tuple[int, ...] | None:
     if isinstance(x, QArray):
         return x.dims
     elif isinstance(x, Qobj):
-        # Handle qutip v5.2.0 auto_tidyup_dims that can create unequal length dims
-        # e.g., [[3, 2], [1, 1]] -> [[3, 2], [1]]
-        if len(x.dims[0]) == len(x.dims[1]):
-            dims = np.max(x.dims, axis=0)
-        else:
-            # Use the longer dimension list (typically the ket space)
-            dims = np.array(
-                x.dims[0] if len(x.dims[0]) >= len(x.dims[1]) else x.dims[1]
-            )
-        return tuple(dims.tolist())
+        # handle [[3, 2], [1, 1]] or [[1, 1], [3, 2]] when `auto_tidyup_dims=False`
+        # or [[3, 2], [1]] or [[1], [3, 2]] when `auto_tidyup_dims=True`
+        return tuple(next(dims for dims in x.dims if set(dims) != {1}))
     else:
         return None
 

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -93,7 +93,13 @@ def get_dims(x: QArrayLike) -> tuple[int, ...] | None:
     if isinstance(x, QArray):
         return x.dims
     elif isinstance(x, Qobj):
-        dims = np.max(x.dims, axis=0)
+        # Handle qutip v5.2.0 auto_tidyup_dims that can create unequal length dims
+        # e.g., [[3, 2], [1, 1]] -> [[3, 2], [1]]
+        if len(x.dims[0]) == len(x.dims[1]):
+            dims = np.max(x.dims, axis=0)
+        else:
+            # Use the longer dimension list (typically the ket space)
+            dims = np.array(x.dims[0] if len(x.dims[0]) >= len(x.dims[1]) else x.dims[1])
         return tuple(dims.tolist())
     else:
         return None

--- a/tests/qarrays/test_utils.py
+++ b/tests/qarrays/test_utils.py
@@ -98,7 +98,7 @@ def test_conversions(layout):
 @pytest.mark.run(order=TEST_INSTANT)
 def test_qutip_tensor_compatibility():
     """Test compatibility with qutip v5.2.0 auto_tidyup_dims.
-    
+
     In qutip v5.2.0, tensor products with trivial dimensions are automatically
     simplified, e.g., [[3, 2], [1, 1]] -> [[3, 2], [1]]. This test ensures
     that asqarray handles such cases correctly.
@@ -108,19 +108,19 @@ def test_qutip_tensor_compatibility():
     result = dq.asqarray(basis_state)
     assert result.shape == (3, 1)
     assert result.dims == (3,)
-    
+
     # Test tensor product (the problematic case)
     tensor_state = qt.tensor(qt.basis(3, 0), qt.basis(2, 1))
     result = dq.asqarray(tensor_state)
     assert result.shape == (6, 1)
     assert result.dims == (3, 2)
-    
+
     # Test more complex tensor product
     complex_tensor = qt.tensor(qt.basis(2, 0), qt.basis(3, 1), qt.basis(2, 0))
     result = dq.asqarray(complex_tensor)
     assert result.shape == (12, 1)
     assert result.dims == (2, 3, 2)
-    
+
     # Test that the tensor product has correct values
     tensor_result = dq.asqarray(qt.tensor(qt.basis(3, 0), qt.basis(2, 1)))
     expected_tensor = jnp.zeros((6, 1), dtype=complex)


### PR DESCRIPTION
Address #1011 by making `get_dims` robust to varying lengths in the first and second entries of  `QObj.dims`.