### PR TITLE
Rouchon4 integrator

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -71,6 +71,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - Rouchon1
         - Rouchon2
         - Rouchon3
+        - Rouchon4
         - Expm
         - Event
         - JumpMonteCarlo

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -24,6 +24,7 @@ from ...method import (
     Rouchon1,
     Rouchon2,
     Rouchon3,
+    Rouchon4,
     Tsit5,
 )
 from ...options import Options, check_options
@@ -56,6 +57,7 @@ from ..core.rouchon_integrator import (
     mesolve_rouchon1_integrator_constructor,
     mesolve_rouchon2_integrator_constructor,
     mesolve_rouchon3_integrator_constructor,
+    mesolve_rouchon4_integrator_constructor,
 )
 
 
@@ -112,6 +114,7 @@ def mesolve(
             [`Rouchon1`][dynamiqs.method.Rouchon1],
             [`Rouchon2`][dynamiqs.method.Rouchon2],
             [`Rouchon3`][dynamiqs.method.Rouchon3],
+            [`Rouchon4`][dynamiqs.method.Rouchon4],
             [`Expm`][dynamiqs.method.Expm],
             [`JumpMonteCarlo`][dynamiqs.method.JumpMonteCarlo],
             [`DiffusiveMonteCarlo`][dynamiqs.method.DiffusiveMonteCarlo],
@@ -352,6 +355,7 @@ def _mesolve(
         Rouchon1: mesolve_rouchon1_integrator_constructor,
         Rouchon2: mesolve_rouchon2_integrator_constructor,
         Rouchon3: mesolve_rouchon3_integrator_constructor,
+        Rouchon4: mesolve_rouchon4_integrator_constructor,
         Dopri5: mesolve_dopri5_integrator_constructor,
         Dopri8: mesolve_dopri8_integrator_constructor,
         Tsit5: mesolve_tsit5_integrator_constructor,

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import replace
+from typing import ClassVar
 
 import diffrax as dx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import numpy as np
 from diffrax import AbstractRungeKutta, Bosh3, Euler, Midpoint, ODETerm
 from diffrax._custom_types import VF, Args, Control, RealScalarLike, Y
 from diffrax._local_interpolation import LocalLinearInterpolation

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -12,7 +12,13 @@ import jax.numpy as jnp
 import numpy as np
 from diffrax import AbstractRungeKutta, Bosh3, Euler, Midpoint, ODETerm
 from diffrax._custom_types import VF, Args, Control, RealScalarLike, Y
-from diffrax._local_interpolation import LocalLinearInterpolation
+from diffrax._local_interpolation import (
+    LocalLinearInterpolation,
+    ThirdOrderHermitePolynomialInterpolation,
+)
+from diffrax._solver.runge_kutta import AbstractERK, ButcherTableau
+from equinox.internal import ω  # noqa: PLC2403
+from jaxtyping import Array, ArrayLike, PyTree, Shaped
 
 from ...gradient import Forward
 from ...qarrays.layout import dense
@@ -22,18 +28,9 @@ from ...result import MESolveResult
 from ...utils.operators import eye
 from .diffrax_integrator import MESolveDiffraxIntegrator
 
-from diffrax._local_interpolation import (
-    LocalLinearInterpolation,
-    ThirdOrderHermitePolynomialInterpolation,
-)
-from diffrax._solver.runge_kutta import AbstractERK, ButcherTableau
-from equinox.internal import ω  # noqa: PLC2403
-from jaxtyping import Array, ArrayLike, PyTree, Shaped
-
-
 # === Custom RK4 solver =======================================
 # diffrax does not include a 4th-order RK solver, so we define one using
-# its AbstractERK + ButcherTableau infrastructure. This is the Zonneveld RK4 
+# its AbstractERK + ButcherTableau infrastructure. This is the Zonneveld RK4
 # tableau, which is a known 4th-order Rouchon method.
 
 _Zonneveld4_tableau = ButcherTableau(
@@ -53,7 +50,7 @@ _Zonneveld4_tableau = ButcherTableau(
 
 # Custom interpolation class to extract the right stages based on
 # diffrax's ThirdOrderHermitePolynomialInterpolation. Due to the structure
-#  of _Zonneveld4_tableau, whose last stage is at c=3/4, we need to extract 
+#  of _Zonneveld4_tableau, whose last stage is at c=3/4, we need to extract
 # the k stages at indices 0 and -2 to get the correct interpolation
 class CustomThirdOrderHermitePolynomialInterpolation(
     ThirdOrderHermitePolynomialInterpolation
@@ -81,6 +78,7 @@ class Zonnenveld4(AbstractERK):
 
     def order(self, _terms):  # noqa: ANN001, ANN201
         return 4
+
 
 class AbstractRouchonTerm(dx.AbstractTerm):
     # this class bypasses the typical Diffrax term implementation, as Rouchon schemes
@@ -362,6 +360,7 @@ class KrausHeun3(KrausMapRK):
     _A = ((0.0, 0.0, 0.0), (1 / 3, 0.0, 0.0), (0.0, 2 / 3, 0.0))
     _b = (0.25, 0.0, 0.75)
 
+
 class KrausRK4(KrausMapRK):
     r"""Fourth-order Rouchon method based on the classic RK4 method.
 
@@ -383,6 +382,7 @@ class KrausRK4(KrausMapRK):
         (0.0, 0.0, 1.0, 0.0),
     )
     _b = (1 / 6, 1 / 3, 1 / 3, 1 / 6)
+
 
 class RouchonPropertiesMixin:
     """Mixin providing shared properties for Rouchon integrators.
@@ -532,7 +532,8 @@ class MESolveFixedRouchon3Integrator(MESolveFixedRouchonIntegrator):
     @property
     def nojump_diffrax_solver(self) -> dx.AbstractSolver:
         return Bosh3()
-    
+
+
 class MESolveFixedRouchon4Integrator(MESolveFixedRouchonIntegrator):
     """Fixed step Rouchon 4 (RK4) integrator for the Lindblad master equation."""
 
@@ -696,7 +697,8 @@ class MESolveAdaptiveRouchon3Integrator(MESolveAdaptiveRouchonIntegrator):
         # Midpoint interpolation needs the k stages from Bosh3
         k = dense_info_high['k']
         return dict(y0=y0, y1=y1_low, k=k[:2])
-    
+
+
 class MESolveAdaptiveRouchon4Integrator(MESolveAdaptiveRouchonIntegrator):
     """Adaptive Rouchon 3-4 integrator with embedded dense outputs from ClassicRK4."""
 
@@ -711,7 +713,6 @@ class MESolveAdaptiveRouchon4Integrator(MESolveAdaptiveRouchonIntegrator):
         # Bosh3 interpolation needs k stages; reuse first 4 from ClassicRK4
         k = dense_info_high['k']
         return dict(y0=y0, y1=y1_low, k=k[:4])
-
 
 
 mesolve_rouchon1_integrator_constructor = lambda **kwargs: (

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -20,6 +20,65 @@ from ...result import MESolveResult
 from ...utils.operators import eye
 from .diffrax_integrator import MESolveDiffraxIntegrator
 
+from diffrax._local_interpolation import (
+    LocalLinearInterpolation,
+    ThirdOrderHermitePolynomialInterpolation,
+)
+from diffrax._solver.runge_kutta import AbstractERK, ButcherTableau
+from equinox.internal import ω  # noqa: PLC2403
+from jaxtyping import Array, ArrayLike, PyTree, Shaped
+
+
+# === Custom RK4 solver =======================================
+# diffrax does not include a 4th-order RK solver, so we define one using
+# its AbstractERK + ButcherTableau infrastructure. This is the Zonneveld RK4 
+# tableau, which is a known 4th-order Rouchon method.
+
+_Zonneveld4_tableau = ButcherTableau(
+    a_lower=(
+        np.array([1 / 2]),
+        np.array([0.0, 1 / 2]),
+        np.array([0.0, 0.0, 1.0]),
+        np.array([5 / 32, 7 / 32, 13 / 32, -1 / 32]),
+    ),
+    b_sol=np.array([1 / 6, 1 / 3, 1 / 3, 1 / 6, 0.0]),
+    b_error=np.array(
+        [1 / 6 + 1 / 2, 1 / 3 - 7 / 3, 1 / 3 - 7 / 3, 1 / 6 - 13 / 6, 0.0 + 16 / 3]
+    ),
+    c=np.array([1 / 2, 1 / 2, 1.0, 3 / 4]),
+)
+
+
+# Custom interpolation class to extract the right stages based on
+# diffrax's ThirdOrderHermitePolynomialInterpolation. Due to the structure
+#  of _Zonneveld4_tableau, whose last stage is at c=3/4, we need to extract 
+# the k stages at indices 0 and -2 to get the correct interpolation
+class CustomThirdOrderHermitePolynomialInterpolation(
+    ThirdOrderHermitePolynomialInterpolation
+):
+    @classmethod
+    def from_k(
+        cls,
+        *,
+        t0: RealScalarLike,
+        t1: RealScalarLike,
+        y0: PyTree[Shaped[ArrayLike, ' ?*dims'], Y],  # noqa: F722
+        y1: PyTree[Shaped[ArrayLike, ' ?*dims'], Y],  # noqa: F722
+        k: PyTree[Shaped[Array, 'order ?*dims'], Y],  # noqa: F722
+    ) -> ThirdOrderHermitePolynomialInterpolation:
+        return cls(t0=t0, t1=t1, y0=y0, y1=y1, k0=ω(k)[0].ω, k1=ω(k)[-2].ω)
+
+
+class Zonnenveld4(AbstractERK):
+    """Classic 4th-order Runge-Kutta with embedded 3rd-order error estimate."""
+
+    tableau: ClassVar[ButcherTableau] = _Zonneveld4_tableau
+    interpolation_cls: ClassVar[
+        Callable[..., ThirdOrderHermitePolynomialInterpolation]
+    ] = CustomThirdOrderHermitePolynomialInterpolation.from_k
+
+    def order(self, _terms):  # noqa: ANN001, ANN201
+        return 4
 
 class AbstractRouchonTerm(dx.AbstractTerm):
     # this class bypasses the typical Diffrax term implementation, as Rouchon schemes
@@ -301,6 +360,27 @@ class KrausHeun3(KrausMapRK):
     _A = ((0.0, 0.0, 0.0), (1 / 3, 0.0, 0.0), (0.0, 2 / 3, 0.0))
     _b = (0.25, 0.0, 0.75)
 
+class KrausRK4(KrausMapRK):
+    r"""Fourth-order Rouchon method based on the classic RK4 method.
+
+    Butcher tableau::
+
+        0     |
+        1/2   | 1/2
+        1/2   | 0     1/2
+        1     | 0     0     1
+        ---------------------------
+              | 1/6   1/3   1/3   1/6
+    """
+
+    _c = (0.0, 0.5, 0.5, 1.0)
+    _A = (
+        (0.0, 0.0, 0.0, 0.0),
+        (0.5, 0.0, 0.0, 0.0),
+        (0.0, 0.5, 0.0, 0.0),
+        (0.0, 0.0, 1.0, 0.0),
+    )
+    _b = (1 / 6, 1 / 3, 1 / 3, 1 / 6)
 
 class RouchonPropertiesMixin:
     """Mixin providing shared properties for Rouchon integrators.
@@ -450,6 +530,15 @@ class MESolveFixedRouchon3Integrator(MESolveFixedRouchonIntegrator):
     @property
     def nojump_diffrax_solver(self) -> dx.AbstractSolver:
         return Bosh3()
+    
+class MESolveFixedRouchon4Integrator(MESolveFixedRouchonIntegrator):
+    """Fixed step Rouchon 4 (RK4) integrator for the Lindblad master equation."""
+
+    _kraus_map_cls = KrausRK4
+
+    @property
+    def nojump_diffrax_solver(self) -> dx.AbstractSolver:
+        return Zonnenveld4()
 
 
 class MESolveAdaptiveRouchonIntegrator(
@@ -605,6 +694,22 @@ class MESolveAdaptiveRouchon3Integrator(MESolveAdaptiveRouchonIntegrator):
         # Midpoint interpolation needs the k stages from Bosh3
         k = dense_info_high['k']
         return dict(y0=y0, y1=y1_low, k=k[:2])
+    
+class MESolveAdaptiveRouchon4Integrator(MESolveAdaptiveRouchonIntegrator):
+    """Adaptive Rouchon 3-4 integrator with embedded dense outputs from ClassicRK4."""
+
+    _solver_low = Bosh3()
+    _solver_high = Zonnenveld4()
+    _fixed_cls_low = MESolveFixedRouchon3Integrator
+    _fixed_cls_high = MESolveFixedRouchon4Integrator
+
+    def _build_dense_info_low(
+        self, y0: QArray, y1_low: QArray, dense_info_high: dict
+    ) -> dict:
+        # Bosh3 interpolation needs k stages; reuse first 4 from ClassicRK4
+        k = dense_info_high['k']
+        return dict(y0=y0, y1=y1_low, k=k[:4])
+
 
 
 mesolve_rouchon1_integrator_constructor = lambda **kwargs: (
@@ -646,6 +751,23 @@ def mesolve_rouchon3_integrator_constructor(**kwargs) -> MESolveDiffraxIntegrato
     return MESolveAdaptiveRouchon3Integrator(
         **kwargs,
         diffrax_solver=AdaptiveRouchonDXSolver(3),
+        fixed_step=False,
+        result_class=MESolveResult,
+    )
+
+
+def mesolve_rouchon4_integrator_constructor(**kwargs) -> MESolveDiffraxIntegrator:
+    """Factory function to create a Rouchon4 integrator."""
+    if kwargs['method'].dt is not None:
+        return MESolveFixedRouchon4Integrator(
+            **kwargs,
+            diffrax_solver=RouchonDXSolver(4),
+            fixed_step=True,
+            result_class=MESolveResult,
+        )
+    return MESolveAdaptiveRouchon4Integrator(
+        **kwargs,
+        diffrax_solver=AdaptiveRouchonDXSolver(4),
         fixed_step=False,
         result_class=MESolveResult,
     )

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -27,6 +27,7 @@ __all__ = [
     'Rouchon1',
     'Rouchon2',
     'Rouchon3',
+    'Rouchon4',
     'Tsit5',
     'Event',
     'Method',
@@ -351,6 +352,64 @@ class Rouchon3(_DEFixedStep, _DEAdaptiveStep):
             self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
         )
         self.normalize = normalize
+
+class Rouchon4(_DEFixedStep, _DEAdaptiveStep):
+    r"""Fourth-order Rouchon method (fixed or adaptive step size ODE method).
+
+    Note:
+        By default the scheme is using adaptive step size. The error is estimated
+        using the difference between the third-order and fourth-order. To use a fixed
+        step size fourth-order method (without evaluating the third-order), set the `dt`
+        argument.
+
+    Args:
+        rtol: Relative tolerance.
+        atol: Absolute tolerance.
+        safety_factor: Safety factor for adaptive step sizing.
+        min_factor: Minimum factor for adaptive step sizing.
+        max_factor: Maximum factor for adaptive step sizing.
+        max_steps: Maximum number of steps.
+        dt: Fixed time step, if specified all arguments specific to adaptive step sizing
+            are ignored (`rtol`, `atol`, `safety_factor`, `min_factor`, `max_factor`
+            and `max_steps`).
+        normalize: If True, the scheme is trace-preserving to machine precision, which
+            is the recommended option because it is much more stable. Otherwise, it is
+            only trace-preserving to the scheme order in the numerical step size.
+
+    Note-: Supported gradients
+        This method supports differentiation with
+        [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
+        [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
+        (default)
+        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+    """
+
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
+        Direct,
+        BackwardCheckpointed,
+        Forward,
+    )
+
+    normalize: bool = eqx.field(static=True, default=True)
+
+    # dummy init to have the signature in the documentation
+    def __init__(
+        self,
+        rtol: float = 1e-6,
+        atol: float = 1e-6,
+        safety_factor: float = 0.9,
+        min_factor: float = 0.2,
+        max_factor: float = 5.0,
+        max_steps: int = 100_000,
+        dt: float | None = None,
+        normalize: bool = True,
+    ):
+        _DEFixedStep.__init__(self, dt)  # ty: ignore[invalid-argument-type]
+        _DEAdaptiveStep.__init__(
+            self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
+        )
+        self.normalize = normalize
+
 
 
 class Dopri5(_DEAdaptiveStep):

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -353,6 +353,7 @@ class Rouchon3(_DEFixedStep, _DEAdaptiveStep):
         )
         self.normalize = normalize
 
+
 class Rouchon4(_DEFixedStep, _DEAdaptiveStep):
     r"""Fourth-order Rouchon method (fixed or adaptive step size ODE method).
 
@@ -409,7 +410,6 @@ class Rouchon4(_DEFixedStep, _DEAdaptiveStep):
             self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
         )
         self.normalize = normalize
-
 
 
 class Dopri5(_DEAdaptiveStep):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -182,6 +182,7 @@ nav:
               - Rouchon1: python_api/method/Rouchon1.md
               - Rouchon2: python_api/method/Rouchon2.md
               - Rouchon3: python_api/method/Rouchon3.md
+              - Rouchon4: python_api/method/Rouchon4.md
               - Expm: python_api/method/Expm.md
               - Event: python_api/method/Event.md
               - JumpMonteCarlo: python_api/method/JumpMonteCarlo.md

--- a/tests/mesolve/test_adaptive_rouchon.py
+++ b/tests/mesolve/test_adaptive_rouchon.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dynamiqs.gradient import Direct
-from dynamiqs.method import Rouchon2, Rouchon3
+from dynamiqs.method import Rouchon2, Rouchon3, Rouchon4
 
 from ..integrator_tester import IntegratorTester
 from ..order import TEST_LONG
@@ -14,12 +14,12 @@ from ..systems import dense_ocavity, otdqubit
 
 @pytest.mark.run(order=TEST_LONG)
 class TestMESolveAdaptiveRouchon(IntegratorTester):
-    @pytest.mark.parametrize('method_class', [Rouchon2, Rouchon3])
+    @pytest.mark.parametrize('method_class', [Rouchon2, Rouchon3, Rouchon4])
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     def test_correctness(self, method_class, system):
         self._test_correctness(system, method_class())
 
-    @pytest.mark.parametrize('method_class', [Rouchon2])
+    @pytest.mark.parametrize('method_class', [Rouchon2, Rouchon3, Rouchon4])
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct()])
     def test_gradient(self, method_class, system, gradient):

--- a/tests/mesolve/test_fixed_rouchon.py
+++ b/tests/mesolve/test_fixed_rouchon.py
@@ -15,7 +15,10 @@ from ..systems import dense_ocavity, otdqubit
 @pytest.mark.run(order=TEST_LONG)
 class TestMESolveFixedRouchon(IntegratorTester):
     @pytest.mark.parametrize(
-        ('method_class', 'dt'), [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2), (Rouchon4, 1e-2)]
+        ('method_class', 'dt'), [(Rouchon1, 1e-4), 
+                                 (Rouchon2, 1e-3), 
+                                 (Rouchon3, 1e-2), 
+                                 (Rouchon4, 1e-2)]
     )
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     def test_correctness(self, method_class, dt, system):
@@ -23,7 +26,10 @@ class TestMESolveFixedRouchon(IntegratorTester):
         self._test_correctness(system, method)
 
     @pytest.mark.parametrize(
-        ('method_class', 'dt'), [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2), (Rouchon4, 1e-2)]
+        ('method_class', 'dt'), [(Rouchon1, 1e-4), 
+                                 (Rouchon2, 1e-3), 
+                                 (Rouchon3, 1e-2), 
+                                 (Rouchon4, 1e-2)]
     )
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct(), BackwardCheckpointed(), Forward()])

--- a/tests/mesolve/test_fixed_rouchon.py
+++ b/tests/mesolve/test_fixed_rouchon.py
@@ -15,10 +15,8 @@ from ..systems import dense_ocavity, otdqubit
 @pytest.mark.run(order=TEST_LONG)
 class TestMESolveFixedRouchon(IntegratorTester):
     @pytest.mark.parametrize(
-        ('method_class', 'dt'), [(Rouchon1, 1e-4), 
-                                 (Rouchon2, 1e-3), 
-                                 (Rouchon3, 1e-2), 
-                                 (Rouchon4, 1e-2)]
+        ('method_class', 'dt'),
+        [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2), (Rouchon4, 1e-2)],
     )
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     def test_correctness(self, method_class, dt, system):
@@ -26,10 +24,8 @@ class TestMESolveFixedRouchon(IntegratorTester):
         self._test_correctness(system, method)
 
     @pytest.mark.parametrize(
-        ('method_class', 'dt'), [(Rouchon1, 1e-4), 
-                                 (Rouchon2, 1e-3), 
-                                 (Rouchon3, 1e-2), 
-                                 (Rouchon4, 1e-2)]
+        ('method_class', 'dt'),
+        [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2), (Rouchon4, 1e-2)],
     )
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct(), BackwardCheckpointed(), Forward()])

