### PR TITLE
Add a `vectorized` option to mesolve

### DIFF
--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -127,6 +127,7 @@ def mesolve(
                     progress_meter: AbstractProgressMeter | bool | None = None,
                     t0: ScalarLike | None = None,
                     save_extra: callable[[Array], PyTree] | None = None,
+                    vectorized: bool = False,
                 )
                 ```
 
@@ -152,6 +153,11 @@ def mesolve(
                     `f(QArray) -> PyTree` that takes a state as input and returns a
                     PyTree. This can be used to save additional arbitrary data
                     during the integration, accessible in `result.extra`.
+                - **vectorized** - If `True`, the master equation is solved by
+                    vectorizing the density matrix and Liouvillian. This is usually
+                    more efficient for small Hilbert spaces but less efficient for
+                    large Hilbert spaces. This option is only supported for
+                    Diffrax-based ODE methods.
 
     Returns:
         `dq.MESolveResult` object holding the result of the

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -280,8 +280,12 @@ sesolve_kvaerno5_integrator_constructor = partial(
 )
 
 
-class MEDiffraxIntegrator(DiffraxIntegrator, MEInterface):
-    """Integrator solving the Lindblad master equation with Diffrax."""
+class MESolveDiffraxIntegrator(
+    DiffraxIntegrator, MEInterface, SolveSaveMixin, SolveInterface
+):
+    """Integrator computing the time evolution of the Lindblad master equation using the
+    Diffrax library.
+    """
 
     @property
     def terms(self) -> dx.AbstractTerm:
@@ -311,12 +315,6 @@ class MEDiffraxIntegrator(DiffraxIntegrator, MEInterface):
             return tmp + tmp.dag()
 
         return dx.ODETerm(vector_field)
-
-
-class MESolveDiffraxIntegrator(MEDiffraxIntegrator, SolveSaveMixin, SolveInterface):
-    """Integrator computing the time evolution of the Lindblad master equation using the
-    Diffrax library.
-    """
 
     def __post_init__(self):
         # convert y0 to a density matrix

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -351,7 +351,7 @@ class JSMESolveEulerJumpIntegrator(JSMESolveFixedStepIntegrator):
         rho_click = Ccal_rho[jump_idx] * normalisation
 
         # === no click
-        # compute Lcal(rho), see `MEDiffraxIntegrator` in
+        # compute Lcal(rho), see `MESolveDiffraxIntegrator` in
         # `integrators/core/diffrax_integrator.py`
         Hnh = -1j * H - 0.5 * sum(L.dag() @ L)
         tmp = Hnh @ rho + 0.5 * sum(Lm_rho_Lmdag)
@@ -540,7 +540,7 @@ class DSMESolveEulerMayuramaIntegrator(DSMEFixedStepIntegrator):
         LdL = sum([_L.dag() @ _L for _L in L])
 
         # === Lcal(rho)
-        # (see MEDiffraxIntegrator in `integrators/core/diffrax_integrator.py`)
+        # (see MESolveDiffraxIntegrator in `integrators/core/diffrax_integrator.py`)
         Hnh = -1j * H - 0.5 * LdL
         tmp = Hnh @ rho + sum([0.5 * _L @ rho @ _L.dag() for _L in L])
         Lcal_rho = tmp + tmp.dag()

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -20,6 +20,7 @@ class Options(eqx.Module):
     t0: ScalarLike | None = None
     save_extra: callable[[QArray], PyTree] | None = None
     nmaxclick: int = 10_000
+    vectorized: bool = False
 
     def __init__(
         self,
@@ -30,6 +31,7 @@ class Options(eqx.Module):
         t0: ScalarLike | None = None,
         save_extra: callable[[QArray], PyTree] | None = None,
         nmaxclick: int = 10_000,
+        vectorized: bool = False,
     ):
         self.save_states = save_states
         self.save_propagators = save_propagators
@@ -37,6 +39,7 @@ class Options(eqx.Module):
         self.progress_meter = progress_meter
         self.t0 = t0
         self.nmaxclick = nmaxclick
+        self.vectorized = vectorized
 
         # make `save_extra` a valid Pytree with `Partial`
         self.save_extra = jtu.Partial(save_extra) if save_extra is not None else None
@@ -64,6 +67,7 @@ class Options(eqx.Module):
             t0=self.t0,
             save_extra=self.save_extra,
             nmaxclick=self.nmaxclick,
+            vectorized=self.vectorized,
         )
 
 
@@ -82,6 +86,7 @@ def check_options(options: Options, solver_name: str):
             'progress_meter',
             't0',
             'save_extra',
+            'vectorized',
         ),
         'sepropagator': ('save_propagators', 'progress_meter', 't0', 'save_extra'),
         'mepropagator': ('save_propagators', 'cartesian_batching', 't0', 'save_extra'),

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -1,5 +1,6 @@
 import pytest
 
+from dynamiqs import Options
 from dynamiqs.gradient import BackwardCheckpointed, Direct, Forward
 from dynamiqs.method import Tsit5
 
@@ -13,8 +14,10 @@ from .open_system import dense_ocavity, dia_ocavity, otdqubit
 @pytest.mark.run(order=TEST_LONG)
 class TestMESolveAdaptive(IntegratorTester):
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
-    def test_correctness(self, system):
-        self._test_correctness(system, Tsit5())
+    @pytest.mark.parametrize('vectorized', [True, False])
+    def test_correctness(self, system, vectorized):
+        options = Options(vectorized=vectorized)
+        self._test_correctness(system, Tsit5(), options=options)
 
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct(), BackwardCheckpointed(), Forward()])


### PR DESCRIPTION
A rather straightforward PR to implement the `vectorized` option to `mesolve`.

The speedup is not particularly impressive however (non-existant in my benchmark actually):
```text
Vectorized, dense: 1.96 ms ± 69.9 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
Unvectorized, dense: 4.1 ms ± 1.03 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)
Vectorized, dia: 2.01 ms ± 55.1 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
Unvectorized, dia: 1.88 ms ± 20.6 μs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

