### PR TITLE
Add opt-in solver benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 
 # python virtual environments
 venv
+.venv/
 
 # distribution / packaging
 *.egg-info/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ help = "clean the code (ruff + codespell + ty)"
 cmd = 'echo "\n>>> pytest -n=auto tests" && pytest -n=auto tests'
 help = "run the unit tests suite (pytest)"
 
+[tool.taskipy.tasks.benchmark]
+cmd = 'echo "\n>>> python -m tests.benchmark.runner --suite smoke --out benchmark-smoke.csv" && python -m tests.benchmark.runner --suite smoke --out benchmark-smoke.csv'
+help = "run the lightweight solver benchmark suite"
+
 [tool.taskipy.tasks.doctest-code]
 cmd = 'echo "\n>>> pytest dynamiqs" && python docs/remove_figs.py docs/figs_code && pytest dynamiqs'
 help = "check code docstrings examples (doctest)"

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -1,0 +1,52 @@
+# Dynamiqs Solver Benchmarks
+
+This directory contains an opt-in benchmark suite for comparing Dynamiqs solvers
+on representative quantum-dynamics problems.
+
+The suite records:
+
+- benchmark name,
+- solver method,
+- runtime,
+- number of solver steps when available,
+- accuracy against an analytical or high-accuracy reference,
+- status and error messages,
+- Dynamiqs/JAX/backend metadata.
+
+Run a lightweight smoke benchmark:
+
+```bash
+python -m tests.benchmark.runner --suite smoke --out benchmark-smoke.csv
+```
+
+Run the full deterministic benchmark suite:
+
+```bash
+python -m tests.benchmark.runner --suite full --out benchmark-full.csv
+```
+
+Limit to selected methods:
+
+```bash
+python -m tests.benchmark.runner --suite full --methods Tsit5 Dopri8 Rouchon3
+```
+
+The normal test suite only runs a small smoke test. The full benchmark is intended
+for local solver comparison and regression tracking across commits.
+
+## Benchmark Problems
+
+- `cross_resonance_modulated_sesolve`: time-dependent closed two-qubit dynamics,
+  referenced against high-accuracy `Dopri8`.
+- `driven_damped_harmonic_oscillator`: one-mode Lindblad dynamics, referenced
+  against the analytical oscillator amplitude.
+- `batched_kerr_oscillator_mesolve`: batched nonlinear open-system dynamics,
+  referenced against high-accuracy `Dopri8`.
+- `ising_chain_8q_sesolve`: closed many-body state-vector evolution, referenced
+  against high-accuracy `Dopri8`. The problem is kept at 8 qubits by default so
+  that it remains reasonable for local CPU runs; it can be scaled to 12 qubits by
+  calling `ising_chain_sesolve(num_qubits=12)`.
+- `two_mode_pwc_vmap_mesolve`: two-mode dissipative PWC drive with batched pulse
+  amplitudes, referenced against high-accuracy `Dopri8`.
+- `zeno_cnot_reduced_mesolve`: reduced three-mode dissipative gate-like model,
+  referenced against high-accuracy `Dopri8`.

--- a/tests/benchmark/README.md
+++ b/tests/benchmark/README.md
@@ -6,10 +6,11 @@ on representative quantum-dynamics problems.
 The suite records:
 
 - benchmark name,
-- solver method,
+- solver method and fixed-step `dt` when applicable,
 - runtime,
-- number of solver steps when available,
-- accuracy against an analytical or high-accuracy reference,
+- mean/min/max solver steps over the batch when available,
+- mean/min/max trajectory infidelity over the batch,
+- benchmark and reference precision,
 - status and error messages,
 - Dynamiqs/JAX/backend metadata.
 
