### PR TITLE
Optimize PWC prefactor evaluation 

### DIFF
--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -741,8 +741,10 @@ class PWC_new_TimeQArray(TimeQArray):
 
     @property
     def discontinuity_ts(self) -> Array:
-        return concatenate_sort(super().discontinuity_ts, 
-                                jnp.unique(self.times.reshape(-1)))
+        # Reconstruct the original [t0, t1, ..., tN] from the (nv, 2) pairs
+        # without jnp.unique (which is not JIT-traceable).
+        unique_times = jnp.concatenate([self.times[:, 0], self.times[-1:, 1]])
+        return concatenate_sort(super().discontinuity_ts, unique_times)
 
     def shift(self, tshift: float) -> TimeQArray:
         tstart, tend = self._shift_bounds(tshift)

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -51,57 +51,6 @@ def constant(qarray: QArrayLike) -> ConstantTimeQArray:
 
 
 def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArray:
-    r"""Instantiate a piecewise constant (PWC) timeqarray.
-
-    A PWC timeqarray takes constant values over some time intervals. It is defined by
-    $$
-        O(t) = \left(\sum_{k=0}^{N-1} c_k\; \Omega_{[t_k, t_{k+1}[}(t)\right) O_0
-    $$
-    where $c_k$ are constant values, $\Omega_{[t_k, t_{k+1}[}$ is the rectangular
-    window function defined by $\Omega_{[t_a, t_b[}(t) = 1$ if $t \in [t_a, t_b[$ and
-    $\Omega_{[t_a, t_b[}(t) = 0$ otherwise, and $O_0$ is a constant qarray.
-
-    Note:
-        The argument `times` must be sorted in ascending order, but does not
-        need to be evenly spaced.
-
-    Note:
-        If the returned timeqarray is called for a time $t$ which does not belong to
-        any time intervals, the returned qarray is null.
-
-    Args:
-        times (array-like of shape (N+1,)): Time points $t_k$ defining the boundaries
-            of the time intervals, where _N_ is the number of time intervals.
-        values (array-like of shape (..., N)): Constant values $c_k$ for each time
-            interval.
-        qarray (qarray-like of shape (n, n)): Constant qarray $O_0$.
-
-    Returns:
-        (timeqarray of shape (..., n, n) when called): Callable returning $O(t)$ for
-            any time $t$.
-
-    Examples:
-        >>> times = [0.0, 1.0, 2.0]
-        >>> values = [3.0, -2.0]
-        >>> qarray = dq.sigmaz()
-        >>> H = dq.pwc(times, values, qarray)
-        >>> H(-0.5)
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
-        [[  ⋅      ⋅   ]
-         [  ⋅      ⋅   ]]
-        >>> H(0.0)
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
-        [[ 3.+0.j    ⋅   ]
-         [   ⋅    -3.+0.j]]
-        >>> H(0.5)
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
-        [[ 3.+0.j    ⋅   ]
-         [   ⋅    -3.+0.j]]
-        >>> H(1.0)
-        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
-        [[-2.+0.j    ⋅   ]
-         [   ⋅     2.+0.j]]
-    """
     # times
     times = jnp.asarray(times)
     times = check_times(times, 'times')
@@ -120,24 +69,6 @@ def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArra
 
     return PWCTimeQArray(times, values, qarray)
 
