### PR TITLE
Expand ty coverage for random and utility modules

### DIFF
--- a/dynamiqs/utils/wigner_utils.py
+++ b/dynamiqs/utils/wigner_utils.py
@@ -98,14 +98,18 @@ def _wigner(state: Array, xvec: Array, yvec: Array, g: float = 2.0) -> Array:
     return w.real * jnp.exp(-2 * a2) * 0.5 * g**2 / jnp.pi
 
 
-def _diag_element(mat: jnp.array, diag: int, element: int) -> float:
+def _diag_element(mat: Array, diag: int, element: int) -> Array:
     r"""Return the element of a matrix `mat` at `jnp.diag(mat, diag)[element]`.
     This function is jittable for `diag` while it is not for the `jnp.diag` version.
     """
     assert mat.shape[0] == mat.shape[1], 'Matrix must be square.'
     n = mat.shape[0]
-    element = jax.lax.select(element < 0, n - jnp.abs(diag) - jnp.abs(element), element)
-    return mat[jnp.maximum(-diag, 0) + element, jnp.maximum(diag, 0) + element]
+    element_index = jax.lax.select(
+        element < 0, n - jnp.abs(diag) - jnp.abs(element), element
+    )
+    return mat[
+        jnp.maximum(-diag, 0) + element_index, jnp.maximum(diag, 0) + element_index
+    ]
 
 
 def _laguerre_series(i: int, x: Array, rho: Array, n: int) -> Array:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,10 @@ exclude = [
     "dynamiqs/integrators",
     "dynamiqs/plot",
     "dynamiqs/qarrays",
-    "dynamiqs/random",
-    "dynamiqs/utils",
+    "dynamiqs/utils/general.py",
+    "dynamiqs/utils/operators.py",
+    "dynamiqs/utils/states.py",
+    "dynamiqs/utils/vectorization.py",
     "dynamiqs/time_qarray.py",
     "dynamiqs/conftest.py"
 ]


### PR DESCRIPTION
Closes #1081.

## Summary

- Include `dynamiqs/random` in `ty check dynamiqs` coverage
- Narrow the `dynamiqs/utils` type exclusion to only the files that still need follow-up work
- Fix the remaining `ty` diagnostics in `wigner_utils.py` so it can be type-checked

## Tests

- `uv run --python 3.11 --extra dev task type`
- `uv run --python 3.11 --extra dev ruff check pyproject.toml dynamiqs/utils/wigner_utils.py dynamiqs/random dynamiqs/utils/global_settings.py dynamiqs/utils/optimal_control.py`
- `uv run --python 3.11 --extra dev ruff format --check pyproject.toml dynamiqs/utils/wigner_utils.py`
- `uv run --python 3.11 --extra dev pytest tests/utils/test_wigner_utils.py -q`