--- a/tests/mesolve/test_fixed_rouchon.py
+++ b/tests/mesolve/test_fixed_rouchon.py
@@ -1,7 +1,7 @@
 import pytest
 
 from dynamiqs.gradient import BackwardCheckpointed, Direct, Forward
-from dynamiqs.method import Rouchon1, Rouchon2, Rouchon3
+from dynamiqs.method import Rouchon1, Rouchon2, Rouchon3, Rouchon4
 
 from ..integrator_tester import IntegratorTester
 from ..order import TEST_LONG
@@ -15,7 +15,7 @@ from ..systems import dense_ocavity, otdqubit
 @pytest.mark.run(order=TEST_LONG)
 class TestMESolveFixedRouchon(IntegratorTester):
     @pytest.mark.parametrize(
-        ('method_class', 'dt'), [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2)]
+        ('method_class', 'dt'), [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2), (Rouchon4, 1e-2)]
     )
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     def test_correctness(self, method_class, dt, system):
@@ -23,7 +23,7 @@ class TestMESolveFixedRouchon(IntegratorTester):
         self._test_correctness(system, method)
 
     @pytest.mark.parametrize(
-        ('method_class', 'dt'), [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2)]
+        ('method_class', 'dt'), [(Rouchon1, 1e-4), (Rouchon2, 1e-3), (Rouchon3, 1e-2), (Rouchon4, 1e-2)]
     )
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct(), BackwardCheckpointed(), Forward()])


### PR DESCRIPTION
Add Rouchon4 integrator. Since diffrax does not have an order 4 integrator, I created a custom here. Runge-Kutta fourth order methods with embedded order 3 are surprisingly hard to find. I implemented Zonneveld 4(3) from this book
[Solving Ordinary Differential Equations I, Ernst Hairer, Gerhard Wanner and Syvert P. Nørsett](https://link.springer.com/book/10.1007/978-3-540-78862-1) for the no-jump evolution.

The tests pass with around the same tolerance as for Rouchon3, but this is not in the regimes where order 4 is truly better (see appended notebook).
[tests_rouchon_rk4_custom.ipynb](https://github.com/user-attachments/files/26312048/tests_rouchon_rk4_custom.ipynb)
