### PR TITLE
Cache decompositions in low rank integrator

### DIFF
--- a/dynamiqs/integrators/core/low_rank_integrator.py
+++ b/dynamiqs/integrators/core/low_rank_integrator.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import warnings
 from functools import partial
+from typing import Any
 
 import diffrax as dx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-import lineax as lx
+import jax.scipy.linalg as jsp_linalg
 from jax import Array
 from jaxtyping import PyTree
 
@@ -22,18 +23,72 @@ from .interfaces import MEInterface, SolveInterface
 from .save_mixin import SolveSaveMixin
 
 
-def qr_solve(A: Array, B: Array) -> Array:
-    operator = lx.MatrixLinearOperator(A)
+def _qr_cache(A: Array) -> tuple[Array, Array]:
+    # Cache the QR factorization once per vector-field evaluation.
+    # We do this explicitly so that AD uses the JVP rule below instead of
+    # differentiating through the QR decomposition.
+    q, r = jnp.linalg.qr(A, mode='reduced')
+    q = jax.lax.stop_gradient(q)
+    r = jax.lax.stop_gradient(r)
+    return q, r
 
-    def solve_single(b: Array) -> Array:
-        return lx.linear_solve(operator, b, throw=False, solver=lx.QR()).value
 
-    return jax.vmap(solve_single, in_axes=1, out_axes=1)(B)  # vmap over columns of B
+def _cholesky_cache(A: Array) -> Array:
+    # Precompute A^+ = (A^H A)^-1 A^H once per vector-field evaluation.
+    A_pinv = jsp_linalg.solve(A.conj().T @ A, A.conj().T, assume_a='pos')
+    return jax.lax.stop_gradient(A_pinv)
 
 
-def cholesky_solve(A: Array, B: Array) -> Array:
-    A_pinv = jax.scipy.linalg.solve(A.conj().T @ A, A.conj().T, assume_a='pos')
+def _qr_pinv_apply(cache: tuple[Array, Array], rhs: Array) -> Array:
+    q, r = cache
+    return jsp_linalg.solve_triangular(r, q.conj().T @ rhs, lower=False)
+
+
+def _qr_pinv_h_apply(cache: tuple[Array, Array], rhs: Array) -> Array:
+    q, r = cache
+    # (A^+)^H rhs = Q (R^{-H} rhs), where A = Q R.
+    return q @ jsp_linalg.solve_triangular(r, rhs, trans='C', lower=False)
+
+
+@jax.custom_jvp
+def _qr_solve_cached(A: Array, cache: tuple[Array, Array], B: Array) -> Array:
+    del A
+    return _qr_pinv_apply(cache, B)
+
+
+@_qr_solve_cached.defjvp
+def _qr_solve_cached_jvp(
+    primals: tuple[Any, ...], tangents: tuple[Any, ...]
+) -> tuple[Array, Array]:
+    A, cache, B = primals
+    dA, _dcache, dB = tangents
+    x = _qr_solve_cached(A, cache, B)
+    # Pseudoinverse JVP formula (independent columns):
+    # dX = A^+ (dB - dA X + (A^+)^H (dA^H (B - A X))).
+    res = B - A @ x
+    dvec = dB - dA @ x + _qr_pinv_h_apply(cache, dA.conj().T @ res)
+    dx = _qr_pinv_apply(cache, dvec)
+    return x, dx
+
+
+@jax.custom_jvp
+def _cholesky_solve_cached(A: Array, A_pinv: Array, B: Array) -> Array:
+    del A
     return A_pinv @ B
+
+
+@_cholesky_solve_cached.defjvp
+def _cholesky_solve_cached_jvp(
+    primals: tuple[Any, ...], tangents: tuple[Any, ...]
+) -> tuple[Array, Array]:
+    A, A_pinv, B = primals
+    dA, _dA_pinv, dB = tangents
+    x = _cholesky_solve_cached(A, A_pinv, B)
+    # Same pseudoinverse formula as the QR path, but using cached A^+.
+    res = B - A @ x
+    dvec = dB - dA @ x + A_pinv.conj().T @ (dA.conj().T @ res)
+    dx = A_pinv @ dvec
+    return x, dx
 
 
 def normalize_m(m: Array) -> Array:
