### PR TITLE
feat: add qarray manipulation utilities

### DIFF
--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -310,6 +310,52 @@ class QArray(eqx.Module):
         """
         return replace(self, data=self.data.broadcast_to(*shape))
 
+    def swapaxes(self, axis1: int, axis2: int) -> QArray | Array:
+        """Swap two axes of a qarray.
+
+        Args:
+            axis1: First axis.
+            axis2: Second axis.
+
+        Returns:
+            New qarray when the resulting shape is compatible with the original Hilbert
+                space dimensions, otherwise a JAX array.
+        """
+        from .utils import swapaxes  # noqa: PLC0415
+
+        return swapaxes(self, axis1, axis2)
+
+    def moveaxis(
+        self, source: int | Sequence[int], destination: int | Sequence[int]
+    ) -> QArray | Array:
+        """Move axes of a qarray to new positions.
+
+        Args:
+            source: Original positions of the axes to move.
+            destination: Destination positions for each original axis.
+
+        Returns:
+            New qarray when the resulting shape is compatible with the original Hilbert
+                space dimensions, otherwise a JAX array.
+        """
+        from .utils import moveaxis  # noqa: PLC0415
+
+        return moveaxis(self, source, destination)
+
+    def expand_dims(self, axis: int | Sequence[int]) -> QArray | Array:
+        """Insert one or more singleton axes into a qarray.
+
+        Args:
+            axis: Position or positions where new axes are inserted.
+
+        Returns:
+            New qarray when the resulting shape is compatible with the original Hilbert
+                space dimensions, otherwise a JAX array.
+        """
+        from .utils import expand_dims  # noqa: PLC0415
+
+        return expand_dims(self, axis)
+
     def powm(self, n: int) -> QArray:
         return replace(self, data=self.data.powm(n))
 

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 
 import jax.numpy as jnp
 import numpy as np
+from jax import Array
 from jaxtyping import ArrayLike, DTypeLike
 from qutip import Qobj
 
@@ -21,12 +22,17 @@ from .sparsedia_primitives import (
 
 __all__ = [
     'asqarray',
+    'concatenate',
+    'expand_dims',
+    'isqarraylike',
+    'moveaxis',
     'sparsedia_from_dict',
     'stack',
+    'swapaxes',
     'to_jax',
     'to_numpy',
     'to_qutip',
-    'isqarraylike',
+    'where',
 ]
 
 
@@ -200,6 +206,129 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
     else:
         raise NotImplementedError(
             'Stacking qarrays with different data types is not implemented.'
+        )
+
+
+def swapaxes(x: QArrayLike, axis1: int, axis2: int) -> QArray | Array:
+    """Swap two axes of a qarray-like object.
+
+    Args:
+        x: Qarray-like object to manipulate.
+        axis1: First axis.
+        axis2: Second axis.
+
+    Returns:
+        A qarray when the resulting shape is compatible with the input Hilbert space
+            dimensions, otherwise a JAX array.
+    """
+    x = asqarray(x)
+    data = jnp.swapaxes(x.to_jax(), axis1, axis2)
+    return _wrap_like_if_compatible(x, data)
+
+
+def moveaxis(
+    x: QArrayLike, source: int | Sequence[int], destination: int | Sequence[int]
+) -> QArray | Array:
+    """Move axes of a qarray-like object to new positions.
+
+    Args:
+        x: Qarray-like object to manipulate.
+        source: Original positions of the axes to move.
+        destination: Destination positions for each original axis.
+
+    Returns:
+        A qarray when the resulting shape is compatible with the input Hilbert space
+            dimensions, otherwise a JAX array.
+    """
+    x = asqarray(x)
+    data = jnp.moveaxis(x.to_jax(), source, destination)
+    return _wrap_like_if_compatible(x, data)
+
+
+def expand_dims(x: QArrayLike, axis: int | Sequence[int]) -> QArray | Array:
+    """Insert one or more singleton axes into a qarray-like object.
+
+    Args:
+        x: Qarray-like object to manipulate.
+        axis: Position or positions where new axes are inserted.
+
+    Returns:
+        A qarray when the resulting shape is compatible with the input Hilbert space
+            dimensions, otherwise a JAX array.
+    """
+    x = asqarray(x)
+    data = jnp.expand_dims(x.to_jax(), axis)
+    return _wrap_like_if_compatible(x, data)
+
+
+def where(condition: ArrayLike, x: QArrayLike, y: QArrayLike) -> QArray | Array:
+    """Select values from qarray-like inputs according to a condition.
+
+    Args:
+        condition: Boolean condition broadcastable against `x` and `y`.
+        x: Values chosen where `condition` is true.
+        y: Values chosen where `condition` is false.
+
+    Returns:
+        A qarray when either input is a qarray and the resulting shape remains
+            compatible with its Hilbert space dimensions, otherwise a JAX array.
+    """
+    reference = _first_qarray(x, y)
+    _check_matching_dims(x, y)
+
+    data = jnp.where(condition, to_jax(x), to_jax(y))
+    if reference is None:
+        return data
+    return _wrap_like_if_compatible(reference, data)
+
+
+def concatenate(qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray | Array:
+    """Join qarray-like objects along an existing axis.
+
+    Args:
+        qarrays: Qarray-like objects to concatenate.
+        axis: Axis in the result along which the inputs are joined.
+
+    Returns:
+        A qarray when all qarray inputs have matching Hilbert space dimensions and the
+            resulting shape is compatible with those dimensions, otherwise a JAX array.
+    """
+    if len(qarrays) == 0:
+        raise ValueError('Argument `qarrays` must contain at least one element.')
+
+    reference = _first_qarray(*qarrays)
+    _check_matching_dims(*qarrays)
+
+    data = jnp.concatenate([to_jax(qarray) for qarray in qarrays], axis=axis)
+    if reference is None:
+        return data
+    return _wrap_like_if_compatible(reference, data)
+
+
+def _wrap_like_if_compatible(reference: QArray, data: Array) -> QArray | Array:
+    if data.shape[-2:] != reference.shape[-2:]:
+        return data
+
+    try:
+        return QArray(reference.dims, reference.vectorized, DenseDataArray(data))
+    except ValueError:
+        return data
+
+
+def _first_qarray(*values: QArrayLike) -> QArray | None:
+    return next((value for value in values if isinstance(value, QArray)), None)
+
+
+def _check_matching_dims(*values: QArrayLike) -> None:
+    qarrays = [value for value in values if isinstance(value, QArray)]
+    if not qarrays:
+        return
+
+    dims = qarrays[0].dims
+    if not all(qarray.dims == dims for qarray in qarrays):
+        raise ValueError(
+            f'Qarrays have incompatible Hilbert space dimensions. '
+            f'Got {[qarray.dims for qarray in qarrays]}.'
         )
 
 

--- a/tests/qarrays/test_utils.py
+++ b/tests/qarrays/test_utils.py
@@ -69,6 +69,71 @@ def test_stack_double(rtol=1e-05, atol=1e-08):
 
 @pytest.mark.run(order=TEST_INSTANT)
 @pytest.mark.parametrize('layout', [dq.dense, dq.dia])
+def test_qarray_manipulation_preserves_batch_qarray(layout):
+    data = jnp.arange(24).reshape(2, 3, 2, 2)
+    qarray = dq.asqarray(data, dims=(2,), layout=layout)
+
+    swapped = dq.swapaxes(qarray, 0, 1)
+    assert isinstance(swapped, dq.QArray)
+    assert swapped.dims == qarray.dims
+    assert jnp.array_equal(swapped.to_jax(), jnp.swapaxes(data, 0, 1))
+
+    moved = dq.moveaxis(qarray, 0, 1)
+    assert isinstance(moved, dq.QArray)
+    assert moved.dims == qarray.dims
+    assert jnp.array_equal(moved.to_jax(), jnp.moveaxis(data, 0, 1))
+
+    expanded = dq.expand_dims(qarray, 1)
+    assert isinstance(expanded, dq.QArray)
+    assert expanded.dims == qarray.dims
+    assert jnp.array_equal(expanded.to_jax(), jnp.expand_dims(data, 1))
+
+    assert jnp.array_equal(qarray.swapaxes(0, 1).to_jax(), jnp.swapaxes(data, 0, 1))
+    assert jnp.array_equal(qarray.moveaxis(0, 1).to_jax(), jnp.moveaxis(data, 0, 1))
+    assert jnp.array_equal(qarray.expand_dims(1).to_jax(), jnp.expand_dims(data, 1))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_qarray_manipulation_returns_array_when_quantum_shape_changes():
+    qarray = dq.asqarray(jnp.arange(24).reshape(2, 3, 2, 2), dims=(2,))
+
+    moved = dq.moveaxis(qarray, -1, 0)
+
+    assert not isinstance(moved, dq.QArray)
+    assert jnp.array_equal(moved, jnp.moveaxis(qarray.to_jax(), -1, 0))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize('layout', [dq.dense, dq.dia])
+def test_qarray_where_and_concatenate(layout):
+    x = dq.asqarray(jnp.arange(8).reshape(2, 2, 2), dims=(2,), layout=layout)
+    y = dq.asqarray(jnp.arange(8, 16).reshape(2, 2, 2), dims=(2,), layout=layout)
+
+    condition = jnp.array([True, False])[:, None, None]
+    selected = dq.where(condition, x, y)
+
+    assert isinstance(selected, dq.QArray)
+    assert selected.dims == x.dims
+    assert jnp.array_equal(
+        selected.to_jax(), jnp.where(condition, x.to_jax(), y.to_jax())
+    )
+
+    selected_with_scalar = dq.where(condition, x, 0)
+    assert isinstance(selected_with_scalar, dq.QArray)
+    assert jnp.array_equal(
+        selected_with_scalar.to_jax(), jnp.where(condition, x.to_jax(), 0)
+    )
+
+    concatenated = dq.concatenate([x, y], axis=0)
+    assert isinstance(concatenated, dq.QArray)
+    assert concatenated.dims == x.dims
+    assert jnp.array_equal(
+        concatenated.to_jax(), jnp.concatenate([x.to_jax(), y.to_jax()], axis=0)
+    )
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize('layout', [dq.dense, dq.dia])
 def test_conversions(layout):
     sx, sy = dq.sigmax(), dq.sigmay()
     assert jnp.allclose(sx.to_jax(), dq.asqarray(sx, layout=layout).to_jax())


### PR DESCRIPTION
## Summary

- adds QArray manipulation helpers: `swapaxes`, `moveaxis`, `expand_dims`, `where`, and `concatenate`
- exposes `swapaxes`, `moveaxis`, and `expand_dims` as `QArray` convenience methods
- wraps results back into a `QArray` when the original quantum-object trailing shape is preserved; otherwise returns the JAX array result
- validates matching Hilbert-space dimensions for multi-QArray `where` and `concatenate`
- extends QArray utility tests across dense and sparse-DIA inputs

Closes #1080.

## Validation

- `uv run --python 3.11 --with-editable . --with pytest --with pytest-ordering python -m pytest tests/qarrays/test_utils.py -q`
- `uv run --python 3.11 --with-editable . --with pytest --with pytest-ordering python -m pytest tests/qarrays -q`
- `uv run --python 3.11 --with ruff ruff check dynamiqs/qarrays/qarray.py dynamiqs/qarrays/utils.py tests/qarrays/test_utils.py`
- `uv run --python 3.11 --with ruff ruff format --check dynamiqs/qarrays/qarray.py dynamiqs/qarrays/utils.py tests/qarrays/test_utils.py`
- `uv run --python 3.11 python -m compileall -q dynamiqs/qarrays tests/qarrays/test_utils.py`
- `git diff --check`

## Notes

Sparse-DIA inputs are accepted and tested. The new manipulation helpers currently materialize a dense result when wrapping is appropriate, matching the issue goal of preserving the QArray abstraction without forcing users to convert manually.

## AI Use Disclosure

This contribution was AI-assisted. I reviewed the QArray API and existing tests, scoped the helpers to batch-safe QArray wrapping semantics, ran the focused and full qarray test suites locally, and checked lint/format gates.
