### PR TITLE
API: flatten solver options into keyword arguments

### DIFF
--- a/docs/documentation/advanced_examples/continuous-diffusive-measurement.md
+++ b/docs/documentation/advanced_examples/continuous-diffusive-measurement.md
@@ -198,8 +198,7 @@ keys = jax.random.split(key, ntrajs)
 
 # simulate trajectories
 method = dq.method.EulerMaruyama(dt=1e-3)
-options = dq.Options(save_states=False)
-result = dq.dsmesolve(H, jump_ops, etas, psi0, tsave, keys, method=method, options=options)
+result = dq.dsmesolve(H, jump_ops, etas, psi0, tsave, keys, method=method, save_states=False)
 print(result)
 ```
 

--- a/docs/documentation/advanced_examples/continuous-jump-measurement.md
+++ b/docs/documentation/advanced_examples/continuous-jump-measurement.md
@@ -182,7 +182,7 @@ for i, exp in enumerate(exps_adaga[:4]):
 plt.plot(tsave, exps_adaga.mean(0), label=f'Average trajectory', color='gray', **kw)
 
 # Lindblad solution
-result_lindblad = dq.mesolve(H, jump_ops, psi0, tsave, options=options, exp_ops=exp_ops)
+result_lindblad = dq.mesolve(H, jump_ops, psi0, tsave, save_states=False, exp_ops=exp_ops)
 plt.plot(tsave, result_lindblad.expects[0].real, ls='--', label=f'Lindblad', color='gray', **kw)
 
 plt.gca().set(

--- a/docs/documentation/advanced_examples/continuous-jump-measurement.md
+++ b/docs/documentation/advanced_examples/continuous-jump-measurement.md
@@ -151,9 +151,8 @@ keys = jax.random.split(key, ntrajs)
 
 # simulate trajectories
 method = dq.method.EulerJump(dt=1e-3)
-options = dq.Options(save_states=False)
 exp_ops = [a.dag() @ a]
-result = dq.jssesolve(H, jump_ops, psi0, tsave, keys, method=method, options=options, exp_ops=exp_ops)
+result = dq.jssesolve(H, jump_ops, psi0, tsave, keys, method=method, save_states=False, exp_ops=exp_ops)
 print(result)
 ```
 

--- a/docs/documentation/advanced_examples/kerr-oscillator.md
+++ b/docs/documentation/advanced_examples/kerr-oscillator.md
@@ -318,9 +318,7 @@ def compute_fidelity(amps):
     H = H0 + Hx + Hp
 
     # run simulation
-    options = dq.Options(progress_meter=False) # disable progress meter
-    result = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=options)
-
+        result = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, progress_meter=False) # disable progress meter
     # fidelity is now defined as the overlap with |1> at the final time only
     return result.expects[1, -1].real
 

--- a/docs/documentation/advanced_examples/kerr-oscillator.md
+++ b/docs/documentation/advanced_examples/kerr-oscillator.md
@@ -318,7 +318,7 @@ def compute_fidelity(amps):
     H = H0 + Hx + Hp
 
     # run simulation
-        result = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, progress_meter=False) # disable progress meter
+    result = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, progress_meter=False) # disable progress meter
     # fidelity is now defined as the overlap with |1> at the final time only
     return result.expects[1, -1].real
 

--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
 
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import ArrayLike, PRNGKeyArray
+from jaxtyping import ArrayLike, PRNGKeyArray, PyTree
 
 from ..._checks import check_hermitian, check_qarray_is_dense, check_shape, check_times
 from ...gradient import Gradient
@@ -41,7 +42,9 @@ def dsmesolve(
     exp_ops: list[QArrayLike] | None = None,
     method: Method | None = None,
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_states: bool = True,
+    cartesian_batching: bool = True,
+    save_extra: Callable[[Array], PyTree] | None = None,
 ) -> DSMESolveResult:
     r"""Solve the diffusive stochastic master equation (SME).
 
@@ -285,6 +288,13 @@ def dsmesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+
+    # === build options
+    options = Options(
+        save_states=save_states,
+        cartesian_batching=cartesian_batching,
+        save_extra=save_extra,
+    )
 
     # === check arguments
     _check_dsmesolve_args(H, Ls, etas, rho0, exp_ops)

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
 
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import ArrayLike, PRNGKeyArray
+from jaxtyping import ArrayLike, PRNGKeyArray, PyTree
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
@@ -40,7 +41,9 @@ def dssesolve(
     exp_ops: list[QArrayLike] | None = None,
     method: Method | None = None,
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_states: bool = True,
+    cartesian_batching: bool = True,
+    save_extra: Callable[[Array], PyTree] | None = None,
 ) -> DSSESolveResult:
     r"""Solve the diffusive stochastic Schrödinger equation (SSE).
 
@@ -265,6 +268,13 @@ def dssesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+
+    # === build options
+    options = Options(
+        save_states=save_states,
+        cartesian_batching=cartesian_batching,
+        save_extra=save_extra,
+    )
 
     # === check arguments
     _check_dssesolve_args(H, Ls, psi0, exp_ops)