@@ -31,6 +32,33 @@ Limit to selected methods:
 python -m tests.benchmark.runner --suite full --methods Tsit5 Dopri8 Rouchon3
 ```
 
+Select all three fixed-step configurations in a family:
+
+```bash
+python -m tests.benchmark.runner --suite full --methods Euler Rouchon1
+```
+
+Run the benchmark itself in double precision:
+
+```bash
+python -m tests.benchmark.runner --suite full --precision double
+```
+
+The reference defaults to double precision and can be changed independently with
+`--reference-precision`. Each problem saves 100 equally spaced states. Accuracy is
+reported as the mean `1 - fidelity` over those states. Batched problems first average
+over time and then report mean, minimum, and maximum across the batch.
+
+The method matrix is:
+
+- `sesolve`: Euler at `dt=1e-2`, `1e-3`, and `1e-4`; Dopri5; Dopri8; Tsit5;
+  Kvaerno3; Kvaerno5.
+- `mesolve`: the same methods plus Rouchon1 at the three `dt` values, Rouchon2,
+  and Rouchon3.
+
+Problems with compatible constant Hamiltonians may additionally opt into Expm. The
+Ising-chain benchmark currently does so.
+
 The normal test suite only runs a small smoke test. The full benchmark is intended
 for local solver comparison and regression tracking across commits.
 
@@ -39,13 +67,13 @@ for local solver comparison and regression tracking across commits.
 - `cross_resonance_modulated_sesolve`: time-dependent closed two-qubit dynamics,
   referenced against high-accuracy `Dopri8`.
 - `driven_damped_harmonic_oscillator`: one-mode Lindblad dynamics, referenced
-  against the analytical oscillator amplitude.
+  against its analytical coherent-state trajectory.
 - `batched_kerr_oscillator_mesolve`: batched nonlinear open-system dynamics,
   referenced against high-accuracy `Dopri8`.
 - `ising_chain_8q_sesolve`: closed many-body state-vector evolution, referenced
   against high-accuracy `Dopri8`. The problem is kept at 8 qubits by default so
   that it remains reasonable for local CPU runs; it can be scaled to 12 qubits by
-  calling `ising_chain_sesolve(num_qubits=12)`.
+  constructing `IsingChainSESolve(num_qubits=12)`.
 - `two_mode_pwc_vmap_mesolve`: two-mode dissipative PWC drive with batched pulse
   amplitudes, referenced against high-accuracy `Dopri8`.
 - `zeno_cnot_reduced_mesolve`: reduced three-mode dissipative gate-like model,

--- a/tests/benchmark/__init__.py
+++ b/tests/benchmark/__init__.py
@@ -1,0 +1,1 @@
+"""Opt-in benchmark suite for Dynamiqs solvers."""

--- a/tests/benchmark/metrics.py
+++ b/tests/benchmark/metrics.py
@@ -1,8 +1,27 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 import jax.numpy as jnp
+
+import dynamiqs as dq
+
+
+@dataclass(frozen=True)
+class MetricStats:
+    mean: float
+    minimum: float
+    maximum: float
+
+
+def aggregate_stats(values: Any) -> MetricStats:
+    values = jnp.asarray(values)
+    return MetricStats(
+        mean=float(jnp.mean(values)),
+        minimum=float(jnp.min(values)),
+        maximum=float(jnp.max(values)),
+    )
 
 
 def relative_l2_error(value: Any, reference: Any) -> float:
@@ -19,7 +38,15 @@ def max_abs_error(value: Any, reference: Any) -> float:
     return float(jnp.max(jnp.abs(value - reference)))
 
 
-def extract_nsteps(result: Any) -> float | None:
+def state_infidelity_stats(states: Any, reference_states: Any) -> MetricStats:
+    """Return batch statistics of the mean trajectory infidelity."""
+    fidelities = jnp.clip(dq.fidelity(states, reference_states), 0.0, 1.0)
+    infidelities = 1.0 - fidelities
+    mean_time_infidelity = jnp.mean(infidelities, axis=-1)
+    return aggregate_stats(mean_time_infidelity)
+
+
+def extract_nsteps_stats(result: Any) -> MetricStats | None:
     infos = getattr(result, 'infos', None)
     if infos is None:
         return None
@@ -29,4 +56,10 @@ def extract_nsteps(result: Any) -> float | None:
     nsteps = jnp.asarray(nsteps)
     if nsteps.size == 0:
         return None
-    return float(jnp.mean(nsteps))
+    return aggregate_stats(nsteps)
+
+
+def extract_nsteps(result: Any) -> float | None:
+    """Return the mean step count, preserving the previous helper API."""
+    stats = extract_nsteps_stats(result)
+    return None if stats is None else stats.mean

--- a/tests/benchmark/metrics.py
+++ b/tests/benchmark/metrics.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+
+
+def relative_l2_error(value: Any, reference: Any) -> float:
+    value = jnp.asarray(value)
+    reference = jnp.asarray(reference)
+    numerator = jnp.linalg.norm(value - reference)
+    denominator = jnp.maximum(jnp.linalg.norm(reference), 1e-14)
+    return float(numerator / denominator)
+
+
+def max_abs_error(value: Any, reference: Any) -> float:
+    value = jnp.asarray(value)
+    reference = jnp.asarray(reference)
+    return float(jnp.max(jnp.abs(value - reference)))
+
+
+def extract_nsteps(result: Any) -> float | None:
+    infos = getattr(result, 'infos', None)
+    if infos is None:
+        return None
+    nsteps = getattr(infos, 'nsteps', None)
+    if nsteps is None:
+        return None
+    nsteps = jnp.asarray(nsteps)
+    if nsteps.size == 0:
+        return None
+    return float(jnp.mean(nsteps))

--- a/tests/benchmark/problems.py
+++ b/tests/benchmark/problems.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -8,389 +9,304 @@ import jax.numpy as jnp
 
 import dynamiqs as dq
 from dynamiqs.gradient import Direct
-from dynamiqs.method import Dopri8, Method
+from dynamiqs.method import (
+    Dopri5,
+    Dopri8,
+    Euler,
+    Expm,
+    Kvaerno3,
+    Kvaerno5,
+    Method,
+    Rouchon1,
+    Rouchon2,
+    Rouchon3,
+    Tsit5,
+)
 from dynamiqs.progress_meter import NoProgressMeter
 
-from .metrics import max_abs_error, relative_l2_error
+from .metrics import MetricStats, state_infidelity_stats
 
 ProblemKind = Literal['sesolve', 'mesolve']
 
 
 @dataclass(frozen=True)
-class BenchmarkProblem:
+class MethodSpec:
+    name: str
+    factory: Callable[[], Method]
+
+    @property
+    def family(self) -> str:
+        return self.name.split('(', maxsplit=1)[0]
+
+
+def _adaptive_method_specs() -> tuple[MethodSpec, ...]:
+    return (
+        MethodSpec('Dopri5', Dopri5),
+        MethodSpec('Dopri8', Dopri8),
+        MethodSpec('Tsit5', Tsit5),
+        MethodSpec('Kvaerno3', Kvaerno3),
+        MethodSpec('Kvaerno5', Kvaerno5),
+    )
+
+
+def _euler_method_specs() -> tuple[MethodSpec, ...]:
+    return tuple(
+        MethodSpec(f'Euler(dt={dt:.0e})', lambda dt=dt: Euler(dt=dt))
+        for dt in (1e-2, 1e-3, 1e-4)
+    )
+
+
+def _rouchon_method_specs() -> tuple[MethodSpec, ...]:
+    return (
+        *(
+            MethodSpec(f'Rouchon1(dt={dt:.0e})', lambda dt=dt: Rouchon1(dt=dt))
+            for dt in (1e-2, 1e-3, 1e-4)
+        ),
+        MethodSpec('Rouchon2', Rouchon2),
+        MethodSpec('Rouchon3', Rouchon3),
+    )
+
+
+SESOLVE_METHODS = (*_euler_method_specs(), *_adaptive_method_specs())
+MESOLVE_METHODS = (*SESOLVE_METHODS, *_rouchon_method_specs())
+
+
+class BenchmarkProblem(ABC):
     name: str
     kind: ProblemKind
     description: str
-    deterministic_methods: Sequence[str]
-    reference_name: str
-    run: Callable[[Method], Any]
-    reference: Callable[[], Any]
-    error: Callable[[Any, Any], float]
+    methods: tuple[MethodSpec, ...]
+    nsave = 100
+    reference_name = 'Dopri8(rtol=atol=1e-9,safety_factor=0.75)'
+
+    @abstractmethod
+    def run(self, method: Method) -> Any:
+        pass
+
+    def reference(self) -> Any:
+        result = self.run(
+            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
+        )
+        result.block_until_ready()
+        return result.states
+
+    def error(self, result: Any, reference: Any) -> MetricStats:
+        return state_infidelity_stats(result.states, reference)
+
+    @staticmethod
+    def solver_options() -> dict[str, Any]:
+        return {'save_states': True, 'progress_meter': NoProgressMeter()}
 
 
-def _solver_options() -> dict[str, Any]:
-    return {'save_states': False, 'progress_meter': NoProgressMeter()}
+class CrossResonanceModulatedSESolve(BenchmarkProblem):
+    name = 'cross_resonance_modulated_sesolve'
+    kind: ProblemKind = 'sesolve'
+    description = 'Closed two-qubit cross-resonance-inspired modulated evolution.'
+    methods = SESOLVE_METHODS
 
+    def run(self, method: Method) -> Any:
+        omega_1 = 4.0
+        omega_2 = 6.0
+        coupling = 0.4
+        epsilon = 0.4
+        gate_time = 0.5 * jnp.pi * jnp.abs(omega_2 - omega_1) / (
+            coupling * epsilon
+        )
+        tsave = jnp.linspace(0.0, gate_time, self.nsave)
 
-def _expect_trajectory(result: Any, exp_index: int = 0) -> jnp.ndarray:
-    if result.expects is None:
-        raise ValueError('benchmark result does not contain expectation values')
-    return jnp.asarray(result.expects[exp_index])
+        sz1 = dq.tensor(dq.sigmaz(), dq.eye(2))
+        sz2 = dq.tensor(dq.eye(2), dq.sigmaz())
+        sp1 = dq.tensor(dq.sigmap(), dq.eye(2))
+        sp2 = dq.tensor(dq.eye(2), dq.sigmap())
+        sm1 = dq.tensor(dq.sigmam(), dq.eye(2))
+        sm2 = dq.tensor(dq.eye(2), dq.sigmam())
 
-
-def cross_resonance_modulated_sesolve() -> BenchmarkProblem:
-    omega_1 = 4.0
-    omega_2 = 6.0
-    coupling = 0.4
-    epsilon = 0.4
-    nsave = 80
-    gate_time = 0.5 * jnp.pi * jnp.abs(omega_2 - omega_1) / (coupling * epsilon)
-    tsave = jnp.linspace(0.0, gate_time, nsave)
-
-    sz1 = dq.tensor(dq.sigmaz(), dq.eye(2))
-    sz2 = dq.tensor(dq.eye(2), dq.sigmaz())
-    sp1 = dq.tensor(dq.sigmap(), dq.eye(2))
-    sp2 = dq.tensor(dq.eye(2), dq.sigmap())
-    sm1 = dq.tensor(dq.sigmam(), dq.eye(2))
-    sm2 = dq.tensor(dq.eye(2), dq.sigmam())
-
-    omega_d = omega_2 - coupling**2 / (omega_1 - omega_2)
-    h0 = 0.5 * omega_1 * sz1 + 0.5 * omega_2 * sz2
-    h0 += coupling * (sp1 @ sm2 + sm1 @ sp2)
-    hd = epsilon * (sp1 + sm1)
-    hamiltonian = h0 + dq.modulated(lambda t: jnp.cos(omega_d * t), hd)
-    psi0 = dq.tensor(dq.basis(2, 1), dq.basis(2, 1))
-    exp_ops = [sz1, sz2]
-
-    def run(method: Method) -> Any:
+        omega_d = omega_2 - coupling**2 / (omega_1 - omega_2)
+        h0 = 0.5 * omega_1 * sz1 + 0.5 * omega_2 * sz2
+        h0 += coupling * (sp1 @ sm2 + sm1 @ sp2)
+        hd = epsilon * (sp1 + sm1)
+        hamiltonian = h0 + dq.modulated(lambda t: jnp.cos(omega_d * t), hd)
+        psi0 = dq.tensor(dq.basis(2, 1), dq.basis(2, 1))
         return dq.sesolve(
             hamiltonian,
             psi0,
             tsave,
-            exp_ops=exp_ops,
             method=method,
             gradient=Direct(),
-            **_solver_options(),
+            **self.solver_options(),
         )
 
-    def reference() -> jnp.ndarray:
-        method = Dopri8(rtol=1e-10, atol=1e-10, safety_factor=0.75, max_steps=1_000_000)
-        result = run(method)
-        result.block_until_ready()
-        return jnp.asarray(result.expects)
 
-    return BenchmarkProblem(
-        name='cross_resonance_modulated_sesolve',
-        kind='sesolve',
-        description='Closed two-qubit cross-resonance-inspired modulated evolution.',
-        deterministic_methods=(
-            'Tsit5',
-            'Dopri5',
-            'Dopri8',
-            'Kvaerno3',
-            'Kvaerno5',
-            'Euler',
-        ),
-        reference_name='Dopri8(rtol=atol=1e-10,safety_factor=0.75)',
-        run=run,
-        reference=reference,
-        error=lambda result, ref: relative_l2_error(result.expects, ref),
-    )
+class DrivenDampedHarmonicOscillator(BenchmarkProblem):
+    name = 'driven_damped_harmonic_oscillator'
+    kind: ProblemKind = 'mesolve'
+    description = 'One-mode driven damped oscillator with an analytical state.'
+    methods = MESOLVE_METHODS
+    reference_name = 'analytical coherent-state trajectory'
 
-
-def driven_damped_harmonic_oscillator() -> BenchmarkProblem:
     trunc = 32
     omega = 1.0
     kappa = 0.05
     epsilon = 2.0
-    nsave = 80
-    t_final = 2.0 * jnp.pi / omega
-    tsave = jnp.linspace(0.0, t_final, nsave)
 
-    destroy = dq.destroy(trunc)
-    hamiltonian = omega * destroy.dag() @ destroy + epsilon * (destroy + destroy.dag())
-    jump_ops = [jnp.sqrt(kappa) * destroy]
-    rho0 = dq.fock_dm(trunc, 0)
-    exp_ops = [destroy]
+    def _tsave(self) -> Any:
+        return jnp.linspace(0.0, 2.0 * jnp.pi / self.omega, self.nsave)
 
-    def alpha_reference() -> jnp.ndarray:
-        rate = kappa / 2.0 + 1j * omega
-        alpha_ss = -1j * epsilon / rate
-        return alpha_ss * (1.0 - jnp.exp(-rate * tsave))
-
-    def run(method: Method) -> Any:
+    def run(self, method: Method) -> Any:
+        destroy = dq.destroy(self.trunc)
+        hamiltonian = self.omega * destroy.dag() @ destroy
+        hamiltonian += self.epsilon * (destroy + destroy.dag())
+        jump_ops = [jnp.sqrt(self.kappa) * destroy]
         return dq.mesolve(
             hamiltonian,
             jump_ops,
-            rho0,
-            tsave,
-            exp_ops=exp_ops,
+            dq.fock_dm(self.trunc, 0),
+            self._tsave(),
             method=method,
             gradient=Direct(),
-            **_solver_options(),
+            **self.solver_options(),
         )
 
-    return BenchmarkProblem(
-        name='driven_damped_harmonic_oscillator',
-        kind='mesolve',
-        description='One-mode driven damped oscillator with analytical amplitude.',
-        deterministic_methods=(
-            'Tsit5',
-            'Dopri5',
-            'Dopri8',
-            'Kvaerno3',
-            'Kvaerno5',
-            'Euler',
-            'Rouchon1',
-            'Rouchon2',
-            'Rouchon3',
-            'Expm',
-        ),
-        reference_name='analytical oscillator amplitude',
-        run=run,
-        reference=alpha_reference,
-        error=lambda result, ref: relative_l2_error(_expect_trajectory(result), ref),
-    )
+    def reference(self) -> Any:
+        rate = self.kappa / 2.0 + 1j * self.omega
+        alpha_ss = -1j * self.epsilon / rate
+        alpha = alpha_ss * (1.0 - jnp.exp(-rate * self._tsave()))
+        return dq.coherent_dm(self.trunc, alpha)
 
 
-def batched_kerr_oscillator_mesolve() -> BenchmarkProblem:
-    trunc = 18
-    detuning = 0.4
-    kerr = 0.08
-    kappa = 0.12
-    drive_amplitudes = jnp.asarray([0.4, 0.7, 1.0])
-    tsave = jnp.linspace(0.0, 4.0, 60)
+class BatchedKerrOscillatorMESolve(BenchmarkProblem):
+    name = 'batched_kerr_oscillator_mesolve'
+    kind: ProblemKind = 'mesolve'
+    description = 'Batched nonlinear Kerr oscillator with damping.'
+    methods = MESOLVE_METHODS
 
-    destroy = dq.destroy(trunc)
-    number = destroy.dag() @ destroy
-    h0 = (
-        detuning * number
-        + 0.5 * kerr * destroy.dag() @ destroy.dag() @ destroy @ destroy
-    )
-    hamiltonian = h0 + drive_amplitudes[:, None, None] * (destroy + destroy.dag())
-    jump_ops = [jnp.sqrt(kappa) * destroy]
-    rho0 = dq.coherent_dm(trunc, 0.8)
-    exp_ops = [number]
-
-    def run(method: Method) -> Any:
+    def run(self, method: Method) -> Any:
+        trunc = 18
+        destroy = dq.destroy(trunc)
+        number = destroy.dag() @ destroy
+        h0 = 0.4 * number
+        h0 += 0.5 * 0.08 * destroy.dag() @ destroy.dag() @ destroy @ destroy
+        drive_amplitudes = jnp.asarray([0.4, 0.7, 1.0])
+        hamiltonian = h0 + drive_amplitudes[:, None, None] * (
+            destroy + destroy.dag()
+        )
         return dq.mesolve(
             hamiltonian,
-            jump_ops,
-            rho0,
-            tsave,
-            exp_ops=exp_ops,
+            [jnp.sqrt(0.12) * destroy],
+            dq.coherent_dm(trunc, 0.8),
+            jnp.linspace(0.0, 4.0, self.nsave),
             method=method,
             gradient=Direct(),
-            **_solver_options(),
+            **self.solver_options(),
         )
 
-    def reference() -> jnp.ndarray:
-        result = run(
-            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
+
+class IsingChainSESolve(BenchmarkProblem):
+    kind: ProblemKind = 'sesolve'
+    description = 'Closed nearest-neighbor Ising chain state-vector evolution.'
+    methods = (*SESOLVE_METHODS, MethodSpec('Expm', Expm))
+
+    def __init__(self, num_qubits: int = 8):
+        self.num_qubits = num_qubits
+        self.name = f'ising_chain_{num_qubits}q_sesolve'
+
+    def run(self, method: Method) -> Any:
+        sx = [
+            dq.tensor(
+                *[
+                    dq.sigmax() if i == j else dq.eye(2)
+                    for i in range(self.num_qubits)
+                ]
+            )
+            for j in range(self.num_qubits)
+        ]
+        sz = [
+            dq.tensor(
+                *[
+                    dq.sigmaz() if i == j else dq.eye(2)
+                    for i in range(self.num_qubits)
+                ]
+            )
+            for j in range(self.num_qubits)
+        ]
+        hamiltonian = sum(0.7 * x for x in sx)
+        hamiltonian += sum(
+            0.2 * sz[i] @ sz[i + 1] for i in range(self.num_qubits - 1)
         )
-        result.block_until_ready()
-        return jnp.asarray(result.expects)
-
-    return BenchmarkProblem(
-        name='batched_kerr_oscillator_mesolve',
-        kind='mesolve',
-        description='Batched nonlinear Kerr oscillator with damping.',
-        deterministic_methods=(
-            'Tsit5',
-            'Dopri5',
-            'Dopri8',
-            'Kvaerno3',
-            'Kvaerno5',
-            'Rouchon2',
-            'Rouchon3',
-        ),
-        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
-        run=run,
-        reference=reference,
-        error=lambda result, ref: relative_l2_error(result.expects, ref),
-    )
-
-
-def ising_chain_sesolve(num_qubits: int = 8) -> BenchmarkProblem:
-    coupling = 0.2
-    field = 0.7
-    tsave = jnp.linspace(0.0, 2.0, 50)
-
-    sx = [
-        dq.tensor(*[dq.sigmax() if i == j else dq.eye(2) for i in range(num_qubits)])
-        for j in range(num_qubits)
-    ]
-    sz = [
-        dq.tensor(*[dq.sigmaz() if i == j else dq.eye(2) for i in range(num_qubits)])
-        for j in range(num_qubits)
-    ]
-    hamiltonian = sum(field * x for x in sx)
-    hamiltonian += sum(coupling * sz[i] @ sz[i + 1] for i in range(num_qubits - 1))
-    plus = (dq.basis(2, 0) + dq.basis(2, 1)).unit()
-    psi0 = dq.tensor(*[plus for _ in range(num_qubits)])
-    exp_ops = [sz[0]]
-
-    def run(method: Method) -> Any:
+        plus = (dq.basis(2, 0) + dq.basis(2, 1)).unit()
+        psi0 = dq.tensor(*[plus for _ in range(self.num_qubits)])
         return dq.sesolve(
             hamiltonian,
             psi0,
-            tsave,
-            exp_ops=exp_ops,
+            jnp.linspace(0.0, 2.0, self.nsave),
             method=method,
             gradient=Direct(),
-            **_solver_options(),
+            **self.solver_options(),
         )
 
-    def reference() -> jnp.ndarray:
-        result = run(
-            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
+
+class TwoModePWCMESolve(BenchmarkProblem):
+    name = 'two_mode_pwc_vmap_mesolve'
+    kind: ProblemKind = 'mesolve'
+    description = 'Two-mode dissipative PWC drive with batched pulse amplitudes.'
+    methods = MESOLVE_METHODS
+
+    def run(self, method: Method) -> Any:
+        dims = (5, 5)
+        a, b = dq.destroy(*dims)
+        na = a.dag() @ a
+        nb = b.dag() @ b
+        h0 = 0.04 * (na @ na + nb @ nb) + 0.03 * na @ nb
+        pulse_times = jnp.asarray([0.0, 0.8, 1.6, 2.4, 3.2])
+        pulse_values = jnp.asarray(
+            [[0.2, 0.5, 0.1, 0.0], [0.1, 0.2, 0.4, 0.1]]
         )
-        result.block_until_ready()
-        return jnp.asarray(result.expects)
-
-    return BenchmarkProblem(
-        name=f'ising_chain_{num_qubits}q_sesolve',
-        kind='sesolve',
-        description='Closed nearest-neighbor Ising chain state-vector evolution.',
-        deterministic_methods=(
-            'Tsit5',
-            'Dopri5',
-            'Dopri8',
-            'Kvaerno3',
-            'Kvaerno5',
-            'Euler',
-            'Expm',
-        ),
-        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
-        run=run,
-        reference=reference,
-        error=lambda result, ref: relative_l2_error(result.expects, ref),
-    )
-
-
-def two_mode_pwc_vmap_mesolve() -> BenchmarkProblem:
-    dims = (5, 5)
-    kerr = 0.04
-    cross_kerr = 0.03
-    kappa = 0.08
-    tsave = jnp.linspace(0.0, 3.0, 40)
-    pulse_times = jnp.asarray([0.0, 0.8, 1.6, 2.4, 3.2])
-    pulse_values = jnp.asarray([[0.2, 0.5, 0.1, 0.0], [0.1, 0.2, 0.4, 0.1]])
-
-    a, b = dq.destroy(*dims)
-    na = a.dag() @ a
-    nb = b.dag() @ b
-    h0 = kerr * (na @ na + nb @ nb) + cross_kerr * na @ nb
-    drive = dq.pwc(pulse_times, pulse_values, a + a.dag())
-    hamiltonian = h0 + drive
-    jump_ops = [jnp.sqrt(kappa) * a, jnp.sqrt(kappa) * b]
-    rho0 = dq.coherent_dm(dims, (0.6, 0.4))
-    exp_ops = [na, nb]
-
-    def run(method: Method) -> Any:
+        hamiltonian = h0 + dq.pwc(pulse_times, pulse_values, a + a.dag())
         return dq.mesolve(
             hamiltonian,
-            jump_ops,
-            rho0,
-            tsave,
-            exp_ops=exp_ops,
+            [jnp.sqrt(0.08) * a, jnp.sqrt(0.08) * b],
+            dq.coherent_dm(dims, (0.6, 0.4)),
+            jnp.linspace(0.0, 3.0, self.nsave),
             method=method,
             gradient=Direct(),
-            **_solver_options(),
+            **self.solver_options(),
         )
 
-    def reference() -> jnp.ndarray:
-        result = run(
-            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
-        )
-        result.block_until_ready()
-        return jnp.asarray(result.expects)
 
-    return BenchmarkProblem(
-        name='two_mode_pwc_vmap_mesolve',
-        kind='mesolve',
-        description='Two-mode dissipative PWC drive with batched pulse amplitudes.',
-        deterministic_methods=(
-            'Tsit5',
-            'Dopri5',
-            'Dopri8',
-            'Kvaerno3',
-            'Kvaerno5',
-            'Rouchon2',
-            'Rouchon3',
-        ),
-        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
-        run=run,
-        reference=reference,
-        error=lambda result, ref: relative_l2_error(result.expects, ref),
-    )
+class ZenoCNOTReducedMESolve(BenchmarkProblem):
+    name = 'zeno_cnot_reduced_mesolve'
+    kind: ProblemKind = 'mesolve'
+    description = 'Reduced three-mode dissipative gate-like benchmark.'
+    methods = MESOLVE_METHODS
 
-
-def zeno_cnot_reduced_mesolve() -> BenchmarkProblem:
-    dims = (3, 3, 3)
-    kappa_buffer = 2.0
-    chi = 0.15
-    drive = 0.4
-    tsave = jnp.linspace(0.0, 2.5, 40)
-
-    a, b, c = dq.destroy(*dims)
-    na = a.dag() @ a
-    nb = b.dag() @ b
-    nc = c.dag() @ c
-    hamiltonian = chi * na @ nb + drive * (c + c.dag()) + 0.1 * nc
-    jump_ops = [jnp.sqrt(kappa_buffer) * c]
-    rho0 = dq.coherent_dm(dims, (0.3, 0.7, 0.0))
-    exp_ops = [na, nb, nc]
-
-    def run(method: Method) -> Any:
+    def run(self, method: Method) -> Any:
+        dims = (3, 3, 3)
+        a, b, c = dq.destroy(*dims)
+        na = a.dag() @ a
+        nb = b.dag() @ b
+        nc = c.dag() @ c
+        hamiltonian = 0.15 * na @ nb + 0.4 * (c + c.dag()) + 0.1 * nc
         return dq.mesolve(
             hamiltonian,
-            jump_ops,
-            rho0,
-            tsave,
-            exp_ops=exp_ops,
+            [jnp.sqrt(2.0) * c],
+            dq.coherent_dm(dims, (0.3, 0.7, 0.0)),
+            jnp.linspace(0.0, 2.5, self.nsave),
             method=method,
             gradient=Direct(),
-            **_solver_options(),
+            **self.solver_options(),
         )
-
-    def reference() -> jnp.ndarray:
-        result = run(
-            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
-        )
-        result.block_until_ready()
-        return jnp.asarray(result.expects)
-
-    return BenchmarkProblem(
-        name='zeno_cnot_reduced_mesolve',
-        kind='mesolve',
-        description='Reduced three-mode dissipative gate-like benchmark.',
-        deterministic_methods=(
-            'Tsit5',
-            'Dopri5',
-            'Dopri8',
-            'Kvaerno3',
-            'Kvaerno5',
-            'Rouchon2',
-            'Rouchon3',
-        ),
-        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
-        run=run,
-        reference=reference,
-        error=lambda result, ref: max_abs_error(result.expects, ref),
-    )
 
 
 def all_problems() -> tuple[BenchmarkProblem, ...]:
     return (
-        cross_resonance_modulated_sesolve(),
-        driven_damped_harmonic_oscillator(),
-        batched_kerr_oscillator_mesolve(),
-        ising_chain_sesolve(num_qubits=8),
-        two_mode_pwc_vmap_mesolve(),
-        zeno_cnot_reduced_mesolve(),
+        CrossResonanceModulatedSESolve(),
+        DrivenDampedHarmonicOscillator(),
+        BatchedKerrOscillatorMESolve(),
+        IsingChainSESolve(num_qubits=8),
+        TwoModePWCMESolve(),
+        ZenoCNOTReducedMESolve(),
     )
 
 
 def smoke_problems() -> tuple[BenchmarkProblem, ...]:
-    return (driven_damped_harmonic_oscillator(),)
+    return (DrivenDampedHarmonicOscillator(),)

--- a/tests/benchmark/problems.py
+++ b/tests/benchmark/problems.py
@@ -109,9 +109,7 @@ class CrossResonanceModulatedSESolve(BenchmarkProblem):
         omega_2 = 6.0
         coupling = 0.4
         epsilon = 0.4
-        gate_time = 0.5 * jnp.pi * jnp.abs(omega_2 - omega_1) / (
-            coupling * epsilon
-        )
+        gate_time = 0.5 * jnp.pi * jnp.abs(omega_2 - omega_1) / (coupling * epsilon)
         tsave = jnp.linspace(0.0, gate_time, self.nsave)
 
         sz1 = dq.tensor(dq.sigmaz(), dq.eye(2))
@@ -187,9 +185,7 @@ class BatchedKerrOscillatorMESolve(BenchmarkProblem):
         h0 = 0.4 * number
         h0 += 0.5 * 0.08 * destroy.dag() @ destroy.dag() @ destroy @ destroy
         drive_amplitudes = jnp.asarray([0.4, 0.7, 1.0])
-        hamiltonian = h0 + drive_amplitudes[:, None, None] * (
-            destroy + destroy.dag()
-        )
+        hamiltonian = h0 + drive_amplitudes[:, None, None] * (destroy + destroy.dag())
         return dq.mesolve(
             hamiltonian,
             [jnp.sqrt(0.12) * destroy],
@@ -213,26 +209,18 @@ class IsingChainSESolve(BenchmarkProblem):
     def run(self, method: Method) -> Any:
         sx = [
             dq.tensor(
-                *[
-                    dq.sigmax() if i == j else dq.eye(2)
-                    for i in range(self.num_qubits)
-                ]
+                *[dq.sigmax() if i == j else dq.eye(2) for i in range(self.num_qubits)]
             )
             for j in range(self.num_qubits)
         ]
         sz = [
             dq.tensor(
-                *[
-                    dq.sigmaz() if i == j else dq.eye(2)
-                    for i in range(self.num_qubits)
-                ]
+                *[dq.sigmaz() if i == j else dq.eye(2) for i in range(self.num_qubits)]
             )
             for j in range(self.num_qubits)
         ]
         hamiltonian = sum(0.7 * x for x in sx)
-        hamiltonian += sum(
-            0.2 * sz[i] @ sz[i + 1] for i in range(self.num_qubits - 1)
-        )
+        hamiltonian += sum(0.2 * sz[i] @ sz[i + 1] for i in range(self.num_qubits - 1))
         plus = (dq.basis(2, 0) + dq.basis(2, 1)).unit()
         psi0 = dq.tensor(*[plus for _ in range(self.num_qubits)])
         return dq.sesolve(
@@ -258,9 +246,7 @@ class TwoModePWCMESolve(BenchmarkProblem):
         nb = b.dag() @ b
         h0 = 0.04 * (na @ na + nb @ nb) + 0.03 * na @ nb
         pulse_times = jnp.asarray([0.0, 0.8, 1.6, 2.4, 3.2])
-        pulse_values = jnp.asarray(
-            [[0.2, 0.5, 0.1, 0.0], [0.1, 0.2, 0.4, 0.1]]
-        )
+        pulse_values = jnp.asarray([[0.2, 0.5, 0.1, 0.0], [0.1, 0.2, 0.4, 0.1]])
         hamiltonian = h0 + dq.pwc(pulse_times, pulse_values, a + a.dag())
         return dq.mesolve(
             hamiltonian,

--- a/tests/benchmark/problems.py
+++ b/tests/benchmark/problems.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import jax.numpy as jnp
+
+import dynamiqs as dq
+from dynamiqs.gradient import Direct
+from dynamiqs.method import Dopri8, Method
+from dynamiqs.progress_meter import NoProgressMeter
+
+from .metrics import max_abs_error, relative_l2_error
+
+ProblemKind = Literal['sesolve', 'mesolve']
+
+
+@dataclass(frozen=True)
+class BenchmarkProblem:
+    name: str
+    kind: ProblemKind
+    description: str
+    deterministic_methods: Sequence[str]
+    reference_name: str
+    run: Callable[[Method], Any]
+    reference: Callable[[], Any]
+    error: Callable[[Any, Any], float]
+
+
+def _solver_options() -> dict[str, Any]:
+    return {'save_states': False, 'progress_meter': NoProgressMeter()}
+
+
+def _expect_trajectory(result: Any, exp_index: int = 0) -> jnp.ndarray:
+    if result.expects is None:
+        raise ValueError('benchmark result does not contain expectation values')
+    return jnp.asarray(result.expects[exp_index])
+
+
+def cross_resonance_modulated_sesolve() -> BenchmarkProblem:
+    omega_1 = 4.0
+    omega_2 = 6.0
+    coupling = 0.4
+    epsilon = 0.4
+    nsave = 80
+    gate_time = 0.5 * jnp.pi * jnp.abs(omega_2 - omega_1) / (coupling * epsilon)
+    tsave = jnp.linspace(0.0, gate_time, nsave)
+
+    sz1 = dq.tensor(dq.sigmaz(), dq.eye(2))
+    sz2 = dq.tensor(dq.eye(2), dq.sigmaz())
+    sp1 = dq.tensor(dq.sigmap(), dq.eye(2))
+    sp2 = dq.tensor(dq.eye(2), dq.sigmap())
+    sm1 = dq.tensor(dq.sigmam(), dq.eye(2))
+    sm2 = dq.tensor(dq.eye(2), dq.sigmam())
+
+    omega_d = omega_2 - coupling**2 / (omega_1 - omega_2)
+    h0 = 0.5 * omega_1 * sz1 + 0.5 * omega_2 * sz2
+    h0 += coupling * (sp1 @ sm2 + sm1 @ sp2)
+    hd = epsilon * (sp1 + sm1)
+    hamiltonian = h0 + dq.modulated(lambda t: jnp.cos(omega_d * t), hd)
+    psi0 = dq.tensor(dq.basis(2, 1), dq.basis(2, 1))
+    exp_ops = [sz1, sz2]
+
+    def run(method: Method) -> Any:
+        return dq.sesolve(
+            hamiltonian,
+            psi0,
+            tsave,
+            exp_ops=exp_ops,
+            method=method,
+            gradient=Direct(),
+            **_solver_options(),
+        )
+
+    def reference() -> jnp.ndarray:
+        method = Dopri8(rtol=1e-10, atol=1e-10, safety_factor=0.75, max_steps=1_000_000)
+        result = run(method)
+        result.block_until_ready()
+        return jnp.asarray(result.expects)
+
+    return BenchmarkProblem(
+        name='cross_resonance_modulated_sesolve',
+        kind='sesolve',
+        description='Closed two-qubit cross-resonance-inspired modulated evolution.',
+        deterministic_methods=(
+            'Tsit5',
+            'Dopri5',
+            'Dopri8',
+            'Kvaerno3',
+            'Kvaerno5',
+            'Euler',
+        ),
+        reference_name='Dopri8(rtol=atol=1e-10,safety_factor=0.75)',
+        run=run,
+        reference=reference,
+        error=lambda result, ref: relative_l2_error(result.expects, ref),
+    )
+
+
+def driven_damped_harmonic_oscillator() -> BenchmarkProblem:
+    trunc = 32
+    omega = 1.0
+    kappa = 0.05
+    epsilon = 2.0
+    nsave = 80
+    t_final = 2.0 * jnp.pi / omega
+    tsave = jnp.linspace(0.0, t_final, nsave)
+
+    destroy = dq.destroy(trunc)
+    hamiltonian = omega * destroy.dag() @ destroy + epsilon * (destroy + destroy.dag())
+    jump_ops = [jnp.sqrt(kappa) * destroy]
+    rho0 = dq.fock_dm(trunc, 0)
+    exp_ops = [destroy]
+
+    def alpha_reference() -> jnp.ndarray:
+        rate = kappa / 2.0 + 1j * omega
+        alpha_ss = -1j * epsilon / rate
+        return alpha_ss * (1.0 - jnp.exp(-rate * tsave))
+
+    def run(method: Method) -> Any:
+        return dq.mesolve(
+            hamiltonian,
+            jump_ops,
+            rho0,
+            tsave,
+            exp_ops=exp_ops,
+            method=method,
+            gradient=Direct(),
+            **_solver_options(),
+        )
+
+    return BenchmarkProblem(
+        name='driven_damped_harmonic_oscillator',
+        kind='mesolve',
+        description='One-mode driven damped oscillator with analytical amplitude.',
+        deterministic_methods=(
+            'Tsit5',
+            'Dopri5',
+            'Dopri8',
+            'Kvaerno3',
+            'Kvaerno5',
+            'Euler',
+            'Rouchon1',
+            'Rouchon2',
+            'Rouchon3',
+            'Expm',
+        ),
+        reference_name='analytical oscillator amplitude',
+        run=run,
+        reference=alpha_reference,
+        error=lambda result, ref: relative_l2_error(_expect_trajectory(result), ref),
+    )
+
+
+def batched_kerr_oscillator_mesolve() -> BenchmarkProblem:
+    trunc = 18
+    detuning = 0.4
+    kerr = 0.08
+    kappa = 0.12
+    drive_amplitudes = jnp.asarray([0.4, 0.7, 1.0])
+    tsave = jnp.linspace(0.0, 4.0, 60)
+
+    destroy = dq.destroy(trunc)
+    number = destroy.dag() @ destroy
+    h0 = (
+        detuning * number
+        + 0.5 * kerr * destroy.dag() @ destroy.dag() @ destroy @ destroy
+    )
+    hamiltonian = h0 + drive_amplitudes[:, None, None] * (destroy + destroy.dag())
+    jump_ops = [jnp.sqrt(kappa) * destroy]
+    rho0 = dq.coherent_dm(trunc, 0.8)
+    exp_ops = [number]
+
+    def run(method: Method) -> Any:
+        return dq.mesolve(
+            hamiltonian,
+            jump_ops,
+            rho0,
+            tsave,
+            exp_ops=exp_ops,
+            method=method,
+            gradient=Direct(),
+            **_solver_options(),
+        )
+
+    def reference() -> jnp.ndarray:
+        result = run(
+            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
+        )
+        result.block_until_ready()
+        return jnp.asarray(result.expects)
+
+    return BenchmarkProblem(
+        name='batched_kerr_oscillator_mesolve',
+        kind='mesolve',
+        description='Batched nonlinear Kerr oscillator with damping.',
+        deterministic_methods=(
+            'Tsit5',
+            'Dopri5',
+            'Dopri8',
+            'Kvaerno3',
+            'Kvaerno5',
+            'Rouchon2',
+            'Rouchon3',
+        ),
+        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
+        run=run,
+        reference=reference,
+        error=lambda result, ref: relative_l2_error(result.expects, ref),
+    )
+
+
+def ising_chain_sesolve(num_qubits: int = 8) -> BenchmarkProblem:
+    coupling = 0.2
+    field = 0.7
+    tsave = jnp.linspace(0.0, 2.0, 50)
+
+    sx = [
+        dq.tensor(*[dq.sigmax() if i == j else dq.eye(2) for i in range(num_qubits)])
+        for j in range(num_qubits)
+    ]
+    sz = [
+        dq.tensor(*[dq.sigmaz() if i == j else dq.eye(2) for i in range(num_qubits)])
+        for j in range(num_qubits)
+    ]
+    hamiltonian = sum(field * x for x in sx)
+    hamiltonian += sum(coupling * sz[i] @ sz[i + 1] for i in range(num_qubits - 1))
+    plus = (dq.basis(2, 0) + dq.basis(2, 1)).unit()
+    psi0 = dq.tensor(*[plus for _ in range(num_qubits)])
+    exp_ops = [sz[0]]
+
+    def run(method: Method) -> Any:
+        return dq.sesolve(
+            hamiltonian,
+            psi0,
+            tsave,
+            exp_ops=exp_ops,
+            method=method,
+            gradient=Direct(),
+            **_solver_options(),
+        )
+
+    def reference() -> jnp.ndarray:
+        result = run(
+            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
+        )
+        result.block_until_ready()
+        return jnp.asarray(result.expects)
+
+    return BenchmarkProblem(
+        name=f'ising_chain_{num_qubits}q_sesolve',
+        kind='sesolve',
+        description='Closed nearest-neighbor Ising chain state-vector evolution.',
+        deterministic_methods=(
+            'Tsit5',
+            'Dopri5',
+            'Dopri8',
+            'Kvaerno3',
+            'Kvaerno5',
+            'Euler',
+            'Expm',
+        ),
+        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
+        run=run,
+        reference=reference,
+        error=lambda result, ref: relative_l2_error(result.expects, ref),
+    )
+
+
+def two_mode_pwc_vmap_mesolve() -> BenchmarkProblem:
+    dims = (5, 5)
+    kerr = 0.04
+    cross_kerr = 0.03
+    kappa = 0.08
+    tsave = jnp.linspace(0.0, 3.0, 40)
+    pulse_times = jnp.asarray([0.0, 0.8, 1.6, 2.4, 3.2])
+    pulse_values = jnp.asarray([[0.2, 0.5, 0.1, 0.0], [0.1, 0.2, 0.4, 0.1]])
+
+    a, b = dq.destroy(*dims)
+    na = a.dag() @ a
+    nb = b.dag() @ b
+    h0 = kerr * (na @ na + nb @ nb) + cross_kerr * na @ nb
+    drive = dq.pwc(pulse_times, pulse_values, a + a.dag())
+    hamiltonian = h0 + drive
+    jump_ops = [jnp.sqrt(kappa) * a, jnp.sqrt(kappa) * b]
+    rho0 = dq.coherent_dm(dims, (0.6, 0.4))
+    exp_ops = [na, nb]
+
+    def run(method: Method) -> Any:
+        return dq.mesolve(
+            hamiltonian,
+            jump_ops,
+            rho0,
+            tsave,
+            exp_ops=exp_ops,
+            method=method,
+            gradient=Direct(),
+            **_solver_options(),
+        )
+
+    def reference() -> jnp.ndarray:
+        result = run(
+            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
+        )
+        result.block_until_ready()
+        return jnp.asarray(result.expects)
+
+    return BenchmarkProblem(
+        name='two_mode_pwc_vmap_mesolve',
+        kind='mesolve',
+        description='Two-mode dissipative PWC drive with batched pulse amplitudes.',
+        deterministic_methods=(
+            'Tsit5',
+            'Dopri5',
+            'Dopri8',
+            'Kvaerno3',
+            'Kvaerno5',
+            'Rouchon2',
+            'Rouchon3',
+        ),
+        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
+        run=run,
+        reference=reference,
+        error=lambda result, ref: relative_l2_error(result.expects, ref),
+    )
+
+
+def zeno_cnot_reduced_mesolve() -> BenchmarkProblem:
+    dims = (3, 3, 3)
+    kappa_buffer = 2.0
+    chi = 0.15
+    drive = 0.4
+    tsave = jnp.linspace(0.0, 2.5, 40)
+
+    a, b, c = dq.destroy(*dims)
+    na = a.dag() @ a
+    nb = b.dag() @ b
+    nc = c.dag() @ c
+    hamiltonian = chi * na @ nb + drive * (c + c.dag()) + 0.1 * nc
+    jump_ops = [jnp.sqrt(kappa_buffer) * c]
+    rho0 = dq.coherent_dm(dims, (0.3, 0.7, 0.0))
+    exp_ops = [na, nb, nc]
+
+    def run(method: Method) -> Any:
+        return dq.mesolve(
+            hamiltonian,
+            jump_ops,
+            rho0,
+            tsave,
+            exp_ops=exp_ops,
+            method=method,
+            gradient=Direct(),
+            **_solver_options(),
+        )
+
+    def reference() -> jnp.ndarray:
+        result = run(
+            Dopri8(rtol=1e-9, atol=1e-9, safety_factor=0.75, max_steps=1_000_000)
+        )
+        result.block_until_ready()
+        return jnp.asarray(result.expects)
+
+    return BenchmarkProblem(
+        name='zeno_cnot_reduced_mesolve',
+        kind='mesolve',
+        description='Reduced three-mode dissipative gate-like benchmark.',
+        deterministic_methods=(
+            'Tsit5',
+            'Dopri5',
+            'Dopri8',
+            'Kvaerno3',
+            'Kvaerno5',
+            'Rouchon2',
+            'Rouchon3',
+        ),
+        reference_name='Dopri8(rtol=atol=1e-9,safety_factor=0.75)',
+        run=run,
+        reference=reference,
+        error=lambda result, ref: max_abs_error(result.expects, ref),
+    )
+
+
+def all_problems() -> tuple[BenchmarkProblem, ...]:
+    return (
+        cross_resonance_modulated_sesolve(),
+        driven_damped_harmonic_oscillator(),
+        batched_kerr_oscillator_mesolve(),
+        ising_chain_sesolve(num_qubits=8),
+        two_mode_pwc_vmap_mesolve(),
+        zeno_cnot_reduced_mesolve(),
+    )
+
+
+def smoke_problems() -> tuple[BenchmarkProblem, ...]:
+    return (driven_damped_harmonic_oscillator(),)

--- a/tests/benchmark/runner.py
+++ b/tests/benchmark/runner.py
@@ -5,42 +5,20 @@ import argparse
 import csv
 import platform
 import time
+from contextlib import contextmanager
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import jax
+import jax.numpy as jnp
 
 import dynamiqs as dq
-from dynamiqs.method import (
-    Dopri5,
-    Dopri8,
-    Euler,
-    Expm,
-    Kvaerno3,
-    Kvaerno5,
-    Method,
-    Rouchon1,
-    Rouchon2,
-    Rouchon3,
-    Tsit5,
-)
 
-from .metrics import extract_nsteps
-from .problems import BenchmarkProblem, all_problems, smoke_problems
+from .metrics import extract_nsteps_stats
+from .problems import BenchmarkProblem, MethodSpec, all_problems, smoke_problems
 
-METHODS: dict[str, Method] = {
-    'Tsit5': Tsit5(),
-    'Dopri5': Dopri5(),
-    'Dopri8': Dopri8(),
-    'Kvaerno3': Kvaerno3(),
-    'Kvaerno5': Kvaerno5(),
-    'Euler': Euler(dt=1e-3),
-    'Rouchon1': Rouchon1(dt=1e-3),
-    'Rouchon2': Rouchon2(),
-    'Rouchon3': Rouchon3(),
-    'Expm': Expm(),
-}
+Precision = Literal['single', 'double']
 
 
 @dataclass(frozen=True)
@@ -49,15 +27,31 @@ class BenchmarkRow:
     kind: str
     method: str
     reference: str
+    precision: str
+    reference_precision: str
     runtime_s: float | None
-    nsteps: float | None
-    error: float | None
+    nsteps_mean: float | None
+    nsteps_min: float | None
+    nsteps_max: float | None
+    error_mean: float | None
+    error_min: float | None
+    error_max: float | None
     status: str
     message: str
     dynamiqs_version: str
     jax_version: str
     backend: str
     platform: str
+
+
+@contextmanager
+def _precision(precision: Precision):
+    previous_x64 = jax.config.read('jax_enable_x64')
+    dq.set_precision(precision)
+    try:
+        yield
+    finally:
+        dq.set_precision('double' if previous_x64 else 'single')
 
 
 def _metadata() -> dict[str, str]:
@@ -69,17 +63,67 @@ def _metadata() -> dict[str, str]:
     }
 
 
+def _target_complex_dtype(precision: Precision) -> Any:
+    return jnp.complex64 if precision == 'single' else jnp.complex128
+
+
+def _reference(
+    problem: BenchmarkProblem,
+    *,
+    precision: Precision,
+    reference_precision: Precision,
+) -> Any:
+    with _precision(reference_precision):
+        reference = dq.to_jax(problem.reference())
+        reference = reference.astype(_target_complex_dtype(precision))
+        reference.block_until_ready()
+        return reference
+
+
+def _empty_row(
+    problem: BenchmarkProblem,
+    method: MethodSpec,
+    *,
+    precision: Precision,
+    reference_precision: Precision,
+    message: str,
+) -> BenchmarkRow:
+    return BenchmarkRow(
+        benchmark=problem.name,
+        kind=problem.kind,
+        method=method.name,
+        reference=problem.reference_name,
+        precision=precision,
+        reference_precision=reference_precision,
+        runtime_s=None,
+        nsteps_mean=None,
+        nsteps_min=None,
+        nsteps_max=None,
+        error_mean=None,
+        error_min=None,
+        error_max=None,
+        status='fail',
+        message=message,
+        **_metadata(),
+    )
+
+
 def _run_once(
-    problem: BenchmarkProblem, method_name: str, method: Method, reference: Any
+    problem: BenchmarkProblem,
+    method_spec: MethodSpec,
+    reference: Any,
+    *,
+    precision: Precision,
+    reference_precision: Precision,
 ) -> BenchmarkRow:
     metadata = _metadata()
     start = time.perf_counter()
     try:
-        result = problem.run(method)
+        result = problem.run(method_spec.factory())
         result.block_until_ready()
         runtime_s = time.perf_counter() - start
         error = problem.error(result, reference)
-        nsteps = extract_nsteps(result)
+        nsteps = extract_nsteps_stats(result)
         status = 'pass'
         message = ''
     except Exception as exc:  # noqa: BLE001 - benchmark should record solver failures.
@@ -92,50 +136,75 @@ def _run_once(
     return BenchmarkRow(
         benchmark=problem.name,
         kind=problem.kind,
-        method=method_name,
+        method=method_spec.name,
         reference=problem.reference_name,
+        precision=precision,
+        reference_precision=reference_precision,
         runtime_s=runtime_s,
-        nsteps=nsteps,
-        error=error,
+        nsteps_mean=None if nsteps is None else nsteps.mean,
+        nsteps_min=None if nsteps is None else nsteps.minimum,
+        nsteps_max=None if nsteps is None else nsteps.maximum,
+        error_mean=None if error is None else error.mean,
+        error_min=None if error is None else error.minimum,
+        error_max=None if error is None else error.maximum,
         status=status,
         message=message,
         **metadata,
     )
 
 
+def _method_selected(method: MethodSpec, method_filter: set[str] | None) -> bool:
+    if method_filter is None:
+        return True
+    return method.name in method_filter or method.family in method_filter
+
+
 def run_suite(
-    problems: tuple[BenchmarkProblem, ...], method_filter: set[str] | None = None
+    problems: tuple[BenchmarkProblem, ...],
+    method_filter: set[str] | None = None,
+    *,
+    precision: Precision = 'single',
+    reference_precision: Precision = 'double',
 ) -> list[BenchmarkRow]:
     rows: list[BenchmarkRow] = []
-    for problem in problems:
-        try:
-            reference = problem.reference()
-        except Exception as exc:  # noqa: BLE001 - benchmark should record reference failures.
-            message = f'reference failed: {type(exc).__name__}: {exc}'
-            for method_name in problem.deterministic_methods:
-                if method_filter is not None and method_name not in method_filter:
-                    continue
-                rows.append(
-                    BenchmarkRow(
-                        benchmark=problem.name,
-                        kind=problem.kind,
-                        method=method_name,
-                        reference=problem.reference_name,
-                        runtime_s=None,
-                        nsteps=None,
-                        error=None,
-                        status='fail',
+    with _precision(precision):
+        for problem in problems:
+            selected_methods = tuple(
+                method
+                for method in problem.methods
+                if _method_selected(method, method_filter)
+            )
+            if not selected_methods:
+                continue
+            try:
+                reference = _reference(
+                    problem,
+                    precision=precision,
+                    reference_precision=reference_precision,
+                )
+            except Exception as exc:  # noqa: BLE001
+                message = f'reference failed: {type(exc).__name__}: {exc}'
+                rows.extend(
+                    _empty_row(
+                        problem,
+                        method,
+                        precision=precision,
+                        reference_precision=reference_precision,
                         message=message,
-                        **_metadata(),
+                    )
+                    for method in selected_methods
+                )
+                continue
+            for method in selected_methods:
+                rows.append(
+                    _run_once(
+                        problem,
+                        method,
+                        reference,
+                        precision=precision,
+                        reference_precision=reference_precision,
                     )
                 )
-            continue
-        for method_name in problem.deterministic_methods:
-            if method_filter is not None and method_name not in method_filter:
-                continue
-            rows.append(
-                _run_once(problem, method_name, METHODS[method_name], reference)
-            )
     return rows
 
 
@@ -149,21 +218,27 @@ def write_csv(rows: list[BenchmarkRow], output: Path) -> None:
             writer.writerow(asdict(row))
 
 
+def _format_stats(mean: float | None, min_: float | None, max_: float | None) -> str:
+    if mean is None or min_ is None or max_ is None:
+        return '-'
+    return f'{mean:.3g}/{min_:.3g}/{max_:.3g}'
+
+
 def print_leaderboard(rows: list[BenchmarkRow]) -> None:
     print('\nDynamiqs solver benchmark leaderboard')
-    print('-' * 92)
+    print('-' * 122)
     print(
-        f'{"benchmark":34} {"method":10} {"status":6} '
-        f'{"runtime_s":>10} {"nsteps":>10} {"error":>12}'
+        f'{"benchmark":34} {"method":20} {"status":6} '
+        f'{"runtime_s":>10} {"nsteps mean/min/max":>22} {"error mean/min/max":>24}'
     )
-    print('-' * 92)
+    print('-' * 122)
     for row in rows:
         runtime = '-' if row.runtime_s is None else f'{row.runtime_s:.4f}'
-        nsteps = '-' if row.nsteps is None else f'{row.nsteps:.1f}'
-        error = '-' if row.error is None else f'{row.error:.3e}'
+        nsteps = _format_stats(row.nsteps_mean, row.nsteps_min, row.nsteps_max)
+        error = _format_stats(row.error_mean, row.error_min, row.error_max)
         print(
-            f'{row.benchmark:34} {row.method:10} {row.status:6} '
-            f'{runtime:>10} {nsteps:>10} {error:>12}'
+            f'{row.benchmark:34} {row.method:20} {row.status:6} '
+            f'{runtime:>10} {nsteps:>22} {error:>24}'
         )
 
 
@@ -171,7 +246,17 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Run Dynamiqs solver benchmarks.')
     parser.add_argument('--suite', choices=('smoke', 'full'), default='smoke')
     parser.add_argument('--out', type=Path, default=Path('benchmark-results.csv'))
-    parser.add_argument('--methods', nargs='*', help='Optional subset of method names.')
+    parser.add_argument(
+        '--methods',
+        nargs='*',
+        help='Method names or families, for example Euler or "Euler(dt=1e-03)".',
+    )
+    parser.add_argument(
+        '--precision', choices=('single', 'double'), default='single'
+    )
+    parser.add_argument(
+        '--reference-precision', choices=('single', 'double'), default='double'
+    )
     return parser.parse_args()
 
 
@@ -179,7 +264,12 @@ def main() -> None:
     args = parse_args()
     problems = smoke_problems() if args.suite == 'smoke' else all_problems()
     method_filter = set(args.methods) if args.methods else None
-    rows = run_suite(problems, method_filter)
+    rows = run_suite(
+        problems,
+        method_filter,
+        precision=args.precision,
+        reference_precision=args.reference_precision,
+    )
     write_csv(rows, args.out)
     print_leaderboard(rows)
     print(f'\nSaved benchmark results to {args.out}')

--- a/tests/benchmark/runner.py
+++ b/tests/benchmark/runner.py
@@ -68,10 +68,7 @@ def _target_complex_dtype(precision: Precision) -> Any:
 
 
 def _reference(
-    problem: BenchmarkProblem,
-    *,
-    precision: Precision,
-    reference_precision: Precision,
+    problem: BenchmarkProblem, *, precision: Precision, reference_precision: Precision
 ) -> Any:
     with _precision(reference_precision):
         reference = dq.to_jax(problem.reference())
@@ -251,9 +248,7 @@ def parse_args() -> argparse.Namespace:
         nargs='*',
         help='Method names or families, for example Euler or "Euler(dt=1e-03)".',
     )
-    parser.add_argument(
-        '--precision', choices=('single', 'double'), default='single'
-    )
+    parser.add_argument('--precision', choices=('single', 'double'), default='single')
     parser.add_argument(
         '--reference-precision', choices=('single', 'double'), default='double'
     )

--- a/tests/benchmark/runner.py
+++ b/tests/benchmark/runner.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+# ruff: noqa: T201
+import argparse
+import csv
+import platform
+import time
+from dataclasses import asdict, dataclass, fields
+from pathlib import Path
+from typing import Any
+
+import jax
+
+import dynamiqs as dq
+from dynamiqs.method import (
+    Dopri5,
+    Dopri8,
+    Euler,
+    Expm,
+    Kvaerno3,
+    Kvaerno5,
+    Method,
+    Rouchon1,
+    Rouchon2,
+    Rouchon3,
+    Tsit5,
+)
+
+from .metrics import extract_nsteps
+from .problems import BenchmarkProblem, all_problems, smoke_problems
+
+METHODS: dict[str, Method] = {
+    'Tsit5': Tsit5(),
+    'Dopri5': Dopri5(),
+    'Dopri8': Dopri8(),
+    'Kvaerno3': Kvaerno3(),
+    'Kvaerno5': Kvaerno5(),
+    'Euler': Euler(dt=1e-3),
+    'Rouchon1': Rouchon1(dt=1e-3),
+    'Rouchon2': Rouchon2(),
+    'Rouchon3': Rouchon3(),
+    'Expm': Expm(),
+}
+
+
+@dataclass(frozen=True)
+class BenchmarkRow:
+    benchmark: str
+    kind: str
+    method: str
+    reference: str
+    runtime_s: float | None
+    nsteps: float | None
+    error: float | None
+    status: str
+    message: str
+    dynamiqs_version: str
+    jax_version: str
+    backend: str
+    platform: str
+
+
+def _metadata() -> dict[str, str]:
+    return {
+        'dynamiqs_version': dq.__version__,
+        'jax_version': jax.__version__,
+        'backend': jax.default_backend(),
+        'platform': platform.platform(),
+    }
+
+
+def _run_once(
+    problem: BenchmarkProblem, method_name: str, method: Method, reference: Any
+) -> BenchmarkRow:
+    metadata = _metadata()
+    start = time.perf_counter()
+    try:
+        result = problem.run(method)
+        result.block_until_ready()
+        runtime_s = time.perf_counter() - start
+        error = problem.error(result, reference)
+        nsteps = extract_nsteps(result)
+        status = 'pass'
+        message = ''
+    except Exception as exc:  # noqa: BLE001 - benchmark should record solver failures.
+        runtime_s = None
+        error = None
+        nsteps = None
+        status = 'fail'
+        message = f'{type(exc).__name__}: {exc}'
+
+    return BenchmarkRow(
+        benchmark=problem.name,
+        kind=problem.kind,
+        method=method_name,
+        reference=problem.reference_name,
+        runtime_s=runtime_s,
+        nsteps=nsteps,
+        error=error,
+        status=status,
+        message=message,
+        **metadata,
+    )
+
+
+def run_suite(
+    problems: tuple[BenchmarkProblem, ...], method_filter: set[str] | None = None
+) -> list[BenchmarkRow]:
+    rows: list[BenchmarkRow] = []
+    for problem in problems:
+        try:
+            reference = problem.reference()
+        except Exception as exc:  # noqa: BLE001 - benchmark should record reference failures.
+            message = f'reference failed: {type(exc).__name__}: {exc}'
+            for method_name in problem.deterministic_methods:
+                if method_filter is not None and method_name not in method_filter:
+                    continue
+                rows.append(
+                    BenchmarkRow(
+                        benchmark=problem.name,
+                        kind=problem.kind,
+                        method=method_name,
+                        reference=problem.reference_name,
+                        runtime_s=None,
+                        nsteps=None,
+                        error=None,
+                        status='fail',
+                        message=message,
+                        **_metadata(),
+                    )
+                )
+            continue
+        for method_name in problem.deterministic_methods:
+            if method_filter is not None and method_name not in method_filter:
+                continue
+            rows.append(
+                _run_once(problem, method_name, METHODS[method_name], reference)
+            )
+    return rows
+
+
+def write_csv(rows: list[BenchmarkRow], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = [field.name for field in fields(BenchmarkRow)]
+    with output.open('w', newline='', encoding='utf-8') as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(asdict(row))
+
+
+def print_leaderboard(rows: list[BenchmarkRow]) -> None:
+    print('\nDynamiqs solver benchmark leaderboard')
+    print('-' * 92)
+    print(
+        f'{"benchmark":34} {"method":10} {"status":6} '
+        f'{"runtime_s":>10} {"nsteps":>10} {"error":>12}'
+    )
+    print('-' * 92)
+    for row in rows:
+        runtime = '-' if row.runtime_s is None else f'{row.runtime_s:.4f}'
+        nsteps = '-' if row.nsteps is None else f'{row.nsteps:.1f}'
+        error = '-' if row.error is None else f'{row.error:.3e}'
+        print(
+            f'{row.benchmark:34} {row.method:10} {row.status:6} '
+            f'{runtime:>10} {nsteps:>10} {error:>12}'
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Run Dynamiqs solver benchmarks.')
+    parser.add_argument('--suite', choices=('smoke', 'full'), default='smoke')
+    parser.add_argument('--out', type=Path, default=Path('benchmark-results.csv'))
+    parser.add_argument('--methods', nargs='*', help='Optional subset of method names.')
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    problems = smoke_problems() if args.suite == 'smoke' else all_problems()
+    method_filter = set(args.methods) if args.methods else None
+    rows = run_suite(problems, method_filter)
+    write_csv(rows, args.out)
+    print_leaderboard(rows)
+    print(f'\nSaved benchmark results to {args.out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/benchmark/test_smoke.py
+++ b/tests/benchmark/test_smoke.py
@@ -6,7 +6,6 @@ import jax.numpy as jnp
 import pytest
 
 import dynamiqs as dq
-
 from tests.order import TEST_LONG
 
 from .metrics import extract_nsteps_stats, state_infidelity_stats

--- a/tests/benchmark/test_smoke.py
+++ b/tests/benchmark/test_smoke.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.order import TEST_LONG
+
+from .problems import smoke_problems
+from .runner import run_suite
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_benchmark_smoke_suite_runs():
+    rows = run_suite(smoke_problems(), method_filter={'Tsit5'})
+
+    assert len(rows) == 1
+    assert rows[0].status == 'pass'
+    assert rows[0].runtime_s is not None
+    assert rows[0].nsteps is not None
+    assert rows[0].error is not None
+    assert rows[0].error < 1e-3

--- a/tests/benchmark/test_smoke.py
+++ b/tests/benchmark/test_smoke.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import jax.numpy as jnp
 import pytest
+
+import dynamiqs as dq
 
 from tests.order import TEST_LONG
 
-from .problems import smoke_problems
+from .metrics import extract_nsteps_stats, state_infidelity_stats
+from .problems import (
+    CrossResonanceModulatedSESolve,
+    DrivenDampedHarmonicOscillator,
+    IsingChainSESolve,
+    ZenoCNOTReducedMESolve,
+    all_problems,
+    smoke_problems,
+)
 from .runner import run_suite
 
 
@@ -13,8 +26,71 @@ def test_benchmark_smoke_suite_runs():
     rows = run_suite(smoke_problems(), method_filter={'Tsit5'})
 
     assert len(rows) == 1
-    assert rows[0].status == 'pass'
-    assert rows[0].runtime_s is not None
-    assert rows[0].nsteps is not None
-    assert rows[0].error is not None
-    assert rows[0].error < 1e-3
+    row = rows[0]
+    assert row.status == 'pass'
+    assert row.runtime_s is not None
+    assert row.nsteps_mean is not None
+    assert row.nsteps_min is not None
+    assert row.nsteps_max is not None
+    assert row.error_mean is not None
+    assert row.error_min is not None
+    assert row.error_max is not None
+    assert row.error_mean < 1e-3
+
+
+def test_method_matrix():
+    sesolve_names = [x.name for x in CrossResonanceModulatedSESolve.methods]
+    mesolve_names = [x.name for x in ZenoCNOTReducedMESolve.methods]
+
+    assert sum(name.startswith('Euler(') for name in sesolve_names) == 3
+    assert not any(name.startswith('Rouchon') for name in sesolve_names)
+    assert sum(name.startswith('Euler(') for name in mesolve_names) == 3
+    assert sum(name.startswith('Rouchon1(') for name in mesolve_names) == 3
+    assert 'Rouchon2' in mesolve_names
+    assert 'Rouchon3' in mesolve_names
+    assert 'Expm' in [x.name for x in IsingChainSESolve.methods]
+    assert 'Expm' not in sesolve_names
+
+
+def test_state_infidelity_stats_preserves_batch():
+    states = dq.stack(
+        [
+            dq.stack([dq.fock(2, 0), dq.fock(2, 0)]),
+            dq.stack([dq.fock(2, 0), dq.fock(2, 1)]),
+        ]
+    )
+    reference = dq.stack(
+        [
+            dq.stack([dq.fock(2, 0), dq.fock(2, 0)]),
+            dq.stack([dq.fock(2, 0), dq.fock(2, 0)]),
+        ]
+    )
+
+    stats = state_infidelity_stats(states, reference)
+
+    assert stats.mean == pytest.approx(0.25)
+    assert stats.minimum == pytest.approx(0.0)
+    assert stats.maximum == pytest.approx(0.5)
+
+
+def test_extract_nsteps_stats_preserves_batch():
+    result = SimpleNamespace(infos=SimpleNamespace(nsteps=jnp.asarray([4, 7, 10])))
+
+    stats = extract_nsteps_stats(result)
+
+    assert stats is not None
+    assert stats.mean == pytest.approx(7.0)
+    assert stats.minimum == pytest.approx(4.0)
+    assert stats.maximum == pytest.approx(10.0)
+
+
+def test_driven_damped_reference_shape():
+    problem = DrivenDampedHarmonicOscillator()
+
+    reference = dq.to_jax(problem.reference())
+
+    assert reference.shape == (problem.nsave, problem.trunc, problem.trunc)
+
+
+def test_all_problems_save_100_states():
+    assert all(problem.nsave == 100 for problem in all_problems())


### PR DESCRIPTION
Addresses #1083.

Adds an opt-in benchmark suite for Dynamiqs solvers with representative deterministic problems, CSV output, leaderboard summary, runtime/nsteps/error metrics, and a lightweight smoke test for CI.

Author: Juan Medina <alberto4002@gmail.com>

Validation:
- py -m ruff check tests\benchmark
- py -m pytest tests\benchmark\test_smoke.py
- py -m tests.benchmark.runner --suite full --methods Tsit5 --out benchmark-full-tsit5.csv