### PR TITLE
perf(sparsedia): cut slindbladian cold-call XLA compile fan-out

### DIFF
--- a/dynamiqs/qarrays/sparsedia_primitives.py
+++ b/dynamiqs/qarrays/sparsedia_primitives.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from functools import partial, reduce
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 from jax._src.core import concrete_or_error
@@ -120,6 +121,7 @@ def mul_sparsedia_array(
     return offsets, out_diags
 
 
+@partial(jax.jit, static_argnums=0)
 def sparsedia_to_array(offsets: tuple[int, ...], diags: Array) -> Array:
     out = jnp.zeros(shape_sparsedia(diags), dtype=diags.dtype)
     for i, offset in enumerate(offsets):

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import jax
 import numpy as np
 
 from .._checks import check_shape
@@ -210,6 +211,7 @@ def sdissipator(L: QArrayLike) -> QArray:
     return sprepost(L, Ldag) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
 
 
+@jax.jit
 def slindbladian(H: QArrayLike, jump_ops: list[QArrayLike]) -> QArray:
     r"""Returns the Lindbladian superoperator (in matrix form).
 


### PR DESCRIPTION
This PR wraps `slindbladian` and `sparsedia_to_array` in `jax.jit`. 

## Benchmark

18 cases, JAX 0.10.0 / complex128 / Apple M3 MacBook (macOS 14.5, 16 GB RAM, CPU-only), isolated venv (only `jax==0.10.0` + `dynamiqs`):

| metric (sum across 18 cases)              | before | after | ratio |
|-------------------------------------------|-------:|------:|------:|
| `dq.slindbladian(H, jumps)` first-call    |  28.1s | 4.87s |  5.8× |
| `.to_jax()` first-call                    |  54.4s | 2.13s | 25.6× |
| total `jit(...)` compiles                 |  2 375 |   891 |  2.7× |
| total compile wall-time                   |  48.3s | 16.0s |  3.0× |

Sparse `slindbladian` first-call:

| case            | before | after | ratio |   | case          | before | after | ratio |
|-----------------|-------:|------:|------:|---|---------------|-------:|------:|------:|
| kerr n=4        | 0.88s  | 0.19s | 4.7× |   | two-mode 8×8  | 1.07s  | 0.26s | 4.1× |
| kerr n=16       | 0.71s  | 0.17s | 4.2× |   | two-mode 12×12| 1.51s  | 0.28s | 5.4× |
| kerr n=64       | 0.86s  | 0.18s | 4.7× |   | 4-qubit       | 2.30s  | 0.43s | 5.3× |
| JC n=16         | 0.76s  | 0.19s | 4.0× |   | **5-qubit**   | 6.10s  | 0.42s | **14.5×** |
| JC n=32         | 1.16s  | 0.25s | 4.6× |   | **6-qubit**   | 4.52s  | 0.57s | 7.9× |

`.to_jax()` first-call (the more dramatic gains, since `sparsedia_to_array`'s per-offset loop was the heaviest pre-patch fan-out):

| case          | before | after | ratio |
|---------------|-------:|------:|------:|
| **two-mode 12×12** | 43.97s | 0.91s | **49×** |
| 6-qubit       | 4.54s  | 0.39s | 12×   |
| kerr n=64     | 0.43s  | 0.09s | 5.0×  |

## Reproducer

Full bench script reproducing the tables above (`python bench.py`):

```python
import time

import jax
from jax import config

config.update("jax_enable_x64", True)
import dynamiqs as dq


def t(label, fn):
    t0 = time.perf_counter()
    out = fn()
    jax.block_until_ready(out)
    print(f"  {label:30s} {time.perf_counter() - t0:7.3f}s")
    return out


def kerr(n):
    a = dq.destroy(n)
    return a.dag() @ a + 0.1 * (a.dag() @ a.dag() @ a @ a) + 0.5 * (a + a.dag()), [a]


def jc(n):
    a = dq.tensor(dq.destroy(n), dq.eye(2))
    sp = dq.tensor(dq.eye(n), dq.sigmap())
    sm = dq.tensor(dq.eye(n), dq.sigmam())
    sz = dq.tensor(dq.eye(n), dq.sigmaz())
    return a.dag() @ a + 0.5 * sz + 0.1 * (a @ sp + a.dag() @ sm), [a, sm]


def tm(n):
    a = dq.tensor(dq.destroy(n), dq.eye(n))
    b = dq.tensor(dq.eye(n), dq.destroy(n))
    return (
        a.dag() @ a
        + b.dag() @ b
        + 0.1 * (a.dag() @ a.dag() @ b + a @ a @ b.dag())
        + 0.05 * (a + a.dag())
    ), [a, b]


def mq(num):
    ops = []
    for i in range(num):
        loc = [dq.eye(2)] * num
        loc[i] = dq.sigmax()
        ops.append(dq.tensor(*loc))
    return sum(ops[1:], ops[0]), ops[:1]


cases = [
    ("kerr n=4", lambda: kerr(4)),
    ("kerr n=16", lambda: kerr(16)),
    ("kerr n=64", lambda: kerr(64)),
    ("JC n=16", lambda: jc(16)),
    ("JC n=32", lambda: jc(32)),
    ("two-mode 8x8", lambda: tm(8)),
    ("two-mode 12x12", lambda: tm(12)),
    ("4-qubit", lambda: mq(4)),
    ("5-qubit", lambda: mq(5)),
    ("6-qubit", lambda: mq(6)),
]
for label, build in cases:
    print(f"=== {label} ===")
    H, jumps = build()
    L = t("slindbladian (first)", lambda: dq.slindbladian(H, jumps))
    t(".to_jax() (first)", lambda: L.to_jax())
```