@@ -181,21 +236,25 @@ class MESolveLowRankIntegrator(
             rho0 = self.y0.todm().to_jax()
             m0 = initialize_m0_from_dm(rho0, self.method.rank, eps, self.method.key)
 
-        # define diffrax term
         linear_solvers = {
-            LinearSolver.CHOLESKY: cholesky_solve,
-            LinearSolver.QR: qr_solve,
+            LinearSolver.CHOLESKY: (_cholesky_cache, _cholesky_solve_cached),
+            LinearSolver.QR: (_qr_cache, _qr_solve_cached),
         }
-        linsolve = linear_solvers[self.method.linear_solver]
+        # Keep solver selection outside the ODE RHS loop while carrying both pieces
+        # required by the cached solve: (cache_builder, linsolve_with_cache).
+        solver_cache_builder, linsolve = linear_solvers[self.method.linear_solver]
 
         def vector_field(t, m, _):  # noqa: ANN001, ANN202
             H = self.H(t)
             Ls = [L(t) for L in self.Ls]
             dm = (-1j) * (H @ m).to_jax()
+            # `m` is fixed for this vector-field evaluation, so we compute and reuse
+            # the decomposition/pseudoinverse across all jump operators.
+            solve_cache = solver_cache_builder(m)
 
             for L in Ls:
                 Lm = (L @ m).to_jax()
-                tmp = linsolve(m, Lm)
+                tmp = linsolve(m, solve_cache, Lm)
                 dm += 0.5 * (Lm @ tmp.conj().T) - 0.5 * (L.dag() @ Lm).to_jax()
 
             return dm

--- a/dynamiqs/integrators/core/low_rank_integrator.py
+++ b/dynamiqs/integrators/core/low_rank_integrator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import warnings
 from functools import partial
-from typing import Any
 
 import diffrax as dx
 import equinox as eqx
@@ -35,60 +34,68 @@ def _qr_cache(A: Array) -> tuple[Array, Array]:
 
 def _cholesky_cache(A: Array) -> Array:
     # Precompute A^+ = (A^H A)^-1 A^H once per vector-field evaluation.
-    A_pinv = jsp_linalg.solve(A.conj().T @ A, A.conj().T, assume_a='pos')
-    return jax.lax.stop_gradient(A_pinv)
+    a_pseudoinverse = jsp_linalg.solve(A.conj().T @ A, A.conj().T, assume_a='pos')
+    return jax.lax.stop_gradient(a_pseudoinverse)
 
 
-def _qr_pinv_apply(cache: tuple[Array, Array], rhs: Array) -> Array:
+def _qr_pseudoinverse_apply(cache: tuple[Array, Array], rhs: Array) -> Array:
     q, r = cache
     return jsp_linalg.solve_triangular(r, q.conj().T @ rhs, lower=False)
 
 
-def _qr_pinv_h_apply(cache: tuple[Array, Array], rhs: Array) -> Array:
+def _qr_pseudoinverse_adjoint_apply(cache: tuple[Array, Array], rhs: Array) -> Array:
     q, r = cache
     # (A^+)^H rhs = Q (R^{-H} rhs), where A = Q R.
     return q @ jsp_linalg.solve_triangular(r, rhs, trans='C', lower=False)
 
 
+# TODO: Extend these cached custom JVP rules to higher-order AD
 @jax.custom_jvp
 def _qr_solve_cached(A: Array, cache: tuple[Array, Array], B: Array) -> Array:
     del A
-    return _qr_pinv_apply(cache, B)
+    return _qr_pseudoinverse_apply(cache, B)
 
 
 @_qr_solve_cached.defjvp
 def _qr_solve_cached_jvp(
-    primals: tuple[Any, ...], tangents: tuple[Any, ...]
+    primals: tuple[Array, tuple[Array, Array], Array],
+    tangents: tuple[Array, tuple[Array, Array], Array],
 ) -> tuple[Array, Array]:
     A, cache, B = primals
-    dA, _dcache, dB = tangents
-    x = _qr_solve_cached(A, cache, B)
+    dA, _cache_tangent, dB = tangents
+    solution = _qr_solve_cached(A, cache, B)
     # Pseudoinverse JVP formula (independent columns):
     # dX = A^+ (dB - dA X + (A^+)^H (dA^H (B - A X))).
-    res = B - A @ x
-    dvec = dB - dA @ x + _qr_pinv_h_apply(cache, dA.conj().T @ res)
-    dx = _qr_pinv_apply(cache, dvec)
-    return x, dx
+    residual = B - A @ solution
+    tangent_rhs = (
+        dB
+        - dA @ solution
+        + _qr_pseudoinverse_adjoint_apply(cache, dA.conj().T @ residual)
+    )
+    solution_tangent = _qr_pseudoinverse_apply(cache, tangent_rhs)
+    return solution, solution_tangent
 
 
 @jax.custom_jvp
-def _cholesky_solve_cached(A: Array, A_pinv: Array, B: Array) -> Array:
+def _cholesky_solve_cached(A: Array, a_pseudoinverse: Array, B: Array) -> Array:
     del A
-    return A_pinv @ B
+    return a_pseudoinverse @ B
 
 
 @_cholesky_solve_cached.defjvp
 def _cholesky_solve_cached_jvp(
-    primals: tuple[Any, ...], tangents: tuple[Any, ...]
+    primals: tuple[Array, Array, Array], tangents: tuple[Array, Array, Array]
 ) -> tuple[Array, Array]:
-    A, A_pinv, B = primals
-    dA, _dA_pinv, dB = tangents
-    x = _cholesky_solve_cached(A, A_pinv, B)
+    A, a_pseudoinverse, B = primals
+    dA, _pseudoinverse_tangent, dB = tangents
+    solution = _cholesky_solve_cached(A, a_pseudoinverse, B)
     # Same pseudoinverse formula as the QR path, but using cached A^+.
-    res = B - A @ x
-    dvec = dB - dA @ x + A_pinv.conj().T @ (dA.conj().T @ res)
-    dx = A_pinv @ dvec
-    return x, dx
+    residual = B - A @ solution
+    tangent_rhs = (
+        dB - dA @ solution + a_pseudoinverse.conj().T @ (dA.conj().T @ residual)
+    )
+    solution_tangent = a_pseudoinverse @ tangent_rhs
+    return solution, solution_tangent
 
 
 def normalize_m(m: Array) -> Array:
@@ -253,9 +260,10 @@ class MESolveLowRankIntegrator(
             solve_cache = solver_cache_builder(m)
 
             for L in Ls:
-                Lm = (L @ m).to_jax()
-                tmp = linsolve(m, solve_cache, Lm)
-                dm += 0.5 * (Lm @ tmp.conj().T) - 0.5 * (L.dag() @ Lm).to_jax()
+                jump_action = (L @ m).to_jax()
+                projected_jump_action = linsolve(m, solve_cache, jump_action)
+                dm += 0.5 * (jump_action @ projected_jump_action.conj().T)
+                dm -= 0.5 * (L.dag() @ jump_action).to_jax()
 
             return dm
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
     "cmap",
     "ipython",
     "tqdm",
-    "lineax",
 ]
 
 [project.urls]

--- a/tests/mesolve/test_adaptive_lowrank.py
+++ b/tests/mesolve/test_adaptive_lowrank.py
@@ -5,7 +5,7 @@ import pytest
 import dynamiqs as dq
 from dynamiqs import Options
 from dynamiqs.gradient import BackwardCheckpointed, Direct, Forward
-from dynamiqs.method import LowRank, Tsit5
+from dynamiqs.method import LinearSolver, LowRank, Tsit5
 
 from ..integrator_tester import IntegratorTester
 from ..order import TEST_LONG
@@ -24,9 +24,14 @@ def _double_precision():
     dq.set_precision('double' if prev_x64 else 'single')
 
 
-def _lowrank_method(system):
+def _lowrank_method(system, linear_solver=LinearSolver.QR):
     rank = 2 if system is otdqubit else system.n // 2
-    return LowRank(rank=rank, ode_method=Tsit5(), key=jax.random.PRNGKey(0))
+    return LowRank(
+        rank=rank,
+        ode_method=Tsit5(),
+        linear_solver=linear_solver,
+        key=jax.random.PRNGKey(0),
+    )
 
 
 @pytest.mark.run(order=TEST_LONG)
@@ -35,15 +40,19 @@ class TestMESolveAdaptiveLowRank(IntegratorTester):
         with pytest.raises(TypeError):
             LowRank(rank=2, ode_method=Tsit5())
 
+    @pytest.mark.parametrize('linear_solver', [LinearSolver.QR, LinearSolver.CHOLESKY])
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
-    def test_correctness(self, system):
+    def test_correctness(self, system, linear_solver):
         options = Options()
-        self._test_correctness(system, _lowrank_method(system), options=options)
+        self._test_correctness(
+            system, _lowrank_method(system, linear_solver), options=options
+        )
 
+    @pytest.mark.parametrize('linear_solver', [LinearSolver.QR, LinearSolver.CHOLESKY])
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct(), BackwardCheckpointed(), Forward()])
-    def test_gradient(self, system, gradient):
-        self._test_gradient(system, _lowrank_method(system), gradient)
+    def test_gradient(self, system, gradient, linear_solver):
+        self._test_gradient(system, _lowrank_method(system, linear_solver), gradient)
 
     @pytest.mark.parametrize('system', [dense_ocavity])
     def test_lowrank_states(self, system):


### PR DESCRIPTION
This PR caches the QR decomposition or pseudoinverse in `MESolveLowRankIntegrator`, so that these expensive operations are performed only once per evaluation of the field. This leads to a significant performance improvement when many jump operators are present.

To accomplish this while keeping AD compatibility, the dependency on `lineax` has been dropped, while reimplementing the relevant rules directly.