### PR TITLE
Api/expose progress meter

### DIFF
--- a/docs/generate_python_api.py
+++ b/docs/generate_python_api.py
@@ -29,6 +29,7 @@ doc_sections = {
     'utils/optimal_control': (['dynamiqs/utils/optimal_control.py'], 'dq'),
     'random': (['dynamiqs/random/'], 'dq.random'),
     'plot': (['dynamiqs/plot/'], 'dq.plot'),
+    'progress_meter': (['dynamiqs/progress_meter.py'], 'dq'),
 }
 
 

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -95,7 +95,6 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         extra:
             table: true
         members:
-        - AbstractProgressMeter
         - NoProgressMeter
         - TextProgressMeter
         - TqdmProgressMeter

--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -88,6 +88,18 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - BackwardCheckpointed
         - Forward
 
+### Progress meters
+
+::: dynamiqs.progress_meter
+    options:
+        extra:
+            table: true
+        members:
+        - AbstractProgressMeter
+        - NoProgressMeter
+        - TextProgressMeter
+        - TqdmProgressMeter
+
 ## Utilities
 
 ### Operators

--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -1,8 +1,8 @@
 from . import plot, random
 from .helpers import *
 from .integrators import *
-from .progress_meter import *
 from .options import *
+from .progress_meter import *
 from .qarrays import *
 from .qarrays.layout import dense, dia
 from .result import *

--- a/dynamiqs/__init__.py
+++ b/dynamiqs/__init__.py
@@ -1,6 +1,7 @@
 from . import plot, random
 from .helpers import *
 from .integrators import *
+from .progress_meter import *
 from .options import *
 from .qarrays import *
 from .qarrays.layout import dense, dia

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -13,17 +13,43 @@ __all__ = [
 
 
 class AbstractProgressMeter(eqx.Module):
+    """Abstract base class for progress meters.
+
+    Implement this class to define a custom progress meter. Pass an instance to any
+    solver via the `progress_meter` argument.
+    """
+
     @abstractmethod
     def to_diffrax(self) -> dx.AbstractProgressMeter:
         pass
 
 
 class NoProgressMeter(AbstractProgressMeter):
+    """Progress meter that produces no output.
+
+    Pass to any solver via `progress_meter=dq.NoProgressMeter()` (or equivalently
+    `progress_meter=False`) to suppress all progress output.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self):
+        pass
+
     def to_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.NoProgressMeter()
 
 
 class TextProgressMeter(AbstractProgressMeter):
+    """Plain-text progress meter that prints to standard output.
+
+    Prints a simple text line updated in place during the integration. Useful in
+    environments where tqdm is not available or not desired.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self):
+        pass
+
     def to_diffrax(self) -> dx.AbstractProgressMeter:
         return dx.TextProgressMeter()
 
@@ -76,5 +102,21 @@ class _DiffraxTqdmProgressMeter(dx.TqdmProgressMeter):
 
 
 class TqdmProgressMeter(AbstractProgressMeter):
+    """tqdm progress bar (default progress meter).
+
+    Displays a rich progress bar powered by [tqdm](https://github.com/tqdm/tqdm),
+    showing percentage completion, elapsed time, and estimated remaining time.
+
+    This is the default progress meter used by all solvers when `progress_meter=None`
+    (unless overridden globally with [`dq.set_progress_meter()`][dynamiqs.set_progress_meter]).
+
+    Pass `progress_meter=True` or `progress_meter=dq.TqdmProgressMeter()` explicitly
+    to force it.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self):
+        pass
+
     def to_diffrax(self) -> dx.AbstractProgressMeter:
         return _DiffraxTqdmProgressMeter()

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -4,11 +4,7 @@ import diffrax as dx
 import equinox as eqx
 from tqdm import tqdm
 
-__all__ = [
-    'NoProgressMeter',
-    'TextProgressMeter',
-    'TqdmProgressMeter',
-]
+__all__ = ['NoProgressMeter', 'TextProgressMeter', 'TqdmProgressMeter']
 
 
 class AbstractProgressMeter(eqx.Module):

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -108,7 +108,8 @@ class TqdmProgressMeter(AbstractProgressMeter):
     showing percentage completion, elapsed time, and estimated remaining time.
 
     This is the default progress meter used by all solvers when `progress_meter=None`
-    (unless overridden globally with [`dq.set_progress_meter()`][dynamiqs.set_progress_meter]).
+    (unless overridden globally with
+    [`dq.set_progress_meter()`][dynamiqs.set_progress_meter]).
 
     Pass `progress_meter=True` or `progress_meter=dq.TqdmProgressMeter()` explicitly
     to force it.

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -5,7 +5,6 @@ import equinox as eqx
 from tqdm import tqdm
 
 __all__ = [
-    'AbstractProgressMeter',
     'NoProgressMeter',
     'TextProgressMeter',
     'TqdmProgressMeter',

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,11 @@ nav:
               - Direct: python_api/gradient/Direct.md
               - BackwardCheckpointed: python_api/gradient/BackwardCheckpointed.md
               - Forward: python_api/gradient/Forward.md
+          - Progress meters:
+              - AbstractProgressMeter: python_api/progress_meter/AbstractProgressMeter.md
+              - NoProgressMeter: python_api/progress_meter/NoProgressMeter.md
+              - TextProgressMeter: python_api/progress_meter/TextProgressMeter.md
+              - TqdmProgressMeter: python_api/progress_meter/TqdmProgressMeter.md
       - Utilities:
           - Operators:
               - eye: python_api/utils/operators/eye.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -192,7 +192,6 @@ nav:
               - BackwardCheckpointed: python_api/gradient/BackwardCheckpointed.md
               - Forward: python_api/gradient/Forward.md
           - Progress meters:
-              - AbstractProgressMeter: python_api/progress_meter/AbstractProgressMeter.md
               - NoProgressMeter: python_api/progress_meter/NoProgressMeter.md
               - TextProgressMeter: python_api/progress_meter/TextProgressMeter.md
               - TqdmProgressMeter: python_api/progress_meter/TqdmProgressMeter.md


### PR DESCRIPTION
## Summary

This PR exposes progress meter classes in the public API and adds them to the generated API documentation.

Users can now access progress meters directly from `dynamiqs`, for example `dq.NoProgressMeter()` or `dq.TqdmProgressMeter()`.

## Changes

- Exported progress meter classes from the top-level `dynamiqs` API.
- Added docstrings for the 4 public progress meter classes:
  - `AbstractProgressMeter`
  - `NoProgressMeter`
  - `TextProgressMeter`
  - `TqdmProgressMeter`
- Added `progress_meter` to the Python API generation script.
- Added generated API pages for progress meters.
- Added a new “Progress meters” section to the API index and navigation.