### PR TITLE
Support static tsave to JIT stochastic solvers

### DIFF
--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -115,22 +115,3 @@ def check_qarray_is_dense(x: QArray, argname: str):
             f'Argument {argname} must have layout `dense` but has layout '
             f'{argname}.layout={x.layout}.'
         )
-
-def check_times_static(x: tuple[float, ...], argname: str, allow_empty: bool = False) -> tuple[float, ...]:
-    # check that a tuple of times is valid (must be sorted strictly ascending)
-
-    if not isinstance(x, tuple):
-        raise TypeError(f"Argument {argname} must be a tuple, but got {type(x)}.")
-
-    if not all(isinstance(v, (int, float)) for v in x):
-        raise TypeError(f"All elements of {argname} must be int or float.")
-
-    if not allow_empty and len(x) == 0:
-        raise ValueError(f"Argument {argname} must contain at least one element.")
-
-    if any(x[i] >= x[i+1] for i in range(len(x)-1)):
-        raise ValueError(
-            f"Argument {argname} must be sorted in strictly ascending order."
-        )
-
-    return x

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -115,3 +115,22 @@ def check_qarray_is_dense(x: QArray, argname: str):
             f'Argument {argname} must have layout `dense` but has layout '
             f'{argname}.layout={x.layout}.'
         )
+
+def check_times_static(x: tuple[float, ...], argname: str, allow_empty: bool = False) -> tuple[float, ...]:
+    # check that a tuple of times is valid (must be sorted strictly ascending)
+
+    if not isinstance(x, tuple):
+        raise TypeError(f"Argument {argname} must be a tuple, but got {type(x)}.")
+
+    if not all(isinstance(v, (int, float)) for v in x):
+        raise TypeError(f"All elements of {argname} must be int or float.")
+
+    if not allow_empty and len(x) == 0:
+        raise ValueError(f"Argument {argname} must contain at least one element.")
+
+    if any(x[i] >= x[i+1] for i in range(len(x)-1)):
+        raise ValueError(
+            f"Argument {argname} must be sorted in strictly ascending order."
+        )
+
+    return x

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import ArrayLike, PRNGKeyArray
 