-def pwc_new(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWC_new_TimeQArray:
-    # times
-    times = jnp.asarray(times)
-    times = check_times(times, 'times')
-
-    # values
-    values = jnp.asarray(values, dtype=cdtype())
-    if values.shape[-1] != len(times) - 1:
-        raise TypeError(
-            'Argument `values` must have shape `(..., len(times)-1)`, but has shape'
-            f' `{values.shape}.'
-        )
-
-    # qarray
-    qarray = asqarray(qarray)
-    check_shape(qarray, 'qarray', '(n, n)')
-
-    return PWC_new_TimeQArray(times, values, qarray)
 
 def modulated(
     f: Callable[[float], Scalar | Array],
@@ -588,102 +519,6 @@ class ConstantTimeQArray(TimeQArray):
 
 
 class PWCTimeQArray(TimeQArray):
-    # note: tstart and tend can be different from times[0] and times[-1]
-
-    times: Array  # (nv+1,)
-    values: Array  # (..., nv)
-    qarray: QArray  # (n, n)
-
-    def __init__(
-        self,
-        times: Array,
-        values: Array,
-        qarray: QArray,
-        *,
-        tstart: float | None = None,
-        tend: float | None = None,
-    ):
-        super().__init__(tstart=tstart, tend=tend)
-        self.times = times
-        self.values = values
-        self.qarray = qarray
-
-    @property
-    def dtype(self) -> jnp.dtype:
-        return self.qarray.dtype
-
-    @property
-    def shape(self) -> tuple[int, ...]:
-        return *self.values.shape[:-1], *self.qarray.shape
-
-    @property
-    def dims(self) -> tuple[int, ...]:
-        return self.qarray.dims
-
-    @property
-    def ndiags(self) -> int:
-        return self.qarray.ndiags
-
-    @property
-    def vectorized(self) -> bool:
-        return self.qarray.vectorized
-
-    @property
-    def layout(self) -> Layout:
-        return self.qarray.layout
-
-    @property
-    def mT(self) -> TimeQArray:
-        qarray = self.qarray.mT
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
-
-    @property
-    def in_axes(self) -> PyTree[int | None]:
-        return PWCTimeQArray(None, 0, None, tstart=None, tend=None)
-
-    @property
-    def discontinuity_ts(self) -> Array:
-        return concatenate_sort(super().discontinuity_ts, self.times)
-
-    def shift(self, tshift: float) -> TimeQArray:
-        tstart, tend = self._shift_bounds(tshift)
-        return replace(self, times=self.times + tshift, tstart=tstart, tend=tend)  # ty: ignore[invalid-argument-type]
-
-    def reshape(self, *shape: int) -> TimeQArray:
-        shape = shape[:-2] + self.values.shape[-1:]  # (..., nv)
-        values = self.values.reshape(*shape)
-        return replace(self, values=values)  # ty: ignore[invalid-argument-type]
-
-    def broadcast_to(self, *shape: int) -> TimeQArray:
-        shape = shape[:-2] + self.values.shape[-1:]  # (..., nv)
-        values = jnp.broadcast_to(self.values, shape)
-        return replace(self, values=values)  # ty: ignore[invalid-argument-type]
-
-    def conj(self) -> TimeQArray:
-        values = self.values.conj()
-        qarray = self.qarray.conj()
-        return replace(self, values=values, qarray=qarray)  # ty: ignore[invalid-argument-type]
-
-    def _prefactor(self, t: ScalarLike) -> Array:
-        zero = jnp.zeros_like(self.values[..., 0])  # (...)
-
-        idx = jnp.searchsorted(self.times, t, side='right') - 1
-        pwc = self.values[..., idx]  # (...)
-
-        pwc_prefactor = jax.lax.select(
-            (t < self.times[0]) | (t >= self.times[-1]), zero, pwc
-        )
-
-        return super()._prefactor(t) * pwc_prefactor
-
-    def _operator(self, t: ScalarLike) -> QArray:  # noqa: ARG002
-        return self.qarray
-
-    def __mul__(self, y: QArrayLike) -> TimeQArray:
-        qarray = self.qarray * y
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
-    
-class PWC_new_TimeQArray(TimeQArray):
     times: Array  # (nv+1,)
     values: Array  # (..., nv)
     qarray: QArray  # (n, n)
@@ -737,7 +572,7 @@ class PWC_new_TimeQArray(TimeQArray):
 
     @property
     def in_axes(self) -> PyTree[int | None]:
-        return PWC_new_TimeQArray(None, 0, None, tstart=None, tend=None)
+        return PWCTimeQArray(None, 0, None, tstart=None, tend=None)
 
     @property
     def discontinuity_ts(self) -> Array:

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -51,6 +51,51 @@ def constant(qarray: QArrayLike) -> ConstantTimeQArray:
 
 
 def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArray:
+    r"""Instantiate a piecewise constant (PWC) timeqarray.
+    A PWC timeqarray takes constant values over some time intervals. It is defined by
+    $$
+        O(t) = \left(\sum_{k=0}^{N-1} c_k\; \Omega_{[t_k, t_{k+1}[}(t)\right) O_0
+    $$
+    where $c_k$ are constant values, $\Omega_{[t_k, t_{k+1}[}$ is the rectangular
+    window function defined by $\Omega_{[t_a, t_b[}(t) = 1$ if $t \in [t_a, t_b[$ and
+    $\Omega_{[t_a, t_b[}(t) = 0$ otherwise, and $O_0$ is a constant qarray.
+    Note:
+        The argument `times` must be sorted in ascending order, but does not
+        need to be evenly spaced.
+    Note:
+        If the returned timeqarray is called for a time $t$ which does not belong to
+        any time intervals, the returned qarray is null.
+    Args:
+        times (array-like of shape (N+1,)): Time points $t_k$ defining the boundaries
+            of the time intervals, where _N_ is the number of time intervals.
+        values (array-like of shape (..., N)): Constant values $c_k$ for each time
+            interval.
+        qarray (qarray-like of shape (n, n)): Constant qarray $O_0$.
+    Returns:
+        (timeqarray of shape (..., n, n) when called): Callable returning $O(t)$ for
+            any time $t$.
+    Examples:
+        >>> times = [0.0, 1.0, 2.0]
+        >>> values = [3.0, -2.0]
+        >>> qarray = dq.sigmaz()
+        >>> H = dq.pwc(times, values, qarray)
+        >>> H(-0.5)
+        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
+        [[  ⋅      ⋅   ]
+         [  ⋅      ⋅   ]]
+        >>> H(0.0)
+        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
+        [[ 3.+0.j    ⋅   ]
+         [   ⋅    -3.+0.j]]
+        >>> H(0.5)
+        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
+        [[ 3.+0.j    ⋅   ]
+         [   ⋅    -3.+0.j]]
+        >>> H(1.0)
+        QArray: shape=(2, 2), dims=(2,), dtype=complex64, layout=dia, ndiags=1
+        [[-2.+0.j    ⋅   ]
+         [   ⋅     2.+0.j]]
+    """
     # times
     times = jnp.asarray(times)
     times = check_times(times, 'times')
@@ -519,6 +564,8 @@ class ConstantTimeQArray(TimeQArray):
 
 
 class PWCTimeQArray(TimeQArray):
+    # note: tstart and tend can be different from times[0] and times[-1]
+
     times: Array  # (nv+1,)
     values: Array  # (..., nv)
     qarray: QArray  # (n, n)

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -125,15 +125,12 @@ def pwc_new(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWC_new_
     times = jnp.asarray(times)
     times = check_times(times, 'times')
 
-    # convert [t0, t1, ..., tN] -> [[t0, t1], [t1, t2], ..., [tN-1, tN]]
-    times = jnp.stack([times[:-1], times[1:]], axis=-1)
-
     # values
     values = jnp.asarray(values, dtype=cdtype())
-    if values.shape[-1] != len(times):
+    if values.shape[-1] != len(times) - 1:
         raise TypeError(
-            'Argument `values` must have shape `(..., number_of_intervals)`, but has shape'
-            f' `{values.shape}`.'
+            'Argument `values` must have shape `(..., len(times)-1)`, but has shape'
+            f' `{values.shape}.'
         )
 
     # qarray
@@ -687,8 +684,7 @@ class PWCTimeQArray(TimeQArray):
         return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
     
 class PWC_new_TimeQArray(TimeQArray):
-
-    times: Array  # (nv, 2)
+    times: Array  # (nv+1,)
     values: Array  # (..., nv)
     qarray: QArray  # (n, n)
 
@@ -705,6 +701,10 @@ class PWC_new_TimeQArray(TimeQArray):
         self.times = times
         self.values = values
         self.qarray = qarray
+
+    @property
+    def _times_reshaped(self) -> Array:
+        return jnp.stack([self.times[:-1], self.times[1:]], axis=-1)  # (nv, 2)
 
     @property
     def dtype(self) -> jnp.dtype:
@@ -741,10 +741,7 @@ class PWC_new_TimeQArray(TimeQArray):
 
     @property
     def discontinuity_ts(self) -> Array:
-        # Reconstruct the original [t0, t1, ..., tN] from the (nv, 2) pairs
-        # without jnp.unique (which is not JIT-traceable).
-        unique_times = jnp.concatenate([self.times[:, 0], self.times[-1:, 1]])
-        return concatenate_sort(super().discontinuity_ts, unique_times)
+        return concatenate_sort(super().discontinuity_ts, self.times)
 
     def shift(self, tshift: float) -> TimeQArray:
         tstart, tend = self._shift_bounds(tshift)
@@ -766,9 +763,8 @@ class PWC_new_TimeQArray(TimeQArray):
         return replace(self, values=values, qarray=qarray)  # ty: ignore[invalid-argument-type]
 
     def _prefactor(self, t: ScalarLike) -> Array:
-        # self.times[:, 0] = left bounds  (nv,)
-        # self.times[:, 1] = right bounds (nv,)
-        active = (t >= self.times[:, 0]) & (t < self.times[:, 1])  # (nv,)
+        intervals = self._times_reshaped
+        active = (t >= intervals[:, 0]) & (t < intervals[:, 1])  # (nv,)
         prefactor = jnp.sum(self.values * active, axis=-1)  # (...)
 
         return super()._prefactor(t) * prefactor

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -52,6 +52,7 @@ def constant(qarray: QArrayLike) -> ConstantTimeQArray:
 
 def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArray:
     r"""Instantiate a piecewise constant (PWC) timeqarray.
+
     A PWC timeqarray takes constant values over some time intervals. It is defined by
     $$
         O(t) = \left(\sum_{k=0}^{N-1} c_k\; \Omega_{[t_k, t_{k+1}[}(t)\right) O_0
@@ -59,21 +60,26 @@ def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArra
     where $c_k$ are constant values, $\Omega_{[t_k, t_{k+1}[}$ is the rectangular
     window function defined by $\Omega_{[t_a, t_b[}(t) = 1$ if $t \in [t_a, t_b[$ and
     $\Omega_{[t_a, t_b[}(t) = 0$ otherwise, and $O_0$ is a constant qarray.
+
     Note:
         The argument `times` must be sorted in ascending order, but does not
         need to be evenly spaced.
+
     Note:
         If the returned timeqarray is called for a time $t$ which does not belong to
         any time intervals, the returned qarray is null.
+
     Args:
         times (array-like of shape (N+1,)): Time points $t_k$ defining the boundaries
             of the time intervals, where _N_ is the number of time intervals.
         values (array-like of shape (..., N)): Constant values $c_k$ for each time
             interval.
         qarray (qarray-like of shape (n, n)): Constant qarray $O_0$.
+
     Returns:
         (timeqarray of shape (..., n, n) when called): Callable returning $O(t)$ for
             any time $t$.
+
     Examples:
         >>> times = [0.0, 1.0, 2.0]
         >>> values = [3.0, -2.0]
@@ -647,9 +653,9 @@ class PWCTimeQArray(TimeQArray):
     def _prefactor(self, t: ScalarLike) -> Array:
         intervals = self._times_reshaped
         active = (t >= intervals[:, 0]) & (t < intervals[:, 1])  # (nv,)
-        prefactor = jnp.sum(self.values * active, axis=-1)  # (...)
+        pwc_prefactor = jnp.sum(self.values * active, axis=-1)  # (...)
 
-        return super()._prefactor(t) * prefactor
+        return super()._prefactor(t) * pwc_prefactor
 
     def _operator(self, t: ScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -120,6 +120,27 @@ def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArra
 
     return PWCTimeQArray(times, values, qarray)
 
+def pwc_new(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWC_new_TimeQArray:
+    # times
+    times = jnp.asarray(times)
+    times = check_times(times, 'times')
+
+    # convert [t0, t1, ..., tN] -> [[t0, t1], [t1, t2], ..., [tN-1, tN]]
+    times = jnp.stack([times[:-1], times[1:]], axis=-1)
+
+    # values
+    values = jnp.asarray(values, dtype=cdtype())
+    if values.shape[-1] != len(times):
+        raise TypeError(
+            'Argument `values` must have shape `(..., number_of_intervals)`, but has shape'
+            f' `{values.shape}`.'
+        )
+
+    # qarray
+    qarray = asqarray(qarray)
+    check_shape(qarray, 'qarray', '(n, n)')
+
+    return PWC_new_TimeQArray(times, values, qarray)
 
 def modulated(
     f: Callable[[float], Scalar | Array],
@@ -657,6 +678,98 @@ class PWCTimeQArray(TimeQArray):
         )
 
         return super()._prefactor(t) * pwc_prefactor
+
+    def _operator(self, t: ScalarLike) -> QArray:  # noqa: ARG002
+        return self.qarray
+
+    def __mul__(self, y: QArrayLike) -> TimeQArray:
+        qarray = self.qarray * y
+        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+    
+class PWC_new_TimeQArray(TimeQArray):
+
+    times: Array  # (nv, 2)
+    values: Array  # (..., nv)
+    qarray: QArray  # (n, n)
+
+    def __init__(
+        self,
+        times: Array,
+        values: Array,
+        qarray: QArray,
+        *,
+        tstart: float | None = None,
+        tend: float | None = None,
+    ):
+        super().__init__(tstart=tstart, tend=tend)
+        self.times = times
+        self.values = values
+        self.qarray = qarray
+
+    @property
+    def dtype(self) -> jnp.dtype:
+        return self.qarray.dtype
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return *self.values.shape[:-1], *self.qarray.shape
+
+    @property
+    def dims(self) -> tuple[int, ...]:
+        return self.qarray.dims
+
+    @property
+    def ndiags(self) -> int:
+        return self.qarray.ndiags
+
+    @property
+    def vectorized(self) -> bool:
+        return self.qarray.vectorized
+
+    @property
+    def layout(self) -> Layout:
+        return self.qarray.layout
+
+    @property
+    def mT(self) -> TimeQArray:
+        qarray = self.qarray.mT
+        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+
+    @property
+    def in_axes(self) -> PyTree[int | None]:
+        return PWC_new_TimeQArray(None, 0, None, tstart=None, tend=None)
+
+    @property
+    def discontinuity_ts(self) -> Array:
+        return concatenate_sort(super().discontinuity_ts, 
+                                jnp.unique(self.times.reshape(-1)))
+
+    def shift(self, tshift: float) -> TimeQArray:
+        tstart, tend = self._shift_bounds(tshift)
+        return replace(self, times=self.times + tshift, tstart=tstart, tend=tend)  # ty: ignore[invalid-argument-type]
+
+    def reshape(self, *shape: int) -> TimeQArray:
+        shape = shape[:-2] + self.values.shape[-1:]  # (..., nv)
+        values = self.values.reshape(*shape)
+        return replace(self, values=values)  # ty: ignore[invalid-argument-type]
+
+    def broadcast_to(self, *shape: int) -> TimeQArray:
+        shape = shape[:-2] + self.values.shape[-1:]  # (..., nv)
+        values = jnp.broadcast_to(self.values, shape)
+        return replace(self, values=values)  # ty: ignore[invalid-argument-type]
+
+    def conj(self) -> TimeQArray:
+        values = self.values.conj()
+        qarray = self.qarray.conj()
+        return replace(self, values=values, qarray=qarray)  # ty: ignore[invalid-argument-type]
+
+    def _prefactor(self, t: ScalarLike) -> Array:
+        # self.times[:, 0] = left bounds  (nv,)
+        # self.times[:, 1] = right bounds (nv,)
+        active = (t >= self.times[:, 0]) & (t < self.times[:, 1])  # (nv,)
+        prefactor = jnp.sum(self.values * active, axis=-1)  # (...)
+
+        return super()._prefactor(t) * prefactor
 
     def _operator(self, t: ScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
     "flit",
     "mike",
     "optax",  # for gradient descent tutorials
-    "ty==0.0.17",
+    "ty",
 ]
 
 [tool.ruff]
@@ -139,23 +139,60 @@ unused-ignore-comment = "error"
 
 # === taskipy tasks definition ===
 
-[tool.taskipy.tasks]
-lint = 'echo "\n>>> ruff check --fix" && ruff check --fix'
-format = 'echo "\n>>> ruff format" && ruff format'
-codespell = 'echo "\n>>> codespell" && codespell tests dynamiqs'
-type = 'echo "\n>>> ty check dynamiqs" && ty check dynamiqs'
-clean = 'task lint && task format && task codespell && task type'
-test = 'echo "\n>>> pytest -n=auto tests" && pytest -n=auto tests'
-doctest-code = 'echo "\n>>> pytest dynamiqs" && python docs/remove_figs.py docs/figs_code && pytest dynamiqs'
-doctest-docs = 'echo "\n>>> pytest docs" && python docs/remove_figs.py docs/figs_docs && pytest docs'
-doctest = 'task doctest-code && task doctest-docs'
-docbuild = 'mkdocs build'
-docserve = 'mkdocs serve'
-all = 'task clean && task test && task doctest'
-ci = '''echo "\n>>> ruff check" && ruff check &&
-        echo "\n>>> ruff format --check" && ruff format --check &&
-        task codespell &&
-        task type &&
-        task test &&
-        task doctest &&
-        task docbuild'''
+[tool.taskipy.tasks.lint]
+cmd = 'echo "\n>>> ruff check --fix" && ruff check --fix'
+help = "lint the code (ruff)"
+
+[tool.taskipy.tasks.format]
+cmd = 'echo "\n>>> ruff format" && ruff format'
+help = "auto-format the code (ruff)"
+
+[tool.taskipy.tasks.codespell]
+cmd = 'echo "\n>>> codespell" && codespell tests dynamiqs'
+help = "check for misspellings (codespell)"
+
+[tool.taskipy.tasks.type]
+cmd = 'echo "\n>>> ty check dynamiqs" && ty check dynamiqs'
+help = "check types (ty)"
+
+[tool.taskipy.tasks.clean]
+cmd = 'task lint && task format && task codespell && task type'
+help = "clean the code (ruff + codespell + ty)"
+
+[tool.taskipy.tasks.test]
+cmd = 'echo "\n>>> pytest -n=auto tests" && pytest -n=auto tests'
+help = "run the unit tests suite (pytest)"
+
+[tool.taskipy.tasks.doctest-code]
+cmd = 'echo "\n>>> pytest dynamiqs" && python docs/remove_figs.py docs/figs_code && pytest dynamiqs'
+help = "check code docstrings examples (doctest)"
+
+[tool.taskipy.tasks.doctest-docs]
+cmd = 'echo "\n>>> pytest docs" && python docs/remove_figs.py docs/figs_docs && pytest docs'
+help = "check documentation examples (doctest)"
+
+[tool.taskipy.tasks.doctest]
+cmd = 'task doctest-code && task doctest-docs'
+help = "check all examples (doctest)"
+
+[tool.taskipy.tasks.docbuild]
+cmd = 'mkdocs build'
+help = "build the documentation website"
+
+[tool.taskipy.tasks.docserve]
+cmd = 'mkdocs serve'
+help = "preview documentation website with hot-reloading"
+
+[tool.taskipy.tasks.all]
+cmd = 'task clean && task test && task doctest'
+help = "run all tasks before a commit (ruff + codespell + ty + pytest + doctest)"
+
+[tool.taskipy.tasks.ci]
+cmd = '''echo "\n>>> ruff check" && ruff check &&
+         echo "\n>>> ruff format --check" && ruff format --check &&
+         task codespell &&
+         task type &&
+         task test &&
+         task doctest &&
+         task docbuild'''
+help = "run all the CI checks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,60 +138,23 @@ unused-ignore-comment = "error"
 
 # === taskipy tasks definition ===
 
-[tool.taskipy.tasks.lint]
-cmd = 'echo "\n>>> ruff check --fix" && ruff check --fix'
-help = "lint the code (ruff)"
-
-[tool.taskipy.tasks.format]
-cmd = 'echo "\n>>> ruff format" && ruff format'
-help = "auto-format the code (ruff)"
-
-[tool.taskipy.tasks.codespell]
-cmd = 'echo "\n>>> codespell" && codespell tests dynamiqs'
-help = "check for misspellings (codespell)"
-
-[tool.taskipy.tasks.type]
-cmd = 'echo "\n>>> ty check dynamiqs" && ty check dynamiqs'
-help = "check types (ty)"
-
-[tool.taskipy.tasks.clean]
-cmd = 'task lint && task format && task codespell && task type'
-help = "clean the code (ruff + codespell + ty)"
-
-[tool.taskipy.tasks.test]
-cmd = 'echo "\n>>> pytest -n=auto tests" && pytest -n=auto tests'
-help = "run the unit tests suite (pytest)"
-
-[tool.taskipy.tasks.doctest-code]
-cmd = 'echo "\n>>> pytest dynamiqs" && python docs/remove_figs.py docs/figs_code && pytest dynamiqs'
-help = "check code docstrings examples (doctest)"
-
-[tool.taskipy.tasks.doctest-docs]
-cmd = 'echo "\n>>> pytest docs" && python docs/remove_figs.py docs/figs_docs && pytest docs'
-help = "check documentation examples (doctest)"
-
-[tool.taskipy.tasks.doctest]
-cmd = 'task doctest-code && task doctest-docs'
-help = "check all examples (doctest)"
-
-[tool.taskipy.tasks.docbuild]
-cmd = 'mkdocs build'
-help = "build the documentation website"
-
-[tool.taskipy.tasks.docserve]
-cmd = 'mkdocs serve'
-help = "preview documentation website with hot-reloading"
-
-[tool.taskipy.tasks.all]
-cmd = 'task clean && task test && task doctest'
-help = "run all tasks before a commit (ruff + codespell + ty + pytest + doctest)"
-
-[tool.taskipy.tasks.ci]
-cmd = '''echo "\n>>> ruff check" && ruff check &&
-         echo "\n>>> ruff format --check" && ruff format --check &&
-         task codespell &&
-         task type &&
-         task test &&
-         task doctest &&
-         task docbuild'''
-help = "run all the CI checks"
+[tool.taskipy.tasks]
+lint = 'echo "\n>>> ruff check --fix" && ruff check --fix'
+format = 'echo "\n>>> ruff format" && ruff format'
+codespell = 'echo "\n>>> codespell" && codespell tests dynamiqs'
+type = 'echo "\n>>> ty check dynamiqs" && ty check dynamiqs'
+clean = 'task lint && task format && task codespell && task type'
+test = 'echo "\n>>> pytest -n=auto tests" && pytest -n=auto tests'
+doctest-code = 'echo "\n>>> pytest dynamiqs" && python docs/remove_figs.py docs/figs_code && pytest dynamiqs'
+doctest-docs = 'echo "\n>>> pytest docs" && python docs/remove_figs.py docs/figs_docs && pytest docs'
+doctest = 'task doctest-code && task doctest-docs'
+docbuild = 'mkdocs build'
+docserve = 'mkdocs serve'
+all = 'task clean && task test && task doctest'
+ci = '''echo "\n>>> ruff check" && ruff check &&
+        echo "\n>>> ruff format --check" && ruff format --check &&
+        task codespell &&
+        task type &&
+        task test &&
+        task doctest &&
+        task docbuild'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
     "flit",
     "mike",
     "optax",  # for gradient descent tutorials
-    "ty",
+    "ty==0.0.17",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,4 +195,4 @@ cmd = '''echo "\n>>> ruff check" && ruff check &&
          task test &&
          task doctest &&
          task docbuild'''
-help = "run all the CI checks"
+help = "run all the CI checks" 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,4 +195,4 @@ cmd = '''echo "\n>>> ruff check" && ruff check &&
          task test &&
          task doctest &&
          task docbuild'''
-help = "run all the CI checks" 
+help = "run all the CI checks"


### PR DESCRIPTION
## Summary

This PR optimizes `PWCTimeQArray._prefactor()` by replacing the `jnp.searchsorted`-based interval lookup with a vectorized interval-mask reduction.

The public `times` representation is unchanged: `times` is still stored as a flat array of shape `(N + 1,)`, so existing user code that accesses `x.times` keeps the same behavior. Internally, the interval view is reconstructed through a private `_times_reshaped` property and used to compute the active interval mask.

## What changed

- Added a private `_times_reshaped` property returning consecutive time intervals from the flat `times` array.
- Replaced the previous `searchsorted` + indexed value lookup in `_prefactor()` with:
  - a boolean mask selecting the active interval,
  - a reduction over interval values.
- Kept the external `times` storage format unchanged for backward compatibility.

## Results

The benchmark compares the current `pwc` implementation against the new interval-mask implementation on CPU and GPU, for both single and 100-interval pulses. All cases agree numerically within tolerance, with maximum observable differences of order `1e-9`.

| Hardware / case | Implementation | Compile time (s) | Execution time (s) | Result |
|---|---:|---:|---:|---|
| GPU, 1 interval | `pwc` | 5.9449 | 1.1839 | baseline |
| GPU, 1 interval | new | **4.0352** | **1.1798** | slightly faster compile, same runtime |
| GPU, 100 intervals | `pwc` | 5.0725 | 3.9727 | baseline |
| GPU, 100 intervals | new | **5.0406** | **1.2530** | **~3.2x faster execution** |
| CPU, 1 interval | `pwc` | 3.1095 | **7.8539** | baseline |
| CPU, 1 interval | new | **2.5600** | 8.0198 | similar runtime |
| CPU, 100 intervals | `pwc` | 3.0377 | 9.6702 | baseline |
| CPU, 100 intervals | new | **2.8817** | **7.9995** | **~17% faster execution** |
| GPU batch 128, 1 interval | `pwc` | 19.7940 | 27.9118 | baseline |
| GPU batch 128, 1 interval | new | **17.7853** | **25.9049** | modest improvement |
| GPU batch 128, 100 intervals | `pwc` | 18.3970 | 33.4496 | baseline |
| GPU batch 128, 100 intervals | new | **18.2105** | **27.1799** | **~19% faster execution** |