It is likely that we need to improve the code of `slindbladian` and underlying functions to get better speed improvements, cc @derekeverett.

<details>
<summary>Benchmark code: time-dependent pi-pulse on a two-level system</summary>

```python
import dynamiqs as dq
import jax.numpy as jnp
from jax.scipy.special import erf
from functools import partial

# set global layout
dq.set_layout('dia')

def pulse(t, T, sigma):
    """Gaussian pulse ansatz."""
    angle = jnp.pi / 2
    norm = jnp.sqrt(2 * jnp.pi) * sigma * T * erf(1 / (2 * jnp.sqrt(2) * sigma))
    gaussian = jnp.exp(-(t - T / 2)**2 / (2 * T**2 * sigma**2))
    return angle * gaussian / norm

# simulation parameters
T1 = 0.01
Tphi = 0.01
nth = 0.1
sigma = 0.2
T = 1.0
ntsave = 11

# time-dependent Hamiltonian
f = partial(pulse, T=T, sigma=sigma)
H = dq.modulated(f, dq.sigmax())

# other mesolve inputs
jump_ops = [
    jnp.sqrt(1 / T1) * dq.sigmam(),
    jnp.sqrt(1 / Tphi) * dq.sigmaz(),
    jnp.sqrt(nth / T1) * dq.sigmap()
]
psi0 = dq.ground()
tsave = jnp.linspace(0.0, T, ntsave)
exp_ops = [dq.ground_dm(), dq.excited_dm()]

# vectorized form
options = dq.Options(vectorized=True, progress_meter=False)
%timeit -n1 -r1 -q dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=options)
%timeit dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=options)

# unvectorized form
options = dq.Options(vectorized=False, progress_meter=False)
%timeit -n1 -r1 -q dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=options)
%timeit dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=options)
```

</details>