--- a/dynamiqs/integrators/apis/floquet.py
+++ b/dynamiqs/integrators/apis/floquet.py
@@ -5,12 +5,13 @@ from functools import partial
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, ArrayLike
+from jaxtyping import Array, ArrayLike, ScalarLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
 from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options, check_options
+from ...progress_meter import AbstractProgressMeter
 from ...qarrays.qarray import QArrayLike
 from ...result import FloquetResult
 from ...time_qarray import TimeQArray
@@ -32,7 +33,8 @@ def floquet(
     *,
     method: Method = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    progress_meter: AbstractProgressMeter | bool | None = None,
+    t0: ScalarLike | None = None,
 ) -> FloquetResult:
     r"""Compute Floquet modes and quasienergies of a periodic closed system.
 
@@ -183,6 +185,9 @@ def floquet(
     # === convert arguments
     H = astimeqarray(H)
     tsave = jnp.asarray(tsave)
+
+    # === build options
+    options = Options(progress_meter=progress_meter, t0=t0)
 
     # === check arguments
     tsave = check_times(tsave, 'tsave')

--- a/dynamiqs/integrators/apis/jsmesolve.py
+++ b/dynamiqs/integrators/apis/jsmesolve.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
 
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import ArrayLike, PRNGKeyArray
+from jaxtyping import ArrayLike, PRNGKeyArray, PyTree
 
 from ..._checks import check_hermitian, check_qarray_is_dense, check_shape, check_times
 from ...gradient import Gradient
@@ -41,7 +42,10 @@ def jsmesolve(
     exp_ops: list[QArrayLike] | None = None,
     method: Method | None = None,
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_states: bool = True,
+    cartesian_batching: bool = True,
+    save_extra: Callable[[Array], PyTree] | None = None,
+    nmaxclick: int = 10_000,
 ) -> JSMESolveResult:
     r"""Solve the jump stochastic master equation (SME).
 
@@ -286,6 +290,14 @@ def jsmesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+
+    # === build options
+    options = Options(
+        save_states=save_states,
+        cartesian_batching=cartesian_batching,
+        save_extra=save_extra,
+        nmaxclick=nmaxclick,
+    )
 
     # === check arguments
     _check_jsmesolve_args(H, Ls, thetas, etas, rho0, exp_ops)

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import ArrayLike, PRNGKeyArray
+from jaxtyping import ArrayLike, PRNGKeyArray, PyTree, ScalarLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
@@ -38,7 +40,11 @@ def jssesolve(
     exp_ops: list[QArrayLike] | None = None,
     method: Method | None = None,
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_states: bool = True,
+    cartesian_batching: bool = True,
+    t0: ScalarLike | None = None,
+    save_extra: Callable[[Array], PyTree] | None = None,
+    nmaxclick: int = 10_000,
 ) -> JSSESolveResult:
     r"""Solve the jump stochastic Schrödinger equation (SSE).
 
@@ -267,6 +273,15 @@ def jssesolve(
     keys = jnp.asarray(keys)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+
+    # === build options
+    options = Options(
+        save_states=save_states,
+        cartesian_batching=cartesian_batching,
+        t0=t0,
+        save_extra=save_extra,
+        nmaxclick=nmaxclick,
+    )
 
     # === check arguments
     _check_jssesolve_args(H, Ls, psi0, exp_ops)

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 from functools import partial
 
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, ArrayLike
+from jaxtyping import Array, ArrayLike, PyTree, ScalarLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
 from ...method import Dopri5, Dopri8, Euler, Expm, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options, check_options
+from ...progress_meter import AbstractProgressMeter
 from ...qarrays.dense_dataarray import DenseDataArray
 from ...qarrays.qarray import QArray, QArrayLike
 from ...result import MEPropagatorResult
@@ -41,7 +43,11 @@ def mepropagator(
     *,
     method: Method | None = None,
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_propagators: bool = True,
+    cartesian_batching: bool = True,
+    progress_meter: AbstractProgressMeter | bool | None = None,
+    t0: ScalarLike | None = None,
+    save_extra: Callable[[Array], PyTree] | None = None,
 ) -> MEPropagatorResult:
     r"""Compute the propagator of the Lindblad master equation.
 
