### PR TITLE
Add Hessian-compatible gradient mode

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -87,6 +87,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - Direct
         - BackwardCheckpointed
         - Forward
+        - HigherOrder
 
 ### Progress meters
 

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -4,7 +4,7 @@ import equinox as eqx
 
 from ._utils import tree_str_inline
 
-__all__ = ['Direct', 'BackwardCheckpointed', 'Forward', 'Gradient']
+__all__ = ['Direct', 'BackwardCheckpointed', 'Forward', 'HigherOrder', 'Gradient']
 
 
 class Gradient(eqx.Module):
@@ -103,6 +103,24 @@ class Forward(Gradient):
         For Diffrax-based methods, this falls back to the
         [`diffrax.ForwardMode`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.ForwardMode)
         option.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self):
+        pass
+
+
+class HigherOrder(Gradient):
+    """Higher-order automatic differentiation.
+
+    Enables support for higher-order automatic differentiation
+    (like [`jax.hessian`](https://docs.jax.dev/en/latest/_autosummary/jax.hessian.html))
+    through Diffrax-based solvers.
+
+    Note:
+        For Diffrax-based methods, this uses
+        [`diffrax.DirectAdjoint`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.DirectAdjoint)
+        and configures compatible solver scans when required by Diffrax.
     """
 
     # dummy init to have the signature in the documentation

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -6,12 +6,13 @@ from functools import partial
 
 import diffrax as dx
 import equinox as eqx
+from diffrax import AbstractRungeKutta
 from jax import Array
 from jaxtyping import PyTree, Scalar
 
 from ..._checks import check_hermitian
 from ..._utils import obj_type_str
-from ...gradient import BackwardCheckpointed, Direct, Forward, Gradient
+from ...gradient import BackwardCheckpointed, Direct, Forward, Gradient, HigherOrder
 from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options
 from ...result import MESolveResult, Result, Saved
@@ -92,10 +93,25 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             return dx.RecursiveCheckpointAdjoint(self.gradient.ncheckpoints)
         elif isinstance(self.gradient, Forward):
             return dx.ForwardMode()
-        elif isinstance(self.gradient, Direct):
+        elif isinstance(self.gradient, Direct | HigherOrder):
             return dx.DirectAdjoint()
         else:
             raise TypeError(f'Unknown gradient type {obj_type_str(self.gradient)}.')
