### PR TITLE
Add `HigherOrder` gradient mode for Hessian computation

### DIFF
--- a/docs/python_api/index.md
+++ b/docs/python_api/index.md
@@ -87,6 +87,7 @@ The **Dynamiqs** Python API features two main types of functions: solvers of dif
         - Direct
         - BackwardCheckpointed
         - Forward
+        - HigherOrder
 
 ### Progress meters
 

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -4,7 +4,7 @@ import equinox as eqx
 
 from ._utils import tree_str_inline
 
-__all__ = ['Direct', 'BackwardCheckpointed', 'Forward', 'Gradient']
+__all__ = ['Direct', 'BackwardCheckpointed', 'Forward', 'HigherOrder', 'Gradient']
 
 
 class Gradient(eqx.Module):
@@ -103,6 +103,41 @@ class Forward(Gradient):
         For Diffrax-based methods, this falls back to the
         [`diffrax.ForwardMode`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.ForwardMode)
         option.
+    """
+
+    # dummy init to have the signature in the documentation
+    def __init__(self):
+        pass
+
+
+class HigherOrder(Gradient):
+    """Automatic differentiation compatible with higher-order derivatives.
+
+    With this option, the gradient is computed by automatically differentiating
+    through the internals of the solver, using a configuration that additionally
+    supports *higher-order* and nested automatic differentiation. This is the
+    option to use to compute Hessians with
+    [`jax.hessian`](https://docs.jax.dev/en/latest/_autosummary/jax.hessian.html)
+    (or, more generally, to nest [`jax.jvp`](https://docs.jax.dev/en/latest/_autosummary/jax.jvp.html)
+    and [`jax.vjp`](https://docs.jax.dev/en/latest/_autosummary/jax.vjp.html)),
+    which the first-order modes ([`dq.gradient.Direct`][dynamiqs.gradient.Direct],
+    [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
+    and [`dq.gradient.Forward`][dynamiqs.gradient.Forward]) do not reliably
+    support.
+
+    Note:
+        For Diffrax-based methods, this falls back to the
+        [`diffrax.DirectAdjoint`](https://docs.kidger.site/diffrax/api/adjoints/#diffrax.DirectAdjoint)
+        option, and additionally instantiates the underlying Runge-Kutta method
+        with `scan_kind="bounded"`. This is the configuration recommended by
+        Diffrax for higher-order autodifferentiation (see the
+        [Diffrax Hessian example](https://docs.kidger.site/diffrax/examples/hessian/)).
+
+    Warning:
+        Supporting higher-order autodiff comes at the cost of increased memory
+        usage and slower execution than the first-order modes. Prefer a
+        first-order mode (e.g. [`dq.gradient.Direct`][dynamiqs.gradient.Direct])
+        when you only need first-order gradients.
     """
 
     # dummy init to have the signature in the documentation

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -11,7 +11,7 @@ from jaxtyping import PyTree, Scalar
 
 from ..._checks import check_hermitian
 from ..._utils import obj_type_str
-from ...gradient import BackwardCheckpointed, Direct, Forward, Gradient
+from ...gradient import BackwardCheckpointed, Direct, Forward, Gradient, HigherOrder
 from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options
 from ...result import MESolveResult, Result, Saved
@@ -92,10 +92,30 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             return dx.RecursiveCheckpointAdjoint(self.gradient.ncheckpoints)
         elif isinstance(self.gradient, Forward):
             return dx.ForwardMode()
-        elif isinstance(self.gradient, Direct):
+        elif isinstance(self.gradient, (Direct, HigherOrder)):
             return dx.DirectAdjoint()
         else:
             raise TypeError(f'Unknown gradient type {obj_type_str(self.gradient)}.')
+
+    @property
+    def solver(self) -> dx.AbstractSolver:
+        # higher-order autodiff (e.g. `jax.hessian`) requires `DirectAdjoint`
+        # together with a Runge-Kutta method built with `scan_kind="bounded"`;
+        # see the diffrax Hessian example and `diffrax.DirectAdjoint`. This is
+        # the same hack used in the Rouchon integrator to make Runge-Kutta
+        # solvers forward-mode compatible.
+        if (
+            isinstance(self.gradient, HigherOrder)
+            and isinstance(self.diffrax_solver, dx.AbstractRungeKutta)
+            and self.diffrax_solver.scan_kind is None
+        ):
+            return eqx.tree_at(
+                lambda s: s.scan_kind,
+                self.diffrax_solver,
+                'bounded',
+                is_leaf=lambda x: x is None,
+            )
+        return self.diffrax_solver
 
     def diffeqsolve(
         self,
@@ -127,7 +147,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             # === solve differential equation with diffrax
             return dx.diffeqsolve(
                 self.terms,
-                self.diffrax_solver,
+                self.solver,
                 t0=t0,
                 t1=t1,
                 dt0=self.dt0,

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -9,7 +9,7 @@ from jaxtyping import PRNGKeyArray
 from optimistix import AbstractRootFinder
 
 from ._utils import tree_str_inline
-from .gradient import BackwardCheckpointed, Direct, Forward, Gradient
+from .gradient import BackwardCheckpointed, Direct, Forward, Gradient, HigherOrder
 
 __all__ = [
     'Dopri5',
@@ -144,14 +144,16 @@ class Euler(_DEFixedStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward]
+        and [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -371,14 +373,16 @@ class Dopri5(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward]
+        and [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -412,14 +416,16 @@ class Dopri8(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward]
+        and [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -453,14 +459,16 @@ class Tsit5(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward]
+        and [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -505,14 +513,16 @@ class Kvaerno3(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward]
+        and [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -557,14 +567,16 @@ class Kvaerno5(_DEAdaptiveStep):
         This method supports differentiation with
         [`dq.gradient.Direct`][dynamiqs.gradient.Direct],
         [`dq.gradient.BackwardCheckpointed`][dynamiqs.gradient.BackwardCheckpointed]
-        (default)
-        and [`dq.gradient.Forward`][dynamiqs.gradient.Forward].
+        (default),
+        [`dq.gradient.Forward`][dynamiqs.gradient.Forward]
+        and [`dq.gradient.HigherOrder`][dynamiqs.gradient.HigherOrder].
     """
 
     SUPPORTED_GRADIENT: ClassVar[_TupleGradient] = (
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -191,6 +191,7 @@ nav:
               - Direct: python_api/gradient/Direct.md
               - BackwardCheckpointed: python_api/gradient/BackwardCheckpointed.md
               - Forward: python_api/gradient/Forward.md
+              - HigherOrder: python_api/gradient/HigherOrder.md
           - Progress meters:
               - NoProgressMeter: python_api/progress_meter/NoProgressMeter.md
               - TextProgressMeter: python_api/progress_meter/TextProgressMeter.md

--- a/tests/test_hessian.py
+++ b/tests/test_hessian.py
@@ -1,0 +1,124 @@
+import diffrax as dx
+import jax
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+from dynamiqs.gradient import Direct, HigherOrder
+from dynamiqs.method import Dopri5, Expm, Tsit5
+
+from .order import TEST_SHORT
+
+# Analytical reference for all tests below. For the qubit Hamiltonian
+# H(w) = (w / 2) sigma_x with initial state |0>, the expectation value of
+# sigma_z after a time t is
+#     <sigma_z>(w) = cos(w t),
+# so its second derivative with respect to w is
+#     d2/dw2 <sigma_z>(w) = -t^2 cos(w t).
+_T = 0.7
+_W = 0.5
+_TSAVE = jnp.array([0.0, _T])
+
+
+# Hessian computation matches the analytical result much more tightly in double
+# precision; keep the precision change local to this module to avoid leakage.
+@pytest.fixture(scope='module', autouse=True)
+def _double_precision():
+    prev_x64 = jax.config.read('jax_enable_x64')
+    dq.set_precision('double')
+    yield
+    dq.set_precision('double' if prev_x64 else 'single')
+
+
+def _sesolve_sz(omega, gradient, method=Tsit5()):  # noqa: B008
+    h = 0.5 * omega * dq.sigmax()
+    psi0 = dq.basis(2, 0)
+    res = dq.sesolve(
+        h, psi0, _TSAVE, exp_ops=[dq.sigmaz()], gradient=gradient, method=method
+    )
+    return res.expects[0, -1].real
+
+
+def _mesolve_sz(omega, gradient, method=Tsit5()):  # noqa: B008
+    h = 0.5 * omega * dq.sigmax()
+    rho0 = dq.todm(dq.basis(2, 0))
+    res = dq.mesolve(
+        h, [], rho0, _TSAVE, exp_ops=[dq.sigmaz()], gradient=gradient, method=method
+    )
+    return res.expects[0, -1].real
+
+
+@pytest.mark.run(order=TEST_SHORT)
+class TestHessian:
+    @pytest.mark.parametrize('method', [Tsit5(), Dopri5()])
+    def test_sesolve_scalar_hessian(self, method):
+        f = lambda w: _sesolve_sz(w, HigherOrder(), method)
+        hess = jax.hessian(f)(_W)
+        expected = -(_T**2) * jnp.cos(_W * _T)
+        assert jnp.allclose(hess, expected, atol=1e-5)
+
+    def test_sesolve_hessian_matrix(self):
+        # Two-parameter Hamiltonian H = ((a + b) / 2) sigma_x, so the full 2x2
+        # Hessian is known analytically: every entry equals -t^2 cos((a + b) t).
+        def f(p):
+            a, b = p
+            h = 0.5 * (a + b) * dq.sigmax()
+            psi0 = dq.basis(2, 0)
+            res = dq.sesolve(
+                h, psi0, _TSAVE, exp_ops=[dq.sigmaz()], gradient=HigherOrder()
+            )
+            return res.expects[0, -1].real
+
+        params = jnp.array([0.3, 0.2])  # a + b = _W = 0.5
+        hess = jax.hessian(f)(params)
+        expected = -(_T**2) * jnp.cos(_W * _T) * jnp.ones((2, 2))
+        assert jnp.allclose(hess, expected, atol=1e-5)
+
+    def test_mesolve_scalar_hessian(self):
+        f = lambda w: _mesolve_sz(w, HigherOrder())
+        hess = jax.hessian(f)(_W)
+        expected = -(_T**2) * jnp.cos(_W * _T)
+        assert jnp.allclose(hess, expected, atol=1e-5)
+
+    def test_first_order_gradient_preserved(self):
+        # HigherOrder must keep first-order gradients correct.
+        f = lambda w: _sesolve_sz(w, HigherOrder())
+        grad = jax.grad(f)(_W)
+        expected = -_T * jnp.sin(_W * _T)
+        assert jnp.allclose(grad, expected, atol=1e-5)
+
+    def test_default_gradient_cannot_compute_hessian(self):
+        # The default differentiation path (RecursiveCheckpointAdjoint) is not
+        # compatible with jax.hessian; this is the limitation HigherOrder fixes.
+        f = lambda w: _sesolve_sz(w, None)
+        with pytest.raises(TypeError, match='custom_vjp'):
+            jax.hessian(f)(_W)
+
+    def test_supported_methods(self):
+        # HigherOrder is enabled for the Diffrax ODE methods...
+        assert Tsit5().supports_gradient(HigherOrder())
+        assert Dopri5().supports_gradient(HigherOrder())
+        # ...but not for methods using a different integrator (e.g. Expm).
+        assert not Expm().supports_gradient(HigherOrder())
+
+    def test_higher_order_rebuilds_solver_with_bounded_scan_kind(self, monkeypatch):
+        # The behaviour that makes HigherOrder work is rebuilding the Runge-Kutta
+        # method with scan_kind="bounded". Capture the solver actually handed to
+        # diffrax to confirm HigherOrder sets it while Direct leaves it as None,
+        # so the rebuild is genuinely exercised rather than dead code.
+        captured = {}
+        original = dx.diffeqsolve
+
+        def spy(terms, solver, **kwargs):
+            captured['scan_kind'] = solver.scan_kind
+            return original(terms, solver, **kwargs)
+
+        monkeypatch.setattr(dx, 'diffeqsolve', spy)
+
+        jax.clear_caches()
+        _sesolve_sz(_W, HigherOrder())
+        assert captured['scan_kind'] == 'bounded'
+
+        jax.clear_caches()
+        _sesolve_sz(_W, Direct())
+        assert captured['scan_kind'] is None


### PR DESCRIPTION
Closes #1082.

`dq.sesolve()` and `dq.mesolve()` could not be differentiated with `jax.hessian()`. The default differentiation path (`diffrax.RecursiveCheckpointAdjoint`) is a `custom_vjp`, so applying forward-mode autodiff on top of reverse-mode (which is what `jax.hessian` does) raises `TypeError: can't apply forward-mode autodiff (jvp) to a custom_vjp function`.

This adds a new gradient mode `dq.gradient.HigherOrder`, kept distinct from the first-order modes, that:

- maps to `diffrax.DirectAdjoint`, and
- instantiates the underlying Runge-Kutta method with `scan_kind="bounded"`, the configuration Diffrax recommends for higher-order autodiff. This reuses the same `eqx.tree_at` trick already used in the Rouchon integrator to make Runge-Kutta solvers forward-mode compatible.

Because the change lives in the shared `DiffraxIntegrator`, it covers both `sesolve()` and `mesolve()`, and the Diffrax ODE methods (`Tsit5`, `Dopri5`, `Dopri8`, `Kvaerno3`, `Kvaerno5`, `Euler`). Methods that use a different integrator (`Expm`, the Rouchon methods, the SDE/Monte-Carlo methods) are intentionally not advertised as supporting it.

### Tests

`tests/test_hessian.py` checks the computed Hessian against analytical results, not just that the solve runs:

- a `sesolve` qubit example with `H(w) = (w/2) sigma_x` where `d^2/dw^2 <sigma_z> = -t^2 cos(w t)`, for both `Tsit5` and `Dopri5`;
- a two-parameter Hessian matrix;
- a `mesolve` analogue;
- first-order gradients are preserved under the new mode;
- the default path still (correctly) refuses `jax.hessian`;
- the mode is whitelisted only for the Diffrax ODE methods;
- the solver is actually rebuilt with `scan_kind="bounded"` under `HigherOrder` and left untouched under `Direct`.

The existing `sesolve`/`mesolve`/propagator suites pass unchanged, and `task lint`, `task format`, and `task type` are clean.

---

AI disclosure: I used Claude Code to help implement and test this change. I reviewed, ran, and verified all of the code and tests myself.
