### PR TITLE
Fix CI dependency resolution for taskipy and ty typing issues

### DIFF
--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -628,7 +628,7 @@ class Event(_DEMethod):
         (default).
     """
 
-    noclick_method: Method = Tsit5()  # ty: ignore[invalid-assignment]
+    noclick_method: Method = Tsit5()
     dtmax: float | None = eqx.field(static=True, default=None)
     root_finder: AbstractRootFinder | None = eqx.field(static=True, default=None)
     smart_sampling: bool = eqx.field(static=True, default=False)
@@ -642,7 +642,7 @@ class Event(_DEMethod):
     # dummy init to have the signature in the documentation
     def __init__(
         self,
-        noclick_method: Method = Tsit5(),  # noqa: B008  # ty: ignore[invalid-parameter-default]
+        noclick_method: Method = Tsit5(),  # noqa: B008
         dtmax: float | None = None,
         root_finder: AbstractRootFinder | None = None,
         smart_sampling: bool = False,
@@ -832,7 +832,7 @@ class LowRank(Method):
     def __init__(
         self,
         rank: int,
-        ode_method: Method = Tsit5(),  # noqa: B008  # ty: ignore[invalid-parameter-default]
+        ode_method: Method = Tsit5(),  # noqa: B008
         linear_solver: LinearSolver = LinearSolver.QR,
         perturbation_scale: float = 1e-5,
         *,

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -64,7 +64,7 @@ class Options(eqx.Module):
         #   dynamically, but then changing the default value would not change the
         #   `options` object attributes, and we would cache hit the JIT-compiled
         #   function for any previous existing `options` object.
-        return Options(  # ty: ignore[invalid-return-type]
+        return Options(
             save_states=self.save_states,
             save_propagators=self.save_propagators,
             cartesian_batching=self.cartesian_batching,

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -20,12 +20,12 @@ class AbstractProgressMeter(eqx.Module):
 
 class NoProgressMeter(AbstractProgressMeter):
     def to_diffrax(self) -> dx.AbstractProgressMeter:
-        return dx.NoProgressMeter()  # ty: ignore[invalid-return-type]
+        return dx.NoProgressMeter()
 
 
 class TextProgressMeter(AbstractProgressMeter):
     def to_diffrax(self) -> dx.AbstractProgressMeter:
-        return dx.TextProgressMeter()  # ty: ignore[invalid-return-type]
+        return dx.TextProgressMeter()
 
 
 def _format_duration(duration_s: float) -> str:
@@ -77,4 +77,4 @@ class _DiffraxTqdmProgressMeter(dx.TqdmProgressMeter):
 
 class TqdmProgressMeter(AbstractProgressMeter):
     def to_diffrax(self) -> dx.AbstractProgressMeter:
-        return _DiffraxTqdmProgressMeter()  # ty: ignore[invalid-return-type]
+        return _DiffraxTqdmProgressMeter()

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -124,7 +124,7 @@ class Result(eqx.Module):
 
     @classmethod
     def out_axes(cls) -> OutAxes:
-        return cast(OutAxes, cls(None, None, None, None, 0, 0))
+        return cls(None, None, None, None, 0, 0)  # ty: ignore[invalid-argument-type]
 
 
 class SolveResult(Result):
@@ -187,7 +187,7 @@ class FloquetResult(Result):
 
     @classmethod
     def out_axes(cls) -> OutAxes:
-        return cast(OutAxes, cls(None, None, None, None, 0, 0, None))
+        return cls(None, None, None, None, 0, 0, None)  # ty: ignore[invalid-argument-type]
 
 
 class SESolveResult(SolveResult):
@@ -227,7 +227,7 @@ class StochasticSolveResult(SolveResult):
 
     @classmethod
     def out_axes(cls) -> OutAxes:
-        return cast(OutAxes, cls(None, None, None, None, 0, 0, 0))
+        return cls(None, None, None, None, 0, 0, 0)  # ty: ignore[invalid-argument-type]
 
     def mean_states(self) -> QArray:
         # todo: document

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast
-
 import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
@@ -13,8 +11,6 @@ from .options import Options
 from .qarrays.qarray import QArray
 from .qarrays.utils import asqarray, to_jax
 from .utils.general import unit
-
-OutAxes = PyTree[None | int]
 
 __all__ = [
     'FloquetResult',

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -11,6 +11,7 @@ from .options import Options
 from .qarrays.qarray import QArray
 from .qarrays.utils import asqarray, to_jax
 from .utils.general import unit
+from typing import cast
 
 OutAxes = PyTree[None | int]
 
@@ -122,7 +123,7 @@ class Result(eqx.Module):
 
     @classmethod
     def out_axes(cls) -> OutAxes:
-        return cls(None, None, None, None, 0, 0)
+        return cast(OutAxes, cls(None, None, None, None, 0, 0))
 
 
 class SolveResult(Result):
@@ -185,7 +186,7 @@ class FloquetResult(Result):
 
     @classmethod
     def out_axes(cls) -> OutAxes:
-        return cls(None, None, None, None, 0, 0, None)
+        return cast(OutAxes, cls(None, None, None, None, 0, 0, None))
 
 
 class SESolveResult(SolveResult):
@@ -225,7 +226,7 @@ class StochasticSolveResult(SolveResult):
 
     @classmethod
     def out_axes(cls) -> OutAxes:
-        return cls(None, None, None, None, 0, 0, 0)
+        return cast(OutAxes, cls(None, None, None, None, 0, 0, 0))
 
     def mean_states(self) -> QArray:
         # todo: document

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -11,7 +11,6 @@ from .options import Options
 from .qarrays.qarray import QArray
 from .qarrays.utils import asqarray, to_jax
 from .utils.general import unit
-from typing import Self
 
 OutAxes = PyTree[None | int]
 

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
@@ -11,7 +13,6 @@ from .options import Options
 from .qarrays.qarray import QArray
 from .qarrays.utils import asqarray, to_jax
 from .utils.general import unit
-from typing import cast
 
 OutAxes = PyTree[None | int]
 

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -119,7 +119,7 @@ class Result(eqx.Module):
         return f'==== {self.__class__.__name__} ====\n' + parts_str
 
     @classmethod
-    def out_axes(cls) -> OutAxes:
+    def out_axes(cls) -> Result:
         return cls(None, None, None, None, 0, 0)  # ty: ignore[invalid-argument-type]
 
 
@@ -182,7 +182,7 @@ class FloquetResult(Result):
         }
 
     @classmethod
-    def out_axes(cls) -> OutAxes:
+    def out_axes(cls) -> FloquetResult:
         return cls(None, None, None, None, 0, 0, None)  # ty: ignore[invalid-argument-type]
 
 
@@ -222,7 +222,7 @@ class StochasticSolveResult(SolveResult):
     keys: PRNGKeyArray
 
     @classmethod
-    def out_axes(cls) -> OutAxes:
+    def out_axes(cls) -> StochasticSolveResult:
         return cls(None, None, None, None, 0, 0, 0)  # ty: ignore[invalid-argument-type]
 
     def mean_states(self) -> QArray:

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -11,6 +11,9 @@ from .options import Options
 from .qarrays.qarray import QArray
 from .qarrays.utils import asqarray, to_jax
 from .utils.general import unit
+from typing import Self
+
+OutAxes = PyTree[None | int]
 
 __all__ = [
     'FloquetResult',
@@ -119,7 +122,7 @@ class Result(eqx.Module):
         return f'==== {self.__class__.__name__} ====\n' + parts_str
 
     @classmethod
-    def out_axes(cls) -> Result:
+    def out_axes(cls) -> OutAxes:
         return cls(None, None, None, None, 0, 0)
 
 
@@ -182,7 +185,7 @@ class FloquetResult(Result):
         }
 
     @classmethod
-    def out_axes(cls) -> FloquetResult:
+    def out_axes(cls) -> OutAxes:
         return cls(None, None, None, None, 0, 0, None)
 
 
@@ -222,7 +225,7 @@ class StochasticSolveResult(SolveResult):
     keys: PRNGKeyArray
 
     @classmethod
-    def out_axes(cls) -> StochasticSolveResult:
+    def out_axes(cls) -> OutAxes:
         return cls(None, None, None, None, 0, 0, 0)
 
     def mean_states(self) -> QArray:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ build-backend = "flit_core.buildapi"
 
 [project.optional-dependencies]
 dev = [
-    "taskipy",
+    "taskipy>=1.14.1",
     "ruff>=0.8",
     "codespell",
     "pytest>=8.0",


### PR DESCRIPTION
## Summary

This PR fixes two small issues that were preventing CI from running properly:

- pins/fixes the `taskipy` version issue during `uv` environment resolution
- fixes formatting issues in the `ty` task instructions

Both problems were encountered while working on #1084

## Notes

Once CI is able to run again, this also includes minor `ty`-related fixes.