+
+    @property
+    def solver(self) -> dx.AbstractSolver:
+        if (
+            isinstance(self.gradient, HigherOrder)
+            and isinstance(self.diffrax_solver, AbstractRungeKutta)
+            and self.diffrax_solver.scan_kind is None
+        ):
+            return eqx.tree_at(
+                lambda s: s.scan_kind,
+                self.diffrax_solver,
+                'bounded',
+                is_leaf=lambda x: x is None,
+            )
+        return self.diffrax_solver
 
     def diffeqsolve(
         self,
@@ -127,7 +143,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             # === solve differential equation with diffrax
             return dx.diffeqsolve(
                 self.terms,
-                self.diffrax_solver,
+                self.solver,
                 t0=t0,
                 t1=t1,
                 dt0=self.dt0,

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -9,7 +9,7 @@ from jaxtyping import PRNGKeyArray
 from optimistix import AbstractRootFinder
 
 from ._utils import tree_str_inline
-from .gradient import BackwardCheckpointed, Direct, Forward, Gradient
+from .gradient import BackwardCheckpointed, Direct, Forward, Gradient, HigherOrder
 
 __all__ = [
     'Dopri5',
@@ -34,6 +34,8 @@ __all__ = [
 
 
 _TupleGradient = tuple[type[Gradient], ...]
+_ODE_GRADIENTS: _TupleGradient = (Direct, BackwardCheckpointed, Forward)
+_DIFFRAX_ODE_GRADIENTS: _TupleGradient = (*_ODE_GRADIENTS, HigherOrder)
 
 
 # === generic methods options
@@ -144,15 +146,12 @@ class Euler(_DEFixedStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward] and
+        [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_DIFFRAX_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(self, dt: float):
@@ -217,15 +216,11 @@ class Rouchon1(_DEFixedStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
+        (default),
         and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_ODE_GRADIENTS,)
 
     # todo: fix static dt (similar issue as static tsave in dssesolve)
     dt: float = eqx.field(static=True)
@@ -264,15 +259,11 @@ class Rouchon2(_DEFixedStep, _DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
+        (default),
         and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_ODE_GRADIENTS,)
 
     normalize: bool = eqx.field(static=True, default=True)
 
@@ -322,15 +313,11 @@ class Rouchon3(_DEFixedStep, _DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
+        (default),
         and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_ODE_GRADIENTS,)
 
     normalize: bool = eqx.field(static=True, default=True)
 
@@ -371,15 +358,12 @@ class Dopri5(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward] and
+        [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_DIFFRAX_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -412,15 +396,12 @@ class Dopri8(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward] and
+        [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_DIFFRAX_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -453,15 +434,12 @@ class Tsit5(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward] and
+        [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_DIFFRAX_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -505,15 +483,12 @@ class Kvaerno3(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward] and
+        [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_DIFFRAX_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -557,15 +532,12 @@ class Kvaerno5(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward] and
+        [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_DIFFRAX_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -633,11 +605,7 @@ class Event(_DEMethod):
     root_finder: AbstractRootFinder | None = eqx.field(static=True, default=None)
     smart_sampling: bool = eqx.field(static=True, default=False)
 
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -701,11 +669,7 @@ class JumpMonteCarlo(_DEMethod):
     jsse_nmaxclick: int = eqx.field(static=True, default=10_000)
 
     # dummy variable, the proper check of gradient support will be done by `jsse_method`
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(
@@ -743,11 +707,7 @@ class DiffusiveMonteCarlo(_DEMethod):
     dsse_method: Method
 
     # dummy variable, the proper check of gradient support will be done by `dsse_method`
-    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
-        Direct,
-        BackwardCheckpointed,
-        Forward,
-    )
+    SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (*_ODE_GRADIENTS,)
 
     # dummy init to have the signature in the documentation
     def __init__(self, keys: PRNGKeyArray, dsse_method: Method):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
               - Direct: python_api/gradient/Direct.md
               - BackwardCheckpointed: python_api/gradient/BackwardCheckpointed.md
               - Forward: python_api/gradient/Forward.md
+              - HigherOrder: python_api/gradient/HigherOrder.md
           - Progress meters:
               - NoProgressMeter: python_api/progress_meter/NoProgressMeter.md
               - TextProgressMeter: python_api/progress_meter/TextProgressMeter.md

--- a/tests/mesolve/test_hessian.py
+++ b/tests/mesolve/test_hessian.py
@@ -1,0 +1,35 @@
+import jax
+import jax.numpy as jnp
+
+import dynamiqs as dq
+from dynamiqs.gradient import HigherOrder
+from dynamiqs.method import Tsit5
+
+
+def test_mesolve_higher_order_gradient_matches_closed_qubit_hessian():
+    t_final = 0.4
+    omega = 0.7
+    tsave = jnp.linspace(0.0, t_final, 9)
+    rho0 = dq.basis(2, 0).todm()
+    sx = dq.sigmax()
+    sz = dq.sigmaz()
+    method = Tsit5(rtol=1e-8, atol=1e-8)
+
+    def final_z_expectation(omega):
+        result = dq.mesolve(
+            0.5 * omega * sx,
+            [],
+            rho0,
+            tsave,
+            exp_ops=[sz],
+            method=method,
+            gradient=HigherOrder(),
+            save_states=False,
+            progress_meter=False,
+        )
+        return jnp.real(result.expects[0, -1])
+
+    actual = jax.hessian(final_z_expectation)(omega)
+    expected = -(t_final**2) * jnp.cos(omega * t_final)
+
+    assert jnp.allclose(actual, expected, rtol=1e-4, atol=1e-5)

--- a/tests/sesolve/test_hessian.py
+++ b/tests/sesolve/test_hessian.py
@@ -1,0 +1,34 @@
+import jax
+import jax.numpy as jnp
+
+import dynamiqs as dq
+from dynamiqs.gradient import HigherOrder
+from dynamiqs.method import Tsit5
+
+
+def test_sesolve_higher_order_gradient_matches_qubit_hessian():
+    t_final = 0.4
+    omega = 0.7
+    tsave = jnp.linspace(0.0, t_final, 9)
+    psi0 = dq.basis(2, 0)
+    sx = dq.sigmax()
+    sz = dq.sigmaz()
+    method = Tsit5(rtol=1e-8, atol=1e-8)
+
+    def final_z_expectation(omega):
+        result = dq.sesolve(
+            0.5 * omega * sx,
+            psi0,
+            tsave,
+            exp_ops=[sz],
+            method=method,
+            gradient=HigherOrder(),
+            save_states=False,
+            progress_meter=False,
+        )
+        return jnp.real(result.expects[0, -1])
+
+    actual = jax.hessian(final_z_expectation)(omega)
+    expected = -(t_final**2) * jnp.cos(omega * t_final)
+
+    assert jnp.allclose(actual, expected, rtol=1e-4, atol=1e-5)


### PR DESCRIPTION
## Summary
- Add `dq.gradient.HigherOrder()` for higher-order autodiff through Diffrax-based ODE solvers.
- Use `DirectAdjoint` with bounded solver scans for the new mode.
- Add analytical Hessian regression tests for `sesolve()` and `mesolve()`, plus docs API entries.

Closes #1082

## Validation
- `uv run --python 3.11 --with pytest --with-editable . pytest tests/sesolve/test_hessian.py tests/mesolve/test_hessian.py tests/sesolve/test_adaptive.py tests/mesolve/test_adaptive.py -q`
- `uv run --python 3.11 --with ruff ruff check dynamiqs/gradient.py dynamiqs/method.py dynamiqs/integrators/core/diffrax_integrator.py tests/sesolve/test_hessian.py tests/mesolve/test_hessian.py`
- `uv run --python 3.11 --with ruff ruff format --check dynamiqs/gradient.py dynamiqs/method.py dynamiqs/integrators/core/diffrax_integrator.py tests/sesolve/test_hessian.py tests/mesolve/test_hessian.py`
- `git diff --check`