### PR TITLE
Fix ClipStepSizeController replace() crash with discontinuous Hamiltonians

### DIFF
--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -113,20 +113,19 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             # === prepare stepsize controller
             stepsize_controller = self.stepsize_controller
             if dtmax is not None:
-                if isinstance(stepsize_controller, dx.ClipStepSizeController):
-                    stepsize_controller = eqx.tree_at(
-                        lambda c: c.controller.dtmax,
-                        stepsize_controller,
-                        dtmax,
-                        is_leaf=lambda x: x is None,
-                    )
-                else:
-                    stepsize_controller = eqx.tree_at(
-                        lambda c: c.dtmax,
-                        stepsize_controller,
-                        dtmax,
-                        is_leaf=lambda x: x is None,
-                    )
+                # Diffrax's ClipStepSizeController and PIDController have different
+                # APIs for setting dtmax, so we need to handle them separately
+                get_dtmax = (
+                    (lambda c: c.controller.dtmax)
+                    if isinstance(stepsize_controller, dx.ClipStepSizeController)
+                    else (lambda c: c.dtmax)
+                )
+                stepsize_controller = eqx.tree_at(
+                    get_dtmax,
+                    stepsize_controller,
+                    dtmax,
+                    is_leaf=lambda x: x is None,
+                )
 
             # === solve differential equation with diffrax
             return dx.diffeqsolve(

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import warnings
 from abc import abstractmethod
-from dataclasses import replace
 from functools import partial
 
 import diffrax as dx
@@ -114,7 +113,20 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             # === prepare stepsize controller
             stepsize_controller = self.stepsize_controller
             if dtmax is not None:
-                stepsize_controller = replace(stepsize_controller, dtmax=dtmax)
+                if isinstance(stepsize_controller, dx.ClipStepSizeController):
+                    stepsize_controller = eqx.tree_at(
+                        lambda c: c.controller.dtmax,
+                        stepsize_controller,
+                        dtmax,
+                        is_leaf=lambda x: x is None,
+                    )
+                else:
+                    stepsize_controller = eqx.tree_at(
+                        lambda c: c.dtmax,
+                        stepsize_controller,
+                        dtmax,
+                        is_leaf=lambda x: x is None,
+                    )
 
             # === solve differential equation with diffrax
             return dx.diffeqsolve(

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -121,10 +121,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
                     else (lambda c: c.dtmax)
                 )
                 stepsize_controller = eqx.tree_at(
-                    get_dtmax,
-                    stepsize_controller,
-                    dtmax,
-                    is_leaf=lambda x: x is None,
+                    get_dtmax, stepsize_controller, dtmax, is_leaf=lambda x: x is None
                 )
 
             # === solve differential equation with diffrax

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -546,6 +546,13 @@ class MESolveAdaptiveRouchonIntegrator(
         stepsize_controller = super().stepsize_controller
         # fix incorrect default linear interpolation by stepping exactly at all times
         # in tsave, so interpolation is bypassed
+        if isinstance(stepsize_controller, dx.ClipStepSizeController):
+            return eqx.tree_at(
+                lambda c: c.step_ts,
+                stepsize_controller,
+                self.ts,
+                is_leaf=lambda x: x is None,
+            )
         return replace(stepsize_controller, step_ts=self.ts)
 
 

--- a/tests/mesolve/test_adaptive_rouchon.py
+++ b/tests/mesolve/test_adaptive_rouchon.py
@@ -1,5 +1,7 @@
+import jax.numpy as jnp
 import pytest
 
+import dynamiqs as dq
 from dynamiqs.gradient import Direct
 from dynamiqs.method import Rouchon2, Rouchon3
 
@@ -24,3 +26,19 @@ class TestMESolveAdaptiveRouchon(IntegratorTester):
     @pytest.mark.parametrize('gradient', [Direct()])
     def test_gradient(self, method_class, system, gradient):
         self._test_gradient(system, method_class(), gradient)
+
+    @pytest.mark.parametrize('method_class', [Rouchon2, Rouchon3])
+    def test_pwc_hamiltonian(self, method_class):
+        """Regression test: adaptive Rouchon with a PWC Hamiltonian must not crash.
+
+        A PWC Hamiltonian introduces discontinuities, causing diffrax to wrap the
+        step-size controller in a ClipStepSizeController. Previously,
+        dataclasses.replace() on that wrapper raised a TypeError.
+        """
+        n = 2
+        H = dq.pwc(jnp.array([0.0, 0.5, 1.0]), jnp.array([1.0, 2.0]), dq.sigmax())
+        jump_ops = [0.1 * dq.sigmam()]
+        rho0 = dq.fock_dm(n, 0)
+        tsave = jnp.linspace(0.0, 1.0, 11)
+        result = dq.mesolve(H, jump_ops, rho0, tsave, method=method_class())
+        assert result.states.shape[-2:] == (n, n)


### PR DESCRIPTION
Fixes #1085

In diffrax 0.7, `ClipStepSizeController` renamed its constructor parameter from
`callback_on_reject` to `_callback_on_reject`, but the dataclass field kept the old
name. This caused `dataclasses.replace(stepsize_controller, step_ts=...)` in
`MESolveAdaptiveRouchonIntegrator.stepsize_controller` to raise a `TypeError` whenever
the Hamiltonian had discontinuities (which wraps the controller in a
`ClipStepSizeController`).

**Fix:** detect `ClipStepSizeController` and reconstruct it directly instead of using
`replace()`.

**Test:** added `test_pwc_hamiltonian` to verify `Rouchon2`/`Rouchon3` no longer crash
with a PWC Hamiltonian.

There may be cleaner ways of fixing this.