-from ..._checks import check_shape, check_times, check_times_static
+from ..._checks import check_shape, check_times_static
 from ...gradient import Gradient
 from ...method import EulerMaruyama, Method, Rouchon1
 from ...options import Options, check_options

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -264,8 +264,8 @@ def dssesolve(
 
     # === check arguments
     _check_dssesolve_args(H, Ls, psi0, exp_ops)
-    check_times(jnp.asarray(tsave), "tsave")  # keep?
-    check_options(options, "dssesolve")
+    check_times(jnp.asarray(tsave), 'tsave')  # keep?
+    check_options(options, 'dssesolve')
     options = options.initialise()
 
     # allows ArrayLike objects when non jitted
@@ -273,7 +273,7 @@ def dssesolve(
         tsave = tuple(tsave.tolist())
 
     if method is None:
-        raise ValueError("Argument `method` must be specified.")
+        raise ValueError('Argument `method` must be specified.')
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to JAX arrays
@@ -283,7 +283,7 @@ def dssesolve(
 
 
 @catch_xla_runtime_error
-@partial(jax.jit, static_argnames=("tsave", "gradient", "options"))
+@partial(jax.jit, static_argnames=('tsave', 'gradient', 'options'))
 def _vectorized_dssesolve(
     H: TimeQArray,
     Ls: list[TimeQArray],
@@ -381,22 +381,22 @@ def _check_dssesolve_args(
     H: TimeQArray, Ls: list[TimeQArray], psi0: QArray, exp_ops: list[QArray] | None
 ):
     # === check H shape
-    check_shape(H, "H", "(..., n, n)", subs={"...": "...H"})
+    check_shape(H, 'H', '(..., n, n)', subs={'...': '...H'})
 
     # === check Ls shape
     for i, L in enumerate(Ls):
-        check_shape(L, f"jump_ops[{i}]", "(..., n, n)", subs={"...": f"...L{i}"})
+        check_shape(L, f'jump_ops[{i}]', '(..., n, n)', subs={'...': f'...L{i}'})
 
     if len(Ls) == 0:
         raise ValueError(
-            "Argument `jump_ops` is an empty list, consider using `dq.sesolve()` to"
-            " solve the Schrödinger equation."
+            'Argument `jump_ops` is an empty list, consider using `dq.sesolve()` to'
+            ' solve the Schrödinger equation.'
         )
 
     # === check psi0 shape
-    check_shape(psi0, "psi0", "(..., n, 1)", subs={"...": "...psi0"})
+    check_shape(psi0, 'psi0', '(..., n, 1)', subs={'...': '...psi0'})
 
     # === check exp_ops shape
     if exp_ops is not None:
         for i, E in enumerate(exp_ops):
-            check_shape(E, f"exp_ops[{i}]", "(n, n)")
+            check_shape(E, f'exp_ops[{i}]', '(n, n)')

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -89,7 +89,8 @@ def dssesolve(
 
     Warning:
         For now, `dssesolve()` only supports linearly spaced `tsave` with values that
-        are exact multiples of the method fixed step size `dt`.
+        are exact multiples of the method fixed step size `dt`. Moreover, to JIT-compile
+        code using `dssesolve()`, `tsave` must be passed as tuple.
 
     Note:
         If you are only interested in simulating trajectories to solve the Lindblad

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -105,8 +105,7 @@ def dssesolve(
         tsave _(array-like of shape (ntsave,))_: Times at which the states and
             expectation values are saved. The equation is solved from `tsave[0]` to
             `tsave[-1]`. Measurements are time-averaged and saved over each interval
-            defined by `tsave`. If jitting is used, `tsave` is a static argument and
-            must be passed as a tuple.
+            defined by `tsave`.
         keys _(list of PRNG keys)_: PRNG keys used to sample the Wiener processes.
             The number of elements defines the number of sampled stochastic
             trajectories.

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import ArrayLike, PRNGKeyArray
 
-from ..._checks import check_shape, check_times
+from ..._checks import check_shape, check_times, check_times_static
 from ...gradient import Gradient
 from ...method import EulerMaruyama, Method, Rouchon1
 from ...options import Options, check_options
@@ -263,14 +263,13 @@ def dssesolve(
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === check arguments
-    _check_dssesolve_args(H, Ls, psi0, exp_ops)
-    check_times(jnp.asarray(tsave), 'tsave')  # keep?
-    check_options(options, 'dssesolve')
-    options = options.initialise()
-
-    # allows ArrayLike objects when non jitted
+     # allows ArrayLike objects when non jitted
     if not isinstance(tsave, tuple):
         tsave = tuple(tsave.tolist())
+    check_times_static(tsave, 'tsave')
+    _check_dssesolve_args(H, Ls, psi0, exp_ops) 
+    check_options(options, 'dssesolve')
+    options = options.initialise()
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -4,6 +4,7 @@ from functools import partial
 
 import jax
 import jax.numpy as jnp
+from jax import Array
 from jaxtyping import ArrayLike, PRNGKeyArray
 
 from ..._checks import check_shape, check_times_static
@@ -287,7 +288,7 @@ def _vectorized_dssesolve(
     H: TimeQArray,
     Ls: list[TimeQArray],
     psi0: QArray,
-    tsave: tuple[float],
+    tsave: Array,
     keys: PRNGKeyArray,
     exp_ops: list[QArray] | None,
     method: Method,
@@ -319,7 +320,7 @@ def _dssesolve_many_trajectories(
     H: TimeQArray,
     Ls: list[TimeQArray],
     psi0: QArray,
-    tsave: tuple[float],
+    tsave: Array,
     keys: PRNGKeyArray,
     exp_ops: list[QArray] | None,
     method: Method,
@@ -337,7 +338,7 @@ def _dssesolve_single_trajectory(
     H: TimeQArray,
     Ls: list[TimeQArray],
     psi0: QArray,
-    tsave: tuple[float],
+    tsave: Array,
     key: PRNGKeyArray,
     exp_ops: list[QArray] | None,
     method: Method,


### PR DESCRIPTION
Fix the issue where `tsave` was converted to an array and then to a tuple, which made stochastic solvers non-JIT compatible. The temporary fix is to bypass this conversion when `tsave` is explicitly passed as a tuple. Note that if a tuple is passed, we do not perform checks on `tsave`.

<details>
  <summary>Old description</summary>


## Summary
Make `tsave` a **static** argument (accepting `tuple[float]`) so `dssesolve` can be JIT-compiled without hash errors.

## What changed
- Accept `tuple[float]` for `tsave`.
- New static validation `check_times_static(tsave)`.
- Minor typing/doc cleanups.

## Why
Prevents `ValueError: Non-hashable static arguments` and allows JIT’ing `dssesolve`.

## Backwards compatibility
- **Non-JIT calls still accept `ArrayLike`** for `tsave`; it’s converted internally (e.g., `jnp.ndarray`/`list` → `tuple`) before calling the jitted wrapper.
- No behavioral change to the solver.

## Usage
```python
# jit compile with tsave marked static
jitted_dssesolve = jax.jit(dq.dssesolve, static_argnames=("tsave",))
jitted_eqx_dssesolve = equinox.filter_jit(dq.dssesolve) # No static argnames
```

</details>