@@ -215,6 +221,15 @@ def mepropagator(
     H = astimeqarray(H)
     Ls = [astimeqarray(L) for L in jump_ops]
     tsave = jnp.asarray(tsave)
+
+    # === build options
+    options = Options(
+        save_propagators=save_propagators,
+        cartesian_batching=cartesian_batching,
+        progress_meter=progress_meter,
+        t0=t0,
+        save_extra=save_extra,
+    )
 
     # === check arguments
     _check_mepropagator_args(H, Ls)

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import ArrayLike
+from jaxtyping import ArrayLike, PyTree, ScalarLike
 
 from ..._checks import check_qarray_is_dense, check_shape, check_times
 from ...gradient import Gradient
@@ -27,6 +28,7 @@ from ...method import (
     Tsit5,
 )
 from ...options import Options, check_options
+from ...progress_meter import AbstractProgressMeter
 from ...qarrays.qarray import QArray, QArrayLike
 from ...qarrays.utils import asqarray
 from ...result import MESolveResult
@@ -68,7 +70,13 @@ def mesolve(
     exp_ops: list[QArrayLike] | None = None,
     method: Method = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_states: bool = True,
+    cartesian_batching: bool = True,
+    progress_meter: AbstractProgressMeter | bool | None = None,
+    t0: ScalarLike | None = None,
+    save_extra: Callable[[Array], PyTree] | None = None,
+    vectorized: bool = False,
+    assume_hermitian: bool = True,
 ) -> MESolveResult:
     r"""Solve the Lindblad master equation.
 
@@ -283,6 +291,17 @@ def mesolve(
     tsave = jnp.asarray(tsave)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+
+    # === build options
+    options = Options(
+        save_states=save_states,
+        cartesian_batching=cartesian_batching,
+        progress_meter=progress_meter,
+        t0=t0,
+        save_extra=save_extra,
+        vectorized=vectorized,
+        assume_hermitian=assume_hermitian,
+    )
 
     # === check arguments
     _check_mesolve_args(H, Ls, rho0, exp_ops)

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -1,15 +1,17 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
 
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, ArrayLike
+from jaxtyping import Array, ArrayLike, PyTree, ScalarLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
 from ...method import Dopri5, Dopri8, Euler, Expm, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options, check_options
+from ...progress_meter import AbstractProgressMeter
 from ...qarrays.layout import dense
 from ...qarrays.qarray import QArrayLike
 from ...result import SEPropagatorResult
@@ -39,7 +41,10 @@ def sepropagator(
     *,
     method: Method | None = None,
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_propagators: bool = True,
+    progress_meter: AbstractProgressMeter | bool | None = None,
+    t0: ScalarLike | None = None,
+    save_extra: Callable[[Array], PyTree] | None = None,
 ) -> SEPropagatorResult:
     r"""Compute the propagator of the Schrödinger equation.
 
@@ -181,6 +186,14 @@ def sepropagator(
     # === convert arguments
     H = astimeqarray(H)
     tsave = jnp.asarray(tsave)
+
+    # === build options
+    options = Options(
+        save_propagators=save_propagators,
+        progress_meter=progress_meter,
+        t0=t0,
+        save_extra=save_extra,
+    )
 
     # === check arguments
     _check_sepropagator_args(H)

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from functools import partial
 
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import ArrayLike
+from jaxtyping import ArrayLike, PyTree, ScalarLike
 
 from ..._checks import check_shape, check_times
 from ...gradient import Gradient
 from ...method import Dopri5, Dopri8, Euler, Expm, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options, check_options
+from ...progress_meter import AbstractProgressMeter
 from ...qarrays.qarray import QArray, QArrayLike
 from ...qarrays.utils import asqarray
 from ...result import SESolveResult
@@ -41,7 +43,11 @@ def sesolve(
     exp_ops: list[QArrayLike] | None = None,
     method: Method = Tsit5(),  # noqa: B008
     gradient: Gradient | None = None,
-    options: Options = Options(),  # noqa: B008
+    save_states: bool = True,
+    cartesian_batching: bool = True,
+    progress_meter: AbstractProgressMeter | bool | None = None,
+    t0: ScalarLike | None = None,
+    save_extra: Callable[[Array], PyTree] | None = None,
 ) -> SESolveResult:
     r"""Solve the Schrödinger equation.
 
@@ -217,6 +223,15 @@ def sesolve(
     tsave = jnp.asarray(tsave)
     if exp_ops is not None:
         exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+
+    # === build options
+    options = Options(
+        save_states=save_states,
+        cartesian_batching=cartesian_batching,
+        progress_meter=progress_meter,
+        t0=t0,
+        save_extra=save_extra,
+    )
 
     # === check arguments
     _check_sesolve_args(H, psi0, exp_ops)

--- a/dynamiqs/options.py
+++ b/dynamiqs/options.py
@@ -96,7 +96,13 @@ def check_options(options: Options, solver_name: str):
             'assume_hermitian',
         ),
         'sepropagator': ('save_propagators', 'progress_meter', 't0', 'save_extra'),
-        'mepropagator': ('save_propagators', 'cartesian_batching', 't0', 'save_extra'),
+        'mepropagator': (
+            'save_propagators',
+            'cartesian_batching',
+            'progress_meter',
+            't0',
+            'save_extra',
+        ),
         'floquet': ('progress_meter', 't0'),
         'jssesolve': (
             'save_states',

--- a/tests/dsmesolve/test_batching.py
+++ b/tests/dsmesolve/test_batching.py
@@ -41,11 +41,17 @@ def test_keys_batching(cartesian_batching, H_batch, rho0_batch, ntrajs):
 
     keys = jax.random.split(jax.random.key(123), num=ntrajs)
     tsave = jnp.linspace(0.0, 0.1 * (ntsave - 1), ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerMaruyama(dt=1e-1)
 
     result = dq.dsmesolve(
-        H, jump_ops, etas, rho0, tsave, keys=keys, options=options, method=method
+        H,
+        jump_ops,
+        etas,
+        rho0,
+        tsave,
+        keys=keys,
+        method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     # expected batch shape
@@ -92,11 +98,17 @@ def test_keys_trajectory_independence(cartesian_batching):
     ntsave = 11
     keys = jax.random.split(jax.random.key(42), ntrajs)
     tsave = jnp.linspace(0.0, 1.0, ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerMaruyama(dt=1e-1)
 
     result = dq.dsmesolve(
-        H, jump_ops, etas, rho0, tsave, keys=keys, options=options, method=method
+        H,
+        jump_ops,
+        etas,
+        rho0,
+        tsave,
+        keys=keys,
+        method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     assert result.keys.shape == (2, ntrajs)

--- a/tests/dssesolve/test_batching.py
+++ b/tests/dssesolve/test_batching.py
@@ -40,11 +40,16 @@ def test_keys_batching(cartesian_batching, H_batch, psi0_batch, ntrajs):
 
     keys = jax.random.split(jax.random.key(123), num=ntrajs)
     tsave = jnp.linspace(0.0, 0.1 * (ntsave - 1), ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerMaruyama(dt=1e-1)
 
     result = dq.dssesolve(
-        H, jump_ops, psi0, tsave, keys=keys, options=options, method=method
+        H,
+        jump_ops,
+        psi0,
+        tsave,
+        keys=keys,
+        method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     # expected batch shape
@@ -90,11 +95,16 @@ def test_keys_trajectory_independence(cartesian_batching):
     ntsave = 11
     keys = jax.random.split(jax.random.key(42), ntrajs)
     tsave = jnp.linspace(0.0, 1.0, ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerMaruyama(dt=1e-1)
 
     result = dq.dssesolve(
-        H, jump_ops, psi0, tsave, keys=keys, options=options, method=method
+        H,
+        jump_ops,
+        psi0,
+        tsave,
+        keys=keys,
+        method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     assert result.keys.shape == (2, ntrajs)

--- a/tests/integrator_tester.py
+++ b/tests/integrator_tester.py
@@ -9,7 +9,6 @@ import jax.tree_util as jtu
 
 from dynamiqs.gradient import Forward, Gradient
 from dynamiqs.method import Method
-from dynamiqs.options import Options
 
 from .systems import System
 
@@ -20,12 +19,12 @@ class IntegratorTester:
         system: System,
         method: Method,
         *,
-        options: Options = Options(),  # noqa: B008
         ysave_atol: float = 1e-3,
         esave_rtol: float = 1e-3,
         esave_atol: float = 1e-4,
+        **solver_kwargs,
     ):
-        result = system.run(method, options=options)
+        result = system.run(method, **solver_kwargs)
 
         # === test ysave
         true_ysave = system.states(system.tsave)
@@ -53,9 +52,9 @@ class IntegratorTester:
         method: Method,
         gradient: Gradient,
         *,
-        options: Options = Options(),  # noqa: B008
         rtol: float = 1e-3,
         atol: float = 1e-4,
+        **solver_kwargs,
     ):
         def assert_allclose(pytree1, pytree2):
             # assert two pytrees are equal
@@ -67,7 +66,7 @@ class IntegratorTester:
 
         # === test gradients depending on final ysave
         def loss_ysave(params):
-            res = system.run(method, gradient=gradient, options=options, params=params)
+            res = system.run(method, gradient=gradient, params=params, **solver_kwargs)
             return system.loss_state(res.states[-1])
 
         # jax.grad uses reverse mode by default
@@ -86,7 +85,7 @@ class IntegratorTester:
 
         # === test gradients depending on final Esave
         def loss_Esave(params):
-            res = system.run(method, gradient=gradient, options=options, params=params)
+            res = system.run(method, gradient=gradient, params=params, **solver_kwargs)
             return system.loss_expect(res.expects[:, -1])
 
         true_grads_Esave = system.grads_expect(system.tsave[-1])

--- a/tests/jsmesolve/test_batching.py
+++ b/tests/jsmesolve/test_batching.py
@@ -42,7 +42,6 @@ def test_keys_batching(cartesian_batching, H_batch, rho0_batch, ntrajs):
 
     keys = jax.random.split(jax.random.key(123), num=ntrajs)
     tsave = jnp.linspace(0.0, 0.1 * (ntsave - 1), ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerJump(dt=1e-1)
 
     result = dq.jsmesolve(
@@ -53,8 +52,8 @@ def test_keys_batching(cartesian_batching, H_batch, rho0_batch, ntrajs):
         rho0,
         tsave,
         keys=keys,
-        options=options,
         method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     # expected batch shape
@@ -102,7 +101,6 @@ def test_keys_trajectory_independence(cartesian_batching):
     ntsave = 11
     keys = jax.random.split(jax.random.key(42), ntrajs)
     tsave = jnp.linspace(0.0, 1.0, ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerJump(dt=1e-1)
 
     result = dq.jsmesolve(
@@ -113,8 +111,8 @@ def test_keys_trajectory_independence(cartesian_batching):
         rho0,
         tsave,
         keys=keys,
-        options=options,
         method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     assert result.keys.shape == (2, ntrajs)

--- a/tests/jssesolve/test_batching.py
+++ b/tests/jssesolve/test_batching.py
@@ -58,10 +58,16 @@ def test_flat_batching(nL1, npsi0, ntrajs):
     H, Ls, psi0, Es, kmc = rand_jssesolve_args(n, nH, nLs, npsi0, nEs)
     keys = jax.random.split(kmc, num=ntrajs)
     tsave = jnp.linspace(0.0, 0.1, ntsave)
-    options = dq.Options(cartesian_batching=False)
     method = dq.method.Event(dtmax=1e-1)
     result = dq.jssesolve(
-        H, Ls, psi0, tsave, keys=keys, exp_ops=Es, options=options, method=method
+        H,
+        Ls,
+        psi0,
+        tsave,
+        keys=keys,
+        exp_ops=Es,
+        method=method,
+        cartesian_batching=False,
     )
 
     # check result shape
@@ -105,11 +111,16 @@ def test_keys_batching(cartesian_batching, H_batch, psi0_batch, ntrajs):
 
     keys = jax.random.split(jax.random.key(123), num=ntrajs)
     tsave = jnp.linspace(0.0, 0.1 * (ntsave - 1), ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerJump(dt=1e-1)
 
     result = dq.jssesolve(
-        H, jump_ops, psi0, tsave, keys=keys, options=options, method=method
+        H,
+        jump_ops,
+        psi0,
+        tsave,
+        keys=keys,
+        method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     # expected batch shape
@@ -155,11 +166,16 @@ def test_keys_trajectory_independence(cartesian_batching):
     ntsave = 11
     keys = jax.random.split(jax.random.key(42), ntrajs)
     tsave = jnp.linspace(0.0, 1.0, ntsave)
-    options = dq.Options(cartesian_batching=cartesian_batching)
     method = dq.method.EulerJump(dt=1e-1)
 
     result = dq.jssesolve(
-        H, jump_ops, psi0, tsave, keys=keys, options=options, method=method
+        H,
+        jump_ops,
+        psi0,
+        tsave,
+        keys=keys,
+        method=method,
+        cartesian_batching=cartesian_batching,
     )
 
     assert result.keys.shape == (2, ntrajs)

--- a/tests/jssesolve/test_jssesolve.py
+++ b/tests/jssesolve/test_jssesolve.py
@@ -24,7 +24,6 @@ def test_against_mesolve_oscillator(smart_sampling, atol=1e-2):
     tsave = jnp.linspace(0.0, 2.0, 11)
     keys = jax.random.split(jax.random.key(31), num=ntrajs)
     exp_ops = [a.dag() @ a]
-    me_options = dq.Options(progress_meter=None)
 
     # solve with jssesolve and mesolve
     root_finder = optx.Newton(1e-4, 1e-4, jtu.Partial(optx.rms_norm))
@@ -32,7 +31,9 @@ def test_against_mesolve_oscillator(smart_sampling, atol=1e-2):
     jsseresult = dq.jssesolve(
         H, jump_ops, psi0, tsave, keys, exp_ops=exp_ops, method=method
     )
-    meresult = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=me_options)
+    meresult = dq.mesolve(
+        H, jump_ops, psi0, tsave, exp_ops=exp_ops, progress_meter=None
+    )
 
     # compare results on average
     assert jnp.allclose(meresult.expects, jsseresult.mean_expects(), atol=atol)
@@ -59,7 +60,6 @@ def test_against_mesolve_qubit(smart_sampling, atol=1e-2):
     tsave = jnp.linspace(0, 1.0, 41)
     keys = jax.random.split(jax.random.key(42), num=ntrajs)
     exp_ops = [dq.excited().todm(), dq.ground().todm()]
-    me_options = dq.Options(progress_meter=None)
     root_finder = optx.Newton(1e-3, 1e-3, jtu.Partial(optx.rms_norm))
     method = dq.method.Event(root_finder=root_finder, smart_sampling=smart_sampling)
 
@@ -67,7 +67,9 @@ def test_against_mesolve_qubit(smart_sampling, atol=1e-2):
     jsseresult = dq.jssesolve(
         H, jump_ops, psi0, tsave, keys=keys, exp_ops=exp_ops, method=method
     )
-    meresult = dq.mesolve(H, jump_ops, psi0, tsave, exp_ops=exp_ops, options=me_options)
+    meresult = dq.mesolve(
+        H, jump_ops, psi0, tsave, exp_ops=exp_ops, progress_meter=None
+    )
 
     # compare results on average
     assert jnp.allclose(meresult.expects, jsseresult.mean_expects(), atol=atol)

--- a/tests/mepropagator/test_batching.py
+++ b/tests/mepropagator/test_batching.py
@@ -38,8 +38,7 @@ def test_flat_batching(nL1):
     # run mepropagator
     H, Ls = rand_mepropagator_args(n, nH, nLs)
     tsave = jnp.linspace(0, 0.01, ntsave)
-    options = dq.Options(cartesian_batching=False)
-    result = dq.mepropagator(H, Ls, tsave, options=options)
+    result = dq.mepropagator(H, Ls, tsave, cartesian_batching=False)
 
     # check result shape
     broadcast_shape = jnp.broadcast_shapes(nH, nL1)

--- a/tests/mepropagator/test_expm.py
+++ b/tests/mepropagator/test_expm.py
@@ -2,16 +2,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from dynamiqs import (
-    Options,
-    dag,
-    eye,
-    mepropagator,
-    pwc,
-    slindbladian,
-    unvectorize,
-    vectorize,
-)
+from dynamiqs import dag, eye, mepropagator, pwc, slindbladian, unvectorize, vectorize
 
 from ..integrator_tester import IntegratorTester
 from ..order import TEST_LONG
@@ -42,8 +33,7 @@ class TestMEPropagator(IntegratorTester):
         _H, Ls = rand_mepropagator_args(2, (), [(), ()])
         H = pwc(times, values, _H)
         tsave = jnp.asarray([0.5, 1.0, 2.0])
-        options = Options(save_propagators=save_propagators)
-        propresult = mepropagator(H, Ls, tsave, options=options)
+        propresult = mepropagator(H, Ls, tsave, save_propagators=save_propagators)
         propagators = propresult.propagators.to_jax()
         U0 = eye(H.shape[-1] ** 2).to_jax()
         lindbladian_1 = slindbladian(3.0 * H.qarray, Ls)

--- a/tests/mesolve/test_adaptive.py
+++ b/tests/mesolve/test_adaptive.py
@@ -1,6 +1,5 @@
 import pytest
 
-from dynamiqs import Options
 from dynamiqs.gradient import BackwardCheckpointed, Direct, Forward
 from dynamiqs.method import Tsit5
 
@@ -19,8 +18,9 @@ class TestMESolveAdaptive(IntegratorTester):
         [(True, True), (False, True), (False, False)],
     )
     def test_correctness(self, system, vectorized, assume_hermitian):
-        options = Options(vectorized=vectorized, assume_hermitian=assume_hermitian)
-        self._test_correctness(system, Tsit5(), options=options)
+        self._test_correctness(
+            system, Tsit5(), vectorized=vectorized, assume_hermitian=assume_hermitian
+        )
 
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct(), BackwardCheckpointed(), Forward()])

--- a/tests/mesolve/test_adaptive_lowrank.py
+++ b/tests/mesolve/test_adaptive_lowrank.py
@@ -3,7 +3,6 @@ import jax.numpy as jnp
 import pytest
 
 import dynamiqs as dq
-from dynamiqs import Options
 from dynamiqs.gradient import BackwardCheckpointed, Direct, Forward
 from dynamiqs.method import LowRank, Tsit5
 
@@ -37,8 +36,7 @@ class TestMESolveAdaptiveLowRank(IntegratorTester):
 
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
     def test_correctness(self, system):
-        options = Options()
-        self._test_correctness(system, _lowrank_method(system), options=options)
+        self._test_correctness(system, _lowrank_method(system))
 
     @pytest.mark.parametrize('system', [dense_ocavity, dia_ocavity, otdqubit])
     @pytest.mark.parametrize('gradient', [Direct(), BackwardCheckpointed(), Forward()])
@@ -47,7 +45,7 @@ class TestMESolveAdaptiveLowRank(IntegratorTester):
 
     @pytest.mark.parametrize('system', [dense_ocavity])
     def test_lowrank_states(self, system):
-        result = system.run(_lowrank_method(system), options=Options())
+        result = system.run(_lowrank_method(system))
         assert isinstance(result, dq.MESolveLowRankResult)
 
         m = result.lowrank_states.to_jax()

--- a/tests/mesolve/test_batching.py
+++ b/tests/mesolve/test_batching.py
@@ -53,8 +53,7 @@ def test_flat_batching(nL1, npsi0):
     # run mesolve
     H, Ls, psi0, Es = rand_mesolve_args(n, nH, nLs, npsi0, nEs)
     tsave = jnp.linspace(0, 0.01, ntsave)
-    options = dq.Options(cartesian_batching=False)
-    result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=Es, options=options)
+    result = dq.mesolve(H, Ls, psi0, tsave, exp_ops=Es, cartesian_batching=False)
 
     # check result shape
     broadcast_shape = jnp.broadcast_shapes(nH, nL1, npsi0)

--- a/tests/sepropagator/test_sepropagator.py
+++ b/tests/sepropagator/test_sepropagator.py
@@ -2,7 +2,7 @@ import jax
 import jax.numpy as jnp
 import pytest
 
-from dynamiqs import Options, constant, eye, pwc, random, sepropagator, sigmax, sigmay
+from dynamiqs import constant, eye, pwc, random, sepropagator, sigmax, sigmay
 from dynamiqs.method import Tsit5
 
 from ..integrator_tester import IntegratorTester
@@ -30,8 +30,9 @@ class TestSEPropagator(IntegratorTester):
     ):
         H = constant(random.herm(jax.random.PRNGKey(42), (*nH, 2, 2)))
         tsave = jnp.linspace(1.0, 10.0, 3)
-        options = Options(save_propagators=save_propagators, t0=0.0)
-        propresult = sepropagator(H, tsave, method=method, options=options)
+        propresult = sepropagator(
+            H, tsave, method=method, save_propagators=save_propagators, t0=0.0
+        )
         propagators = propresult.propagators.to_jax()
         ts = tsave if save_propagators else jnp.asarray([10.0])
         Hts = jnp.einsum('...ij,t->...tij', H.qarray.to_jax(), ts)
@@ -46,8 +47,9 @@ class TestSEPropagator(IntegratorTester):
         qarray = sigmay()
         H = pwc(times, values, qarray)
         tsave = jnp.asarray([0.5, 1.0, 2.0])
-        options = Options(save_propagators=save_propagators)
-        propresult = sepropagator(H, tsave, method=method, options=options)
+        propresult = sepropagator(
+            H, tsave, method=method, save_propagators=save_propagators
+        )
         propagators = propresult.propagators.to_jax()
         U0 = eye(H.shape[-1]).to_jax()
         U1 = jax.scipy.linalg.expm(-1j * H.qarray.to_jax() * 3.0 * 0.5)
@@ -71,8 +73,9 @@ class TestSEPropagator(IntegratorTester):
         H2 = pwc(times_2, values_2, sigmax())
         H = H1 + H2
         tsave = jnp.asarray([0.5, 1.0, 2.5])
-        options = Options(save_propagators=save_propagators)
-        propresult = sepropagator(H, tsave, method=method, options=options)
+        propresult = sepropagator(
+            H, tsave, method=method, save_propagators=save_propagators
+        )
         propagators = propresult.propagators.to_jax()
         H1_array = H1.qarray.to_jax()
         H2_array = H2.qarray.to_jax()

--- a/tests/sesolve/test_batching.py
+++ b/tests/sesolve/test_batching.py
@@ -47,8 +47,7 @@ def test_flat_batching(npsi0):
     # run sesolve
     H, psi0, Es = rand_sesolve_args(n, nH, npsi0, nEs)
     tsave = jnp.linspace(0, 0.01, ntsave)
-    options = dq.Options(cartesian_batching=False)
-    result = dq.sesolve(H, psi0, tsave, exp_ops=Es, options=options)
+    result = dq.sesolve(H, psi0, tsave, exp_ops=Es, cartesian_batching=False)
 
     # check result shape
     broadcast_shape = jnp.broadcast_shapes(nH, npsi0)

--- a/tests/systems/_system.py
+++ b/tests/systems/_system.py
@@ -9,7 +9,6 @@ from jaxtyping import PyTree
 from dynamiqs import QArray, stack
 from dynamiqs.gradient import Gradient
 from dynamiqs.method import Method
-from dynamiqs.options import Options
 from dynamiqs.result import Result
 from dynamiqs.time_qarray import TimeQArray
 
@@ -72,7 +71,6 @@ class System(ABC):
         method: Method,
         *,
         gradient: Gradient | None = None,
-        options: Options = Options(),  # noqa: B008
         params: PyTree | None = None,
     ) -> Result:
         pass

--- a/tests/systems/closed_system.py
+++ b/tests/systems/closed_system.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import NamedTuple
 
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
-from jaxtyping import ArrayLike, PyTree
+from jaxtyping import ArrayLike, PyTree, ScalarLike
 
 import dynamiqs as dq
 from dynamiqs import QArray
 from dynamiqs.gradient import Gradient
 from dynamiqs.method import Method
-from dynamiqs.options import Options
+from dynamiqs.progress_meter import AbstractProgressMeter
 from dynamiqs.qarrays.layout import Layout
 from dynamiqs.result import Result
 from dynamiqs.time_qarray import TimeQArray
@@ -25,8 +26,12 @@ class ClosedSystem(System):
         method: Method,
         *,
         gradient: Gradient | None = None,
-        options: Options = Options(),  # noqa: B008
         params: PyTree | None = None,
+        save_states: bool = True,
+        cartesian_batching: bool = True,
+        progress_meter: AbstractProgressMeter | bool | None = None,
+        t0: ScalarLike | None = None,
+        save_extra: Callable[[Array], PyTree] | None = None,
     ) -> Result:
         params = self.params_default if params is None else params
         H = self.H(params)
@@ -39,7 +44,11 @@ class ClosedSystem(System):
             exp_ops=Es,
             method=method,
             gradient=gradient,
-            options=options,
+            save_states=save_states,
+            cartesian_batching=cartesian_batching,
+            progress_meter=progress_meter,
+            t0=t0,
+            save_extra=save_extra,
         )
 
 

--- a/tests/systems/floquet_qubit.py
+++ b/tests/systems/floquet_qubit.py
@@ -4,13 +4,13 @@ from typing import NamedTuple
 
 import jax.numpy as jnp
 from jax import Array
-from jaxtyping import PyTree
+from jaxtyping import PyTree, ScalarLike
 
 from dynamiqs import basis, sigmax, sigmaz, stack
 from dynamiqs.gradient import Gradient
 from dynamiqs.integrators.apis.floquet import floquet
 from dynamiqs.method import Method
-from dynamiqs.options import Options
+from dynamiqs.progress_meter import AbstractProgressMeter
 from dynamiqs.result import FloquetResult
 from dynamiqs.time_qarray import CallableTimeQArray
 
@@ -31,14 +31,21 @@ class FloquetQubit(System):
         method: Method,
         *,
         gradient: Gradient | None = None,
-        options: Options = Options(),  # noqa: B008
         params: PyTree | None = None,
+        progress_meter: AbstractProgressMeter | bool | None = None,
+        t0: ScalarLike | None = None,
     ) -> FloquetResult:
         params = self.params_default if params is None else params
         H = self.H(params)
         T = 2.0 * jnp.pi / params.omega_d
         return floquet(
-            H, T, params.tsave, method=method, gradient=gradient, options=options
+            H,
+            T,
+            params.tsave,
+            method=method,
+            gradient=gradient,
+            progress_meter=progress_meter,
+            t0=t0,
         )
 
     def __init__(

--- a/tests/systems/open_system.py
+++ b/tests/systems/open_system.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Callable
 from typing import NamedTuple
 
 import jax.numpy as jnp
 import numpy as np
 from jax import Array
-from jaxtyping import ArrayLike, PyTree
+from jaxtyping import ArrayLike, PyTree, ScalarLike
 
 import dynamiqs as dq
 from dynamiqs import QArray, asqarray, dense
 from dynamiqs.gradient import Gradient
 from dynamiqs.method import Method
-from dynamiqs.options import Options
+from dynamiqs.progress_meter import AbstractProgressMeter
 from dynamiqs.qarrays.layout import Layout
 from dynamiqs.result import Result
 from dynamiqs.time_qarray import TimeQArray
@@ -30,8 +31,14 @@ class OpenSystem(System):
         method: Method,
         *,
         gradient: Gradient | None = None,
-        options: Options = Options(),  # noqa: B008
         params: PyTree | None = None,
+        save_states: bool = True,
+        cartesian_batching: bool = True,
+        progress_meter: AbstractProgressMeter | bool | None = None,
+        t0: ScalarLike | None = None,
+        save_extra: Callable[[Array], PyTree] | None = None,
+        vectorized: bool = False,
+        assume_hermitian: bool = True,
     ) -> Result:
         params = self.params_default if params is None else params
         H = self.H(params)
@@ -46,7 +53,13 @@ class OpenSystem(System):
             exp_ops=Es,
             method=method,
             gradient=gradient,
-            options=options,
+            save_states=save_states,
+            cartesian_batching=cartesian_batching,
+            progress_meter=progress_meter,
+            t0=t0,
+            save_extra=save_extra,
+            vectorized=vectorized,
+            assume_hermitian=assume_hermitian,
         )
 
 


### PR DESCRIPTION
## Summary

This PR flattens solver options in the public API.

Instead of passing an `Options` object via `options=...`, users now pass solver settings directly as keyword arguments.

This change applies to the codebase only. Documentation updates will be handled separately.

This modification only affects the public API. Internally, each solver still constructs a `dq.Options` object before passing it to lower-level integrators. This PR can therefore serve as a first step toward fully removing the `dq.Options` class in a future change, if we decide to go in that direction.


## Changes

- Removed the `options=` argument from the public API of all 9 main solver functions.
- corrected 3 documentation expales to run with the new functions 
- corrected all tests where options were passed to the solver

## Affected solvers

- `sesolve`
- `mesolve`
- `dssesolve`
- `dsmesolve`
- `jssesolve`
- `jsmesolve`
- `floquet`
- `sepropagator`
- `mepropagator`

## Additional fixes

This PR also fixes two inconsistencies in solver option handling:

- Added `progress_meter` to `mepropagator`, which was already supported by the underlying diffrax integrator.

## Breaking change

Code using `options=dq.Options(...)` with these solvers will now raise a `TypeError`.

## Examples

Before:

```
dq.mesolve(..., options=dq.Options(save_states=False))
```

After:

```
dq.mesolve(..., save_states=False)
```