### PR TITLE
fix: use floor division in integrate_by_chunks

### DIFF
--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -138,7 +138,7 @@ class StochasticSolveFixedStepIntegrator(
         # chunks of 1000 dts to ensure a fixed memory usage
 
         nsteps_per_chunk = 1000
-        nchunks = round(nsteps / nsteps_per_chunk)
+        nchunks = nsteps // nsteps_per_chunk
 
         # iterate over each chunk
         def step(carry, key):  # noqa: ANN001, ANN202


### PR DESCRIPTION
Replace `round(nsteps / nsteps_per_chunk)` with `nsteps // nsteps_per_chunk` to avoid rounding up when `nsteps % 1000 >= 500`, which caused extra integration steps.

Closes #1092