### PR TITLE
Improve type check coverage

### DIFF
--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
@@ -7,7 +9,9 @@ from jax import Array
 
 from .qarrays.layout import dense
 from .qarrays.qarray import QArray
-from .time_qarray import TimeQArray
+
+if TYPE_CHECKING:
+    from .time_qarray import TimeQArray
 
 _is_perfect_square = lambda n: int(n**0.5) ** 2 == n
 

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
+import numpy as np
 from jax import Array
 
 from .qarrays.layout import dense
@@ -34,7 +35,7 @@ _cases = {
 }
 
 
-def _has_shape(x: Array | QArray, shape: str) -> bool:
+def _has_shape(x: Array | np.ndarray | QArray, shape: str) -> bool:
     if shape in _cases:
         return _cases[shape](x)
     else:
@@ -42,8 +43,11 @@ def _has_shape(x: Array | QArray, shape: str) -> bool:
 
 
 def check_shape(
-    x: Array | QArray, argname: str, *shapes: str, subs: dict[str, str] | None = None
-):
+    x: Array | np.ndarray | QArray,
+    argname: str,
+    *shapes: str,
+    subs: dict[str, str] | None = None,
+) -> None:
     # subs is used to replace symbols in the error message, this can be used to e.g.
     # specify a shape (?, n, n) but print an error message with (nH?, n, n), by passing
     # subs={'?': 'nH?'} to replace the '?' by 'nH?' in the shape specification
@@ -91,7 +95,7 @@ def check_times(x: Array, argname: str, allow_empty: bool = False) -> Array:
     )
 
 
-def check_type_int(x: Array | QArray, argname: str):
+def check_type_int(x: Array | np.ndarray | QArray, argname: str) -> None:
     if not jnp.issubdtype(x.dtype, jnp.integer):
         raise ValueError(
             f'Argument {argname} must be of type integer, but is of type'
@@ -108,7 +112,7 @@ def check_hermitian(x: QArray, argname: str) -> QArray:
     )
 
 
-def check_qarray_is_dense(x: QArray, argname: str):
+def check_qarray_is_dense(x: QArray, argname: str) -> None:
     # check if the layout of x is dense
     if x.layout != dense:
         raise ValueError(

--- a/dynamiqs/_checks.py
+++ b/dynamiqs/_checks.py
@@ -7,6 +7,7 @@ from jax import Array
 
 from .qarrays.layout import dense
 from .qarrays.qarray import QArray
+from .time_qarray import TimeQArray
 
 _is_perfect_square = lambda n: int(n**0.5) ** 2 == n
 
@@ -35,7 +36,7 @@ _cases = {
 }
 
 
-def _has_shape(x: Array | np.ndarray | QArray, shape: str) -> bool:
+def _has_shape(x: Array | np.ndarray | QArray | TimeQArray, shape: str) -> bool:
     if shape in _cases:
         return _cases[shape](x)
     else:
@@ -43,7 +44,7 @@ def _has_shape(x: Array | np.ndarray | QArray, shape: str) -> bool:
 
 
 def check_shape(
-    x: Array | np.ndarray | QArray,
+    x: Array | np.ndarray | QArray | TimeQArray,
     argname: str,
     *shapes: str,
     subs: dict[str, str] | None = None,

--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -45,7 +45,7 @@ def concatenate_sort(*args: Array) -> Array:
     return jnp.sort(jnp.concatenate(args))
 
 
-def is_batched_scalar(y: ArrayLike) -> bool:
+def is_batched_scalar(y: Any) -> bool:
     # check if a qarray-like is a scalar or a set of scalars of shape (..., 1, 1)
     return isinstance(y, get_args(ScalarLike)) or (
         isinstance(y, get_args(ArrayLike))

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from functools import wraps
 from typing import Any
 
@@ -48,7 +48,7 @@ def ispwc(x: TimeQArray) -> bool:
         return False
 
 
-def catch_xla_runtime_error(func: callable) -> callable:
+def catch_xla_runtime_error(func: Callable) -> Callable:
     # Decorator to catch `XlaRuntimeError`` exceptions, and set a more friendly
     # exception message. Note that this will not work for jitted function, as the
     # exception code will be traced out.
@@ -91,8 +91,8 @@ def assert_method_supported(method: Method, supported_methods: Sequence[type[Met
 
 
 def multi_vmap(
-    f: callable, in_axes: int | None | Sequence[Any], out_axes: Any, nvmap: int
-) -> callable:
+    f: Callable, in_axes: int | None | Sequence[Any], out_axes: Any, nvmap: int
+) -> Callable:
     """Vectorize a function multiple time over multiple shared axes (similar to
     jnp.vectorize).
 
@@ -142,8 +142,8 @@ def multi_vmap(
 
 
 def cartesian_vmap(
-    f: callable, in_axes: int | None | Sequence[Any], out_axes: Any, nvmap: PyTree[int]
-) -> callable:
+    f: Callable, in_axes: int | None | Sequence[Any], out_axes: Any, nvmap: PyTree[int]
+) -> Callable:
     """Vectorize a function multiple time over distinct axes.
 
     The function `f` is mapped multiple time over on each input specified by `nvmap`

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -81,7 +81,7 @@ def catch_xla_runtime_error(func: callable) -> callable:
     return wrapper
 
 
-def assert_method_supported(method: Method, supported_methods: Sequence[Method]):
+def assert_method_supported(method: Method, supported_methods: Sequence[type[Method]]):
     if not isinstance(method, tuple(supported_methods)):
         supported_str = ', '.join(f'`{x.__name__}`' for x in supported_methods)
         raise TypeError(

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -27,7 +27,7 @@ class HasShape(Protocol):
     shape: tuple[int, ...]
 
 
-T = TypeVar('T', bound=HasShape)
+HasShapeType = TypeVar('HasShapeType', bound=HasShape)
 
 
 def astimeqarray(x: QArrayLike | TimeQArray) -> TimeQArray:
@@ -194,7 +194,9 @@ def cartesian_vmap(
     return f
 
 
-def attach_batch_indices(x: T, ndim_suffix: int = 2) -> tuple[T, Array]:
+def attach_batch_indices(
+    x: HasShapeType, ndim_suffix: int = 2
+) -> tuple[HasShapeType, Array]:
     """Bundle an array with an array of batch indices for key-folding through vmap.
 
     Returns ``(x, indices)`` where *indices* is an arange over the batch

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from functools import wraps
-from typing import Any
+from typing import Any, Protocol, TypeVar
 
 import jax
 import jax.numpy as jnp
@@ -21,6 +21,13 @@ from ..time_qarray import (
     SummedTimeQArray,
     TimeQArray,
 )
+
+
+class HasShape(Protocol):
+    shape: tuple[int, ...]
+
+
+T = TypeVar('T', bound=HasShape)
 
 
 def astimeqarray(x: QArrayLike | TimeQArray) -> TimeQArray:
@@ -81,7 +88,7 @@ def catch_xla_runtime_error(func: Callable) -> Callable:
     return wrapper
 
 
-def assert_method_supported(method: Method, supported_methods: Sequence[type[Method]]):
+def assert_method_supported(method: Method, supported_methods: Iterable[type[Method]]):
     if not isinstance(method, tuple(supported_methods)):
         supported_str = ', '.join(f'`{x.__name__}`' for x in supported_methods)
         raise TypeError(
@@ -187,7 +194,7 @@ def cartesian_vmap(
     return f
 
 
-def attach_batch_indices(x: Array, ndim_suffix: int = 2) -> tuple[Array, Array]:
+def attach_batch_indices(x: T, ndim_suffix: int = 2) -> tuple[T, Array]:
     """Bundle an array with an array of batch indices for key-folding through vmap.
 
     Returns ``(x, indices)`` where *indices* is an arange over the batch

--- a/dynamiqs/integrators/_utils.py
+++ b/dynamiqs/integrators/_utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import functools
 import math
+import operator
 from collections.abc import Callable, Iterable, Sequence
 from functools import wraps
 from typing import Any, Protocol, TypeVar
@@ -13,7 +15,7 @@ from jaxtyping import PRNGKeyArray, PyTree
 
 from .._utils import obj_type_str
 from ..method import Method, _DEAdaptiveStep
-from ..qarrays.qarray import QArrayLike
+from ..qarrays.qarray import QArray, QArrayLike
 from ..qarrays.utils import asqarray
 from ..time_qarray import (
     ConstantTimeQArray,
@@ -27,7 +29,11 @@ class HasShape(Protocol):
     shape: tuple[int, ...]
 
 
-HasShapeType = TypeVar('HasShapeType', bound=HasShape)
+HasShapeT = TypeVar('HasShapeT', bound=HasShape)
+
+
+def sum_qarrays(qarrays: list[QArray]) -> QArray:
+    return functools.reduce(operator.add, qarrays)
 
 
 def astimeqarray(x: QArrayLike | TimeQArray) -> TimeQArray:
@@ -194,9 +200,7 @@ def cartesian_vmap(
     return f
 
 
-def attach_batch_indices(
-    x: HasShapeType, ndim_suffix: int = 2
-) -> tuple[HasShapeType, Array]:
+def attach_batch_indices(x: HasShapeT, ndim_suffix: int = 2) -> tuple[HasShapeT, Array]:
     """Bundle an array with an array of batch indices for key-folding through vmap.
 
     Returns ``(x, indices)`` where *indices* is an arange over the batch

--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -44,7 +44,7 @@ def dsmesolve(
     gradient: Gradient | None = None,
     save_states: bool = True,
     cartesian_batching: bool = True,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
 ) -> DSMESolveResult:
     r"""Solve the diffusive stochastic master equation (SME).
 
@@ -398,7 +398,7 @@ def _dsmesolve_many_trajectories(
 
     # vectorize input over keys
     in_axes = (None, None, None, None, None, None, 0, None, None, None, None)
-    out_axes = DSMESolveResult(None, None, None, None, 0, 0, 0)
+    out_axes = DSMESolveResult(None, None, None, None, 0, 0, 0)  # ty: ignore
     f = jax.vmap(_dsmesolve_single_trajectory, in_axes, out_axes)
     return f(H, Lcs, Lms, etas, rho0, tsave, keys, exp_ops, method, gradient, options)
 

--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -277,9 +277,9 @@ def dsmesolve(
     rho0 = asqarray(rho0)
     keys = jnp.asarray(keys)
 
-    exp_ops_ = None
+    _exp_ops = None
     if exp_ops is not None:
-        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        _exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -289,18 +289,18 @@ def dsmesolve(
     )
 
     # === check arguments
-    _check_dsmesolve_args(H, Ls, etas, rho0, exp_ops_)
+    _check_dsmesolve_args(H, Ls, etas, rho0, _exp_ops)
     check_options(options, 'dsmesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
-    tsave_ = tsave
+    _tsave = tsave
     if not isinstance(tsave, tuple):
-        tsave_ = jnp.asarray(tsave)
-        tsave_ = check_times(tsave_, 'tsave')
-        tsave_ = tuple(tsave_.tolist())
+        _tsave = jnp.asarray(tsave)
+        _tsave = check_times(_tsave, 'tsave')
+        _tsave = tuple(_tsave.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -318,7 +318,7 @@ def dsmesolve(
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to JAX arrays
     return _vectorized_dsmesolve(
-        H, Lcs, Lms, etas, rho0, tsave_, keys, exp_ops_, method, gradient, options
+        H, Lcs, Lms, etas, rho0, _tsave, keys, _exp_ops, method, gradient, options
     )
 
 

--- a/dynamiqs/integrators/apis/dsmesolve.py
+++ b/dynamiqs/integrators/apis/dsmesolve.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -275,8 +276,10 @@ def dsmesolve(
     etas = jnp.asarray(etas)
     rho0 = asqarray(rho0)
     keys = jnp.asarray(keys)
+
+    exp_ops_ = None
     if exp_ops is not None:
-        exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -286,18 +289,18 @@ def dsmesolve(
     )
 
     # === check arguments
-    _check_dsmesolve_args(H, Ls, etas, rho0, exp_ops)
-    tsave = check_times(tsave, 'tsave')
+    _check_dsmesolve_args(H, Ls, etas, rho0, exp_ops_)
     check_options(options, 'dsmesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
+    tsave_ = tsave
     if not isinstance(tsave, tuple):
-        tsave = jnp.asarray(tsave)
-        tsave = check_times(tsave, 'tsave')
-        tsave = tuple(tsave.tolist())
+        tsave_ = jnp.asarray(tsave)
+        tsave_ = check_times(tsave_, 'tsave')
+        tsave_ = tuple(tsave_.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -315,7 +318,7 @@ def dsmesolve(
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to JAX arrays
     return _vectorized_dsmesolve(
-        H, Lcs, Lms, etas, rho0, tsave, keys, exp_ops, method, gradient, options
+        H, Lcs, Lms, etas, rho0, tsave_, keys, exp_ops_, method, gradient, options
     )
 
 
@@ -422,7 +425,7 @@ def _dsmesolve_single_trajectory(
         Rouchon1: dsmesolve_rouchon1_integrator_constructor,
     }
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -444,10 +447,7 @@ def _dsmesolve_single_trajectory(
     )
 
     # === run solver
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(DSMESolveResult, integrator.run())
 
 
 def _check_dsmesolve_args(

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -43,7 +43,7 @@ def dssesolve(
     gradient: Gradient | None = None,
     save_states: bool = True,
     cartesian_batching: bool = True,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
 ) -> DSSESolveResult:
     r"""Solve the diffusive stochastic Schrödinger equation (SSE).
 

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -255,8 +256,10 @@ def dssesolve(
     Ls = [astimeqarray(L) for L in jump_ops]
     psi0 = asqarray(psi0)
     keys = jnp.asarray(keys)
+
+    exp_ops_ = None
     if exp_ops is not None:
-        exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -266,17 +269,18 @@ def dssesolve(
     )
 
     # === check arguments
-    _check_dssesolve_args(H, Ls, psi0, exp_ops)
+    _check_dssesolve_args(H, Ls, psi0, exp_ops_)
     check_options(options, 'dssesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
+    tsave_ = tsave
     if not isinstance(tsave, tuple):
-        tsave = jnp.asarray(tsave)
-        tsave = check_times(tsave, 'tsave')
-        tsave = tuple(tsave.tolist())
+        tsave_ = jnp.asarray(tsave)
+        tsave_ = check_times(tsave_, 'tsave')
+        tsave_ = tuple(tsave_.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -284,7 +288,7 @@ def dssesolve(
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to JAX arrays
     return _vectorized_dssesolve(
-        H, Ls, psi0, tsave, keys, exp_ops, method, gradient, options
+        H, Ls, psi0, tsave_, keys, exp_ops_, method, gradient, options
     )
 
 
@@ -365,7 +369,7 @@ def _dssesolve_many_trajectories(
     keys = fold_keys_with_batch_indices(keys, batch_indices)
 
     # vectorize input over keys
-    in_axes = (None, None, None, None, 0, None, None, None, None)  # ty: ignore[invalid-argument-type]
+    in_axes = (None, None, None, None, 0, None, None, None, None)
     out_axes = DSSESolveResult(None, None, None, None, 0, 0, 0)  # ty: ignore[invalid-argument-type]
     f = jax.vmap(_dssesolve_single_trajectory, in_axes, out_axes)
     return f(H, Ls, psi0, tsave, keys, exp_ops, method, gradient, options)
@@ -388,7 +392,7 @@ def _dssesolve_single_trajectory(
         Rouchon1: dssesolve_rouchon1_integrator_constructor,
     }
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -408,10 +412,7 @@ def _dssesolve_single_trajectory(
     )
 
     # === run solver
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(DSSESolveResult, integrator.run())
 
 
 def _check_dssesolve_args(

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -365,8 +365,8 @@ def _dssesolve_many_trajectories(
     keys = fold_keys_with_batch_indices(keys, batch_indices)
 
     # vectorize input over keys
-    in_axes = (None, None, None, None, 0, None, None, None, None)
-    out_axes = DSSESolveResult(None, None, None, None, 0, 0, 0)
+    in_axes = (None, None, None, None, 0, None, None, None, None)  # ty: ignore[invalid-argument-type]
+    out_axes = DSSESolveResult(None, None, None, None, 0, 0, 0)  # ty: ignore[invalid-argument-type]
     f = jax.vmap(_dssesolve_single_trajectory, in_axes, out_axes)
     return f(H, Ls, psi0, tsave, keys, exp_ops, method, gradient, options)
 

--- a/dynamiqs/integrators/apis/dssesolve.py
+++ b/dynamiqs/integrators/apis/dssesolve.py
@@ -257,9 +257,9 @@ def dssesolve(
     psi0 = asqarray(psi0)
     keys = jnp.asarray(keys)
 
-    exp_ops_ = None
+    _exp_ops = None
     if exp_ops is not None:
-        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        _exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -269,18 +269,18 @@ def dssesolve(
     )
 
     # === check arguments
-    _check_dssesolve_args(H, Ls, psi0, exp_ops_)
+    _check_dssesolve_args(H, Ls, psi0, _exp_ops)
     check_options(options, 'dssesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
-    tsave_ = tsave
+    _tsave = tsave
     if not isinstance(tsave, tuple):
-        tsave_ = jnp.asarray(tsave)
-        tsave_ = check_times(tsave_, 'tsave')
-        tsave_ = tuple(tsave_.tolist())
+        _tsave = jnp.asarray(tsave)
+        _tsave = check_times(_tsave, 'tsave')
+        _tsave = tuple(_tsave.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -288,7 +288,7 @@ def dssesolve(
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to JAX arrays
     return _vectorized_dssesolve(
-        H, Ls, psi0, tsave_, keys, exp_ops_, method, gradient, options
+        H, Ls, psi0, _tsave, keys, _exp_ops, method, gradient, options
     )
 
 

--- a/dynamiqs/integrators/apis/jsmesolve.py
+++ b/dynamiqs/integrators/apis/jsmesolve.py
@@ -279,9 +279,9 @@ def jsmesolve(
     rho0 = asqarray(rho0)
     keys = jnp.asarray(keys)
 
-    exp_ops_ = None
+    _exp_ops = None
     if exp_ops is not None:
-        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        _exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -292,18 +292,18 @@ def jsmesolve(
     )
 
     # === check arguments
-    _check_jsmesolve_args(H, Ls, thetas, etas, rho0, exp_ops_)
+    _check_jsmesolve_args(H, Ls, thetas, etas, rho0, _exp_ops)
     check_options(options, 'jsmesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
-    tsave_ = tsave
+    _tsave = tsave
     if not isinstance(tsave, tuple):
-        tsave_ = jnp.asarray(tsave)
-        tsave_ = check_times(tsave_, 'tsave')
-        tsave_ = tuple(tsave_.tolist())
+        _tsave = jnp.asarray(tsave)
+        _tsave = check_times(_tsave, 'tsave')
+        _tsave = tuple(_tsave.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -328,9 +328,9 @@ def jsmesolve(
         thetas,
         etas,
         rho0,
-        tsave_,
+        _tsave,
         keys,
-        exp_ops_,
+        _exp_ops,
         method,
         gradient,
         options,

--- a/dynamiqs/integrators/apis/jsmesolve.py
+++ b/dynamiqs/integrators/apis/jsmesolve.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -277,8 +278,10 @@ def jsmesolve(
     etas = jnp.asarray(etas)
     rho0 = asqarray(rho0)
     keys = jnp.asarray(keys)
+
+    exp_ops_ = None
     if exp_ops is not None:
-        exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -289,17 +292,18 @@ def jsmesolve(
     )
 
     # === check arguments
-    _check_jsmesolve_args(H, Ls, thetas, etas, rho0, exp_ops)
+    _check_jsmesolve_args(H, Ls, thetas, etas, rho0, exp_ops_)
     check_options(options, 'jsmesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
+    tsave_ = tsave
     if not isinstance(tsave, tuple):
-        tsave = jnp.asarray(tsave)
-        tsave = check_times(tsave, 'tsave')
-        tsave = tuple(tsave.tolist())
+        tsave_ = jnp.asarray(tsave)
+        tsave_ = check_times(tsave_, 'tsave')
+        tsave_ = tuple(tsave_.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -318,7 +322,18 @@ def jsmesolve(
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to JAX arrays
     return _vectorized_jsmesolve(
-        H, Lcs, Lms, thetas, etas, rho0, tsave, keys, exp_ops, method, gradient, options
+        H,
+        Lcs,
+        Lms,
+        thetas,
+        etas,
+        rho0,
+        tsave_,
+        keys,
+        exp_ops_,
+        method,
+        gradient,
+        options,
     )
 
 
@@ -427,7 +442,7 @@ def _jsmesolve_single_trajectory(
     # === select integrator constructor
     integrator_constructors = {EulerJump: jsmesolve_euler_jump_integrator_constructor}
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -450,10 +465,7 @@ def _jsmesolve_single_trajectory(
     )
 
     # === run solver
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(JSMESolveResult, integrator.run())
 
 
 def _check_jsmesolve_args(  # noqa: C901

--- a/dynamiqs/integrators/apis/jsmesolve.py
+++ b/dynamiqs/integrators/apis/jsmesolve.py
@@ -44,7 +44,7 @@ def jsmesolve(
     gradient: Gradient | None = None,
     save_states: bool = True,
     cartesian_batching: bool = True,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
     nmaxclick: int = 10_000,
 ) -> JSMESolveResult:
     r"""Solve the jump stochastic master equation (SME).
@@ -403,7 +403,7 @@ def _jsmesolve_many_trajectories(
 
     # vectorize input over keys
     in_axes = (None, None, None, None, None, None, None, 0, None, None, None, None)
-    out_axes = JSMESolveResult(None, None, None, None, 0, 0, 0)
+    out_axes = JSMESolveResult(None, None, None, None, 0, 0, 0)  # ty: ignore
     f = jax.vmap(_jsmesolve_single_trajectory, in_axes, out_axes)
     return f(
         H, Lcs, Lms, thetas, etas, rho0, tsave, keys, exp_ops, method, gradient, options

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -261,9 +261,9 @@ def jssesolve(
     psi0 = asqarray(psi0)
     keys = jnp.asarray(keys)
 
-    exp_ops_ = None
+    _exp_ops = None
     if exp_ops is not None:
-        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        _exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -275,19 +275,19 @@ def jssesolve(
     )
 
     # === check arguments
-    _check_jssesolve_args(H, Ls, psi0, exp_ops_)
+    _check_jssesolve_args(H, Ls, psi0, _exp_ops)
     check_options(options, 'jssesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
-    tsave_ = tsave
+    _tsave = tsave
     if not isinstance(tsave, tuple):
-        tsave_ = jnp.asarray(tsave)
-        tsave_ = check_times(tsave_, 'tsave')
+        _tsave = jnp.asarray(tsave)
+        _tsave = check_times(_tsave, 'tsave')
         if isinstance(method, EulerJump):
-            tsave_ = tuple(tsave_.tolist())
+            _tsave = tuple(_tsave.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -299,7 +299,7 @@ def jssesolve(
         f = jax.jit(f, static_argnames=('tsave', 'gradient', 'options'))
     else:
         f = jax.jit(f, static_argnames=('gradient', 'options'))
-    return f(H, Ls, psi0, tsave_, keys, exp_ops_, method, gradient, options)
+    return f(H, Ls, psi0, _tsave, keys, _exp_ops, method, gradient, options)
 
 
 @catch_xla_runtime_error

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -259,8 +260,10 @@ def jssesolve(
     Ls = [astimeqarray(L) for L in jump_ops]
     psi0 = asqarray(psi0)
     keys = jnp.asarray(keys)
+
+    exp_ops_ = None
     if exp_ops is not None:
-        exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -272,18 +275,19 @@ def jssesolve(
     )
 
     # === check arguments
-    _check_jssesolve_args(H, Ls, psi0, exp_ops)
+    _check_jssesolve_args(H, Ls, psi0, exp_ops_)
     check_options(options, 'jssesolve')
     options = options.initialise()
 
     # todo: fix static tsave
     # this condition allows the user to pass a tuple for tsave to bypass this bit of
     # code (e.g., to JIT-compile this function)
+    tsave_ = tsave
     if not isinstance(tsave, tuple):
-        tsave = jnp.asarray(tsave)
-        tsave = check_times(tsave, 'tsave')
+        tsave_ = jnp.asarray(tsave)
+        tsave_ = check_times(tsave_, 'tsave')
         if isinstance(method, EulerJump):
-            tsave = tuple(tsave.tolist())
+            tsave_ = tuple(tsave_.tolist())
 
     if method is None:
         raise ValueError('Argument `method` must be specified.')
@@ -295,7 +299,7 @@ def jssesolve(
         f = jax.jit(f, static_argnames=('tsave', 'gradient', 'options'))
     else:
         f = jax.jit(f, static_argnames=('gradient', 'options'))
-    return f(H, Ls, psi0, tsave, keys, exp_ops, method, gradient, options)
+    return f(H, Ls, psi0, tsave_, keys, exp_ops_, method, gradient, options)
 
 
 @catch_xla_runtime_error
@@ -380,7 +384,7 @@ def _jssesolve_many_trajectories(
     else:
         # vectorize input over keys
         in_axes = (None, None, None, None, 0, None, None, None, None)
-        out_axes = JSSESolveResult(None, None, None, None, 0, 0, 0)
+        out_axes = JSSESolveResult(None, None, None, None, 0, 0, 0)  # ty: ignore
         f = jax.vmap(f, in_axes, out_axes)
 
     return f(H, Ls, psi0, tsave, keys, exp_ops, method, gradient, options)
@@ -403,7 +407,7 @@ def _jssesolve_single_trajectory(
         Event: jssesolve_event_integrator_constructor,
     }
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -423,10 +427,7 @@ def _jssesolve_single_trajectory(
     )
 
     # === run integrator
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(JSSESolveResult, integrator.run())
 
 
 def _check_jssesolve_args(

--- a/dynamiqs/integrators/apis/jssesolve.py
+++ b/dynamiqs/integrators/apis/jssesolve.py
@@ -43,7 +43,7 @@ def jssesolve(
     save_states: bool = True,
     cartesian_batching: bool = True,
     t0: ScalarLike | None = None,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
     nmaxclick: int = 10_000,
 ) -> JSSESolveResult:
     r"""Solve the jump stochastic Schrödinger equation (SSE).

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -16,7 +16,7 @@ from ...options import Options, check_options
 from ...progress_meter import AbstractProgressMeter
 from ...qarrays.dense_dataarray import DenseDataArray
 from ...qarrays.materialized_qarray import MaterializedQArray
-from ...qarrays.qarray import QArrayLike
+from ...qarrays.qarray import QArray, QArrayLike
 from ...result import MEPropagatorResult
 from ...time_qarray import TimeQArray
 from .._utils import (

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -47,7 +47,7 @@ def mepropagator(
     cartesian_batching: bool = True,
     progress_meter: AbstractProgressMeter | bool | None = None,
     t0: ScalarLike | None = None,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
 ) -> MEPropagatorResult:
     r"""Compute the propagator of the Lindblad master equation.
 

--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -280,7 +281,7 @@ def _mepropagator(
         Kvaerno5: mepropagator_kvaerno5_integrator_constructor,
     }
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -301,10 +302,7 @@ def _mepropagator(
     )
 
     # === run integrator
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(MEPropagatorResult, integrator.run())
 
 
 def _check_mepropagator_args(H: TimeQArray, Ls: list[TimeQArray]):

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -74,7 +74,7 @@ def mesolve(
     cartesian_batching: bool = True,
     progress_meter: AbstractProgressMeter | bool | None = None,
     t0: ScalarLike | None = None,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
     vectorized: bool = False,
     assume_hermitian: bool = True,
 ) -> MESolveResult:

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -270,9 +270,9 @@ def mesolve(
     rho0 = asqarray(rho0)
     tsave = jnp.asarray(tsave)
 
-    exp_ops_ = None
+    _exp_ops = None
     if exp_ops is not None:
-        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        _exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -286,7 +286,7 @@ def mesolve(
     )
 
     # === check arguments
-    _check_mesolve_args(H, Ls, rho0, exp_ops_)
+    _check_mesolve_args(H, Ls, rho0, _exp_ops)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'mesolve')
     options = options.initialise()
@@ -294,16 +294,16 @@ def mesolve(
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays
     f = _vectorized_mesolve
-    tsave_ = tsave
+    _tsave = tsave
     if isinstance(method, DiffusiveMonteCarlo) or (
         isinstance(method, JumpMonteCarlo) and isinstance(method.jsse_method, EulerJump)
     ):
-        tsave_ = tuple(tsave.tolist())  # todo: fix static tsave
+        _tsave = tuple(tsave.tolist())  # todo: fix static tsave
         f = jax.jit(f, static_argnames=('tsave', 'gradient', 'options'))
     else:
         f = jax.jit(f, static_argnames=('gradient', 'options'))
 
-    return f(H, Ls, rho0, tsave_, exp_ops_, method, gradient, options)
+    return f(H, Ls, rho0, _tsave, _exp_ops, method, gradient, options)
 
 
 @catch_xla_runtime_error

--- a/dynamiqs/integrators/apis/mesolve.py
+++ b/dynamiqs/integrators/apis/mesolve.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -268,8 +269,10 @@ def mesolve(
     Ls = [astimeqarray(L) for L in jump_ops]
     rho0 = asqarray(rho0)
     tsave = jnp.asarray(tsave)
+
+    exp_ops_ = None
     if exp_ops is not None:
-        exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -283,7 +286,7 @@ def mesolve(
     )
 
     # === check arguments
-    _check_mesolve_args(H, Ls, rho0, exp_ops)
+    _check_mesolve_args(H, Ls, rho0, exp_ops_)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'mesolve')
     options = options.initialise()
@@ -291,15 +294,16 @@ def mesolve(
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays
     f = _vectorized_mesolve
+    tsave_ = tsave
     if isinstance(method, DiffusiveMonteCarlo) or (
         isinstance(method, JumpMonteCarlo) and isinstance(method.jsse_method, EulerJump)
     ):
-        tsave = tuple(tsave.tolist())  # todo: fix static tsave
+        tsave_ = tuple(tsave.tolist())  # todo: fix static tsave
         f = jax.jit(f, static_argnames=('tsave', 'gradient', 'options'))
     else:
         f = jax.jit(f, static_argnames=('gradient', 'options'))
 
-    return f(H, Ls, rho0, tsave, exp_ops, method, gradient, options)
+    return f(H, Ls, rho0, tsave_, exp_ops_, method, gradient, options)
 
 
 @catch_xla_runtime_error
@@ -361,7 +365,7 @@ def _mesolve(
         LowRank: mesolve_lowrank_integrator_constructor,
     }
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -379,10 +383,7 @@ def _mesolve(
     )
 
     # === run integrator
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(MESolveResult, integrator.run())
 
 
 def _check_mesolve_args(

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -233,7 +234,7 @@ def _sepropagator(
         Kvaerno5: sepropagator_kvaerno5_integrator_constructor,
     }
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -251,10 +252,7 @@ def _sepropagator(
     )
 
     # === run integrator
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(SEPropagatorResult, integrator.run())
 
 
 def _check_sepropagator_args(H: TimeQArray):

--- a/dynamiqs/integrators/apis/sepropagator.py
+++ b/dynamiqs/integrators/apis/sepropagator.py
@@ -13,7 +13,7 @@ from ...method import Dopri5, Dopri8, Euler, Expm, Kvaerno3, Kvaerno5, Method, T
 from ...options import Options, check_options
 from ...progress_meter import AbstractProgressMeter
 from ...qarrays.layout import dense
-from ...qarrays.qarray import QArrayLike
+from ...qarrays.qarray import QArray, QArrayLike
 from ...result import SEPropagatorResult
 from ...time_qarray import TimeQArray
 from ...utils.operators import eye
@@ -44,7 +44,7 @@ def sepropagator(
     save_propagators: bool = True,
     progress_meter: AbstractProgressMeter | bool | None = None,
     t0: ScalarLike | None = None,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
 ) -> SEPropagatorResult:
     r"""Compute the propagator of the Schrödinger equation.
 

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -205,8 +206,10 @@ def sesolve(
     H = astimeqarray(H)
     psi0 = asqarray(psi0)
     tsave = jnp.asarray(tsave)
+
+    exp_ops_ = None
     if exp_ops is not None:
-        exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -218,14 +221,14 @@ def sesolve(
     )
 
     # === check arguments
-    _check_sesolve_args(H, psi0, exp_ops)
+    _check_sesolve_args(H, psi0, exp_ops_)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'sesolve')
     options = options.initialise()
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays
-    return _vectorized_sesolve(H, psi0, tsave, exp_ops, method, gradient, options)
+    return _vectorized_sesolve(H, psi0, tsave, exp_ops_, method, gradient, options)
 
 
 @catch_xla_runtime_error
@@ -279,7 +282,7 @@ def _sesolve(
         Expm: sesolve_expm_integrator_constructor,
     }
     assert_method_supported(method, integrator_constructors.keys())
-    integrator_constructor = integrator_constructors[type(method)]
+    integrator_constructor = integrator_constructors[type(method)]  # ty: ignore
 
     # === check gradient is supported
     method.assert_supports_gradient(gradient)
@@ -297,10 +300,7 @@ def _sesolve(
     )
 
     # === run integrator
-    result = integrator.run()
-
-    # === return result
-    return result  # noqa: RET504
+    return cast(SESolveResult, integrator.run())
 
 
 def _check_sesolve_args(H: TimeQArray, psi0: QArray, exp_ops: list[QArray] | None):

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -47,7 +47,7 @@ def sesolve(
     cartesian_batching: bool = True,
     progress_meter: AbstractProgressMeter | bool | None = None,
     t0: ScalarLike | None = None,
-    save_extra: Callable[[Array], PyTree] | None = None,
+    save_extra: Callable[[QArray], PyTree] | None = None,
 ) -> SESolveResult:
     r"""Solve the Schrödinger equation.
 

--- a/dynamiqs/integrators/apis/sesolve.py
+++ b/dynamiqs/integrators/apis/sesolve.py
@@ -207,9 +207,9 @@ def sesolve(
     psi0 = asqarray(psi0)
     tsave = jnp.asarray(tsave)
 
-    exp_ops_ = None
+    _exp_ops = None
     if exp_ops is not None:
-        exp_ops_ = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
+        _exp_ops = [asqarray(E) for E in exp_ops] if len(exp_ops) > 0 else None
 
     # === build options
     options = Options(
@@ -221,14 +221,14 @@ def sesolve(
     )
 
     # === check arguments
-    _check_sesolve_args(H, psi0, exp_ops_)
+    _check_sesolve_args(H, psi0, _exp_ops)
     tsave = check_times(tsave, 'tsave')
     check_options(options, 'sesolve')
     options = options.initialise()
 
     # we implement the jitted vectorization in another function to pre-convert QuTiP
     # objects (which are not JIT-compatible) to qarrays
-    return _vectorized_sesolve(H, psi0, tsave, exp_ops_, method, gradient, options)
+    return _vectorized_sesolve(H, psi0, tsave, _exp_ops, method, gradient, options)
 
 
 @catch_xla_runtime_error

--- a/dynamiqs/integrators/core/abstract_integrator.py
+++ b/dynamiqs/integrators/core/abstract_integrator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import Generic, TypeVar
+from typing import Generic
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -10,14 +10,9 @@ from jaxtyping import PRNGKeyArray, PyTree, Scalar
 
 from ...gradient import Gradient
 from ...method import Method
-from ...result import Result, Saved, SolveSaved, StochasticSolveResult
+from ...result import Result, SolveSaved, StochasticSolveResult
 from .interfaces import OptionsInterface
-
-# _SavedT lets BaseIntegrator subclasses specify which concrete Saved type they work
-# with (e.g. SolveSaved, PropagatorSaved). Making BaseIntegrator generic over
-# _SavedT, methods like `result()` and `postprocess_saved()` gets per-subclass
-# type signatures instead of accepting/returning the broad Saved base class.
-_SavedT = TypeVar('_SavedT', bound=Saved)
+from .save_mixin import SavedT
 
 
 class AbstractIntegrator(eqx.Module):
@@ -33,7 +28,7 @@ class AbstractIntegrator(eqx.Module):
         pass
 
 
-class BaseIntegrator(AbstractIntegrator, OptionsInterface, Generic[_SavedT]):
+class BaseIntegrator(AbstractIntegrator, OptionsInterface, Generic[SavedT]):
     """Integrator evolving an initial state over a set of times.
 
     This integrator evolves the initial pytree `y0` over a set of times specified by
@@ -55,7 +50,7 @@ class BaseIntegrator(AbstractIntegrator, OptionsInterface, Generic[_SavedT]):
     def t1(self) -> Scalar:
         return self.ts[-1]
 
-    def result(self, saved: _SavedT, infos: PyTree | None = None) -> Result:
+    def result(self, saved: SavedT, infos: PyTree | None = None) -> Result:
         return self.result_class(
             self.ts, self.method, self.gradient, self.options, saved, infos
         )

--- a/dynamiqs/integrators/core/abstract_integrator.py
+++ b/dynamiqs/integrators/core/abstract_integrator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from typing import Generic, TypeVar
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -9,8 +10,10 @@ from jaxtyping import PRNGKeyArray, PyTree, Scalar
 
 from ...gradient import Gradient
 from ...method import Method
-from ...result import Result, Saved
+from ...result import Result, Saved, SolveSaved, StochasticSolveResult
 from .interfaces import OptionsInterface
+
+_SavedT = TypeVar('_SavedT', bound=Saved)
 
 
 class AbstractIntegrator(eqx.Module):
@@ -26,7 +29,7 @@ class AbstractIntegrator(eqx.Module):
         pass
 
 
-class BaseIntegrator(AbstractIntegrator, OptionsInterface):
+class BaseIntegrator(AbstractIntegrator, OptionsInterface, Generic[_SavedT]):
     """Integrator evolving an initial state over a set of times.
 
     This integrator evolves the initial pytree `y0` over a set of times specified by
@@ -42,19 +45,19 @@ class BaseIntegrator(AbstractIntegrator, OptionsInterface):
 
     @property
     def t0(self) -> Scalar:
-        return self.ts[0] if self.options.t0 is None else self.options.t0
+        return self.ts[0] if self.options.t0 is None else jnp.asarray(self.options.t0)
 
     @property
     def t1(self) -> Scalar:
         return self.ts[-1]
 
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
+    def result(self, saved: _SavedT, infos: PyTree | None = None) -> Result:
         return self.result_class(
             self.ts, self.method, self.gradient, self.options, saved, infos
         )
 
 
-class StochasticBaseIntegrator(BaseIntegrator):
+class StochasticBaseIntegrator(BaseIntegrator[SolveSaved]):
     """Integrator stochastically evolving an initial state over a set of times.
 
     In addition to `BaseIntegrator`, it includes a PRNG key for the stochastic
@@ -62,8 +65,9 @@ class StochasticBaseIntegrator(BaseIntegrator):
     """
 
     key: PRNGKeyArray
+    result_class: type[StochasticSolveResult]
 
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
+    def result(self, saved: SolveSaved, infos: PyTree | None = None) -> Result:
         ts = jnp.asarray(self.ts)  # todo: fix static tsave
         return self.result_class(
             ts, self.method, self.gradient, self.options, saved, infos, self.key

--- a/dynamiqs/integrators/core/abstract_integrator.py
+++ b/dynamiqs/integrators/core/abstract_integrator.py
@@ -13,6 +13,10 @@ from ...method import Method
 from ...result import Result, Saved, SolveSaved, StochasticSolveResult
 from .interfaces import OptionsInterface
 
+# _SavedT lets BaseIntegrator subclasses specify which concrete Saved type they work
+# with (e.g. SolveSaved, PropagatorSaved). Making BaseIntegrator generic over
+# _SavedT, methods like `result()` and `postprocess_saved()` gets per-subclass
+# type signatures instead of accepting/returning the broad Saved base class.
 _SavedT = TypeVar('_SavedT', bound=Saved)
 
 

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -27,7 +27,7 @@ from ...method import (
 )
 from ...options import Options
 from ...progress_meter import AbstractProgressMeter
-from ...result import MESolveResult, Result, Saved, SolveSaved
+from ...result import MESolveResult, Result, SolveSaved
 from ...utils.vectorization import slindbladian, unvectorize, vectorize
 from .abstract_integrator import BaseIntegrator
 from .interfaces import AbstractTimeInterface, MEInterface, SEInterface, SolveInterface
@@ -200,7 +200,7 @@ def call_diffeqsolve(
     dtmax: float | None = None,
 ) -> dx.Solution:
     # === define custom diffrax integrator
-    class BasicDiffraxIntegrator(DiffraxIntegrator, SolveSaveMixin):
+    class BasicDiffraxIntegrator(DiffraxIntegrator):
         @property
         def terms(self) -> dx.AbstractTerm:
             return terms
@@ -208,6 +208,12 @@ def call_diffeqsolve(
         @property
         def discontinuity_ts(self) -> Array:
             return discontinuity_ts
+
+        def save(self, y: PyTree) -> PyTree:
+            pass
+
+        def postprocess_saved(self, saved: PyTree, ylast: PyTree) -> PyTree:
+            pass
 
     # === set Diffrax solver
     solvers: dict[type[Method], tuple[dx.AbstractSolver, bool]] = {

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -27,7 +27,7 @@ from ...method import (
 )
 from ...options import Options
 from ...progress_meter import AbstractProgressMeter
-from ...result import MESolveResult, Result, Saved
+from ...result import MESolveResult, Result, Saved, SolveSaved
 from ...utils.vectorization import slindbladian, unvectorize, vectorize
 from .abstract_integrator import BaseIntegrator
 from .interfaces import AbstractTimeInterface, MEInterface, SEInterface, SolveInterface
@@ -369,7 +369,7 @@ class MESolveDiffraxIntegrator(
         if self.options.vectorized:
             self.y0 = vectorize(self.y0)  # (n^2, 1)
 
-    def save(self, y: PyTree) -> Saved:
+    def save(self, y: PyTree) -> SolveSaved:
         # TODO: implement bexpect for vectorized operators and convert at the end
         # instead of at each step
         if self.options.vectorized:

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import warnings
 from abc import abstractmethod
+from collections.abc import Callable
 from functools import partial
+from typing import cast
 
 import diffrax as dx
 import equinox as eqx
@@ -12,8 +14,19 @@ from jaxtyping import PyTree, Scalar
 from ..._checks import check_hermitian
 from ..._utils import obj_type_str
 from ...gradient import BackwardCheckpointed, Direct, Forward, Gradient
-from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Method, Tsit5
+from ...method import (
+    Dopri5,
+    Dopri8,
+    Euler,
+    Kvaerno3,
+    Kvaerno5,
+    Method,
+    Tsit5,
+    _DEAdaptiveStep,
+    _DEFixedStep,
+)
 from ...options import Options
+from ...progress_meter import AbstractProgressMeter
 from ...result import MESolveResult, Result, Saved
 from ...utils.vectorization import slindbladian, unvectorize, vectorize
 from .abstract_integrator import BaseIntegrator
@@ -60,24 +73,30 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
         if self.fixed_step:
             return dx.ConstantStepSize()
         else:
-            jump_ts = None if len(self.discontinuity_ts) == 0 else self.discontinuity_ts
+            method = cast(_DEAdaptiveStep, self.method)
             return dx.PIDController(
-                rtol=self.method.rtol,
-                atol=self.method.atol,
-                safety=self.method.safety_factor,
-                factormin=self.method.min_factor,
-                factormax=self.method.max_factor,
-                jump_ts=jump_ts,
+                rtol=method.rtol,
+                atol=method.atol,
+                safety=method.safety_factor,
+                factormin=method.min_factor,
+                factormax=method.max_factor,
             )
 
     @property
     def dt0(self) -> float | None:
-        return self.method.dt if self.fixed_step else None
+        if self.fixed_step:
+            method = cast(_DEFixedStep, self.method)
+            return method.dt
+        return None
 
     @property
     def max_steps(self) -> int:
-        # TODO: fix hard-coded max_steps for fixed methods
-        return 100_000 if self.fixed_step else self.method.max_steps
+        if self.fixed_step:
+            # TODO: fix hard-coded max_steps for fixed methods
+            return 100_000
+        else:
+            assert isinstance(self.method, _DEAdaptiveStep)
+            return self.method.max_steps
 
     @property
     @abstractmethod
@@ -137,7 +156,9 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
                 adjoint=self.adjoint,
                 event=event,
                 max_steps=self.max_steps,
-                progress_meter=self.options.progress_meter.to_diffrax(),
+                progress_meter=cast(
+                    AbstractProgressMeter, self.options.progress_meter
+                ).to_diffrax(),
             )
 
     def run(self) -> Result:
@@ -151,7 +172,8 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
         solution = self.diffeqsolve(self.t0, self.t1, self.y0, saveat)
 
         # === collect and return results
-        saved = self.postprocess_saved(*solution.ys)
+        ys = cast(tuple, solution.ys)
+        saved = self.postprocess_saved(*ys)
         return self.result(saved, infos=self.infos(solution.stats))
 
     def infos(self, stats: dict[str, Array]) -> PyTree:
@@ -170,15 +192,15 @@ def call_diffeqsolve(
     y0: PyTree,
     terms: dx.AbstractTerm,
     method: Method,
-    gradient: Gradient,
+    gradient: Gradient | None,
     options: Options,
     discontinuity_ts: Array,
     event: dx.Event | None = None,
-    save: callable | None = None,
+    save: Callable | None = None,
     dtmax: float | None = None,
 ) -> dx.Solution:
     # === define custom diffrax integrator
-    class BasicDiffraxIntegrator(DiffraxIntegrator):
+    class BasicDiffraxIntegrator(DiffraxIntegrator, SolveSaveMixin):
         @property
         def terms(self) -> dx.AbstractTerm:
             return terms
@@ -187,21 +209,16 @@ def call_diffeqsolve(
         def discontinuity_ts(self) -> Array:
             return discontinuity_ts
 
-        def save(self, y: PyTree) -> Saved:
-            pass
-
-        def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
-            pass
-
     # === set Diffrax solver
-    diffrax_solver, fixed_step = {
+    solvers: dict[type[Method], tuple[dx.AbstractSolver, bool]] = {
         Euler: (dx.Euler(), True),
         Dopri5: (dx.Dopri5(), False),
         Dopri8: (dx.Dopri8(), False),
         Tsit5: (dx.Tsit5(), False),
         Kvaerno3: (dx.Kvaerno3(), False),
         Kvaerno5: (dx.Kvaerno5(), False),
-    }[type(method)]
+    }
+    diffrax_solver, fixed_step = solvers[type(method)]
 
     # === init integrator
     integrator = BasicDiffraxIntegrator(
@@ -209,7 +226,7 @@ def call_diffeqsolve(
         y0=y0,
         method=method,
         gradient=gradient,
-        result_class=None,
+        result_class=Result,
         options=options,
         diffrax_solver=diffrax_solver,
         fixed_step=fixed_step,

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -72,8 +72,10 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
     def stepsize_controller(self) -> dx.AbstractStepSizeController:
         if self.fixed_step:
             return dx.ConstantStepSize()
+
         else:
             method = cast(_DEAdaptiveStep, self.method)
+
             return dx.PIDController(
                 rtol=method.rtol,
                 atol=method.atol,
@@ -95,8 +97,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             # TODO: fix hard-coded max_steps for fixed methods
             return 100_000
         else:
-            assert isinstance(self.method, _DEAdaptiveStep)
-            return self.method.max_steps
+            return cast(_DEAdaptiveStep, self.method).max_steps
 
     @property
     @abstractmethod

--- a/dynamiqs/integrators/core/event_integrator.py
+++ b/dynamiqs/integrators/core/event_integrator.py
@@ -70,7 +70,7 @@ class JSSESolveEventIntegrator(
             # sample a no-click trajectory and compute its probability
             solution = self._solve_noclick(self.ts, self.y0)
 
-            assert solution.ys is not None  # Only for the typechecker
+            assert solution.ys is not None
             psis = solution.ys[0]
             noclick_psis = psis.unit()
             noclick_prob = psis[-1].norm() ** 2
@@ -124,14 +124,14 @@ class JSSESolveEventIntegrator(
         solution = self._solve_noclick(ts, y.psi, event=event, save=self.save)
 
         # === collect solve result
-        assert solution.ys is not None  # Only for the typechecker
-        assert solution.ts is not None  # Only for the typechecker
+        assert solution.ys is not None
+        assert solution.ts is not None
         new_saved = solution.ys[0]
         psiclick, tclick = solution.ys[1][0], solution.ts[1][0]
 
         y = replace(y, psi=psiclick, t=tclick)
         click_occurred = solution.event_mask
-        assert click_occurred is not None  # Only for the typechecker
+        assert click_occurred is not None
 
         # === save intermediate states, expectation values and extras
         save_cond = lambda y: (

--- a/dynamiqs/integrators/core/event_integrator.py
+++ b/dynamiqs/integrators/core/event_integrator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import replace
-from typing import cast
 
 import diffrax as dx
 import equinox as eqx
@@ -114,7 +113,7 @@ class JSSESolveEventIntegrator(
             dtmax=self.method.dtmax,
         )
 
-    def save(self, y: PyTree) -> Saved:
+    def save(self, y: PyTree) -> SolveSaved:
         return super().save(y.unit())
 
     def _solve_until_click(self, y: JumpState, rand: Array) -> tuple[JumpState, bool]:
@@ -199,7 +198,6 @@ class JSSESolveEventIntegrator(
         indices = jnp.zeros(len(self.Ls), dtype=int)
         y = stack([self.y0] * len(self.ts))
         saved = self.reorder_Esave(self.save(y))
-        saved = cast(SolveSaved, saved)
         y0 = JumpState(self.y0, self.t0, key, clicktimes, indices, saved, 0)
 
         # === loop over no-click evolutions until the final time is reached
@@ -215,7 +213,6 @@ class JSSESolveEventIntegrator(
 
         # === return result
         saved = self.postprocess_saved(yend.saved, yend.psi[None, ...])
-        saved = cast(SolveSaved, saved)
         return JumpSolveSaved(saved.ysave, saved.extra, saved.Esave, yend.clicktimes)
 
 

--- a/dynamiqs/integrators/core/event_integrator.py
+++ b/dynamiqs/integrators/core/event_integrator.py
@@ -1,19 +1,23 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import replace
+from typing import cast
 
 import diffrax as dx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+from diffrax._custom_types import RealScalarLike
 from equinox.internal import while_loop
 from jax import Array
 from jaxtyping import PRNGKeyArray, PyTree
 
+from ...method import Event
 from ...options import Options
 from ...qarrays.qarray import QArray
 from ...qarrays.utils import stack
-from ...result import JSSESolveResult, JumpSolveSaved, Result, Saved, SolveSaved
+from ...result import JumpSolveSaved, Result, Saved, SolveSaved
 from ...utils.general import expect
 from .abstract_integrator import StochasticBaseIntegrator
 from .diffrax_integrator import call_diffeqsolve
@@ -35,14 +39,14 @@ class JumpState(eqx.Module):
     """State for the jump SSE event integrator."""
 
     psi: QArray  # state (integrated from initial to current time)
-    t: float  # current time
+    t: RealScalarLike  # current time
     key: PRNGKeyArray  # active key
     clicktimes: Array  # click times of shape (nLs, nmaxclick)
     indices: Array  # last click time indices of shape (nLs,)
     saved: SolveSaved  # saved states, expectation values and extras
     save_index: int
 
-    def new_click(self, idx: int, t: float) -> tuple[Array, Array]:
+    def new_click(self, idx: Array, t: RealScalarLike) -> tuple[Array, Array]:
         clicktimes = self.clicktimes.at[idx, self.indices[idx]].set(t)
         indices = self.indices.at[idx].add(1)
         return clicktimes, indices
@@ -60,10 +64,14 @@ class JSSESolveEventIntegrator(
 ):
     """Integrator computing the time evolution of the Jump SSE using Diffrax events."""
 
+    method: Event
+
     def run(self) -> Result:
         if self.method.smart_sampling:
             # sample a no-click trajectory and compute its probability
             solution = self._solve_noclick(self.ts, self.y0)
+
+            assert solution.ys is not None  # Only for the typechecker
             psis = solution.ys[0]
             noclick_psis = psis.unit()
             noclick_prob = psis[-1].norm() ** 2
@@ -74,7 +82,7 @@ class JSSESolveEventIntegrator(
             infos = None
 
         # vectorize over keys
-        out_axes = JumpSolveSaved(0, 0, 0, 0)
+        out_axes = JumpSolveSaved(0, 0, 0, 0)  # ty: ignore[invalid-argument-type]
         f = lambda key: self._solve_single_trajectory(key, noclick_prob)
         saved = jax.vmap(f, 0, out_axes)(self.key)
         return self.result(saved, infos)
@@ -82,9 +90,9 @@ class JSSESolveEventIntegrator(
     def _solve_noclick(
         self,
         ts: Array,
-        psi0: Array,
+        psi0: QArray,
         event: dx.Event | None = None,
-        save: callable | None = None,
+        save: Callable | None = None,
     ) -> dx.Solution:
         terms = dx.ODETerm(
             lambda t, y, _: (
@@ -109,9 +117,7 @@ class JSSESolveEventIntegrator(
     def save(self, y: PyTree) -> Saved:
         return super().save(y.unit())
 
-    def _solve_until_click(
-        self, y: JumpState, rand: float
-    ) -> tuple[JumpState, SolveSaved, bool]:
+    def _solve_until_click(self, y: JumpState, rand: Array) -> tuple[JumpState, bool]:
         # === solve until the next click event
         cond_fn = lambda t, y, *a, **kw: y.norm() ** 2 - rand  # noqa: ARG005
         event = dx.Event(cond_fn, self.method.root_finder)
@@ -119,10 +125,14 @@ class JSSESolveEventIntegrator(
         solution = self._solve_noclick(ts, y.psi, event=event, save=self.save)
 
         # === collect solve result
+        assert solution.ys is not None  # Only for the typechecker
+        assert solution.ts is not None  # Only for the typechecker
         new_saved = solution.ys[0]
         psiclick, tclick = solution.ys[1][0], solution.ts[1][0]
+
         y = replace(y, psi=psiclick, t=tclick)
         click_occurred = solution.event_mask
+        assert click_occurred is not None  # Only for the typechecker
 
         # === save intermediate states, expectation values and extras
         save_cond = lambda y: (
@@ -142,7 +152,7 @@ class JSSESolveEventIntegrator(
 
     def _solve_single_trajectory(
         self, key: PRNGKeyArray, noclick_prob: float | None
-    ) -> JSSESolveResult:
+    ) -> JumpSolveSaved:
         def loop_body(y: JumpState) -> JumpState:
             # === pick a random number for the next click event
             newkey, key_click, key_jump_choice = jax.random.split(y.key, 3)
@@ -189,6 +199,7 @@ class JSSESolveEventIntegrator(
         indices = jnp.zeros(len(self.Ls), dtype=int)
         y = stack([self.y0] * len(self.ts))
         saved = self.reorder_Esave(self.save(y))
+        saved = cast(SolveSaved, saved)
         y0 = JumpState(self.y0, self.t0, key, clicktimes, indices, saved, 0)
 
         # === loop over no-click evolutions until the final time is reached
@@ -204,6 +215,7 @@ class JSSESolveEventIntegrator(
 
         # === return result
         saved = self.postprocess_saved(yend.saved, yend.psi[None, ...])
+        saved = cast(SolveSaved, saved)
         return JumpSolveSaved(saved.ysave, saved.extra, saved.Esave, yend.clicktimes)
 
 

--- a/dynamiqs/integrators/core/event_integrator.py
+++ b/dynamiqs/integrators/core/event_integrator.py
@@ -16,7 +16,7 @@ from ...method import Event
 from ...options import Options
 from ...qarrays.qarray import QArray
 from ...qarrays.utils import stack
-from ...result import JumpSolveSaved, Result, Saved, SolveSaved
+from ...result import JumpSolveSaved, Result, SolveSaved
 from ...utils.general import expect
 from .abstract_integrator import StochasticBaseIntegrator
 from .diffrax_integrator import call_diffeqsolve

--- a/dynamiqs/integrators/core/expm_integrator.py
+++ b/dynamiqs/integrators/core/expm_integrator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from functools import partial
-from typing import cast
 
 import equinox as eqx
 import jax
@@ -78,7 +77,6 @@ class ExpmIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface):
         def step(carry: QArray, x: QArray) -> tuple[QArray, Saved]:
             # note the ordering x @ carry: we accumulate propagators from the left
             x_next = x @ carry
-            x_next = cast(QArray, x_next)
             return x_next, self.save(x_next)
 
         ylast, saved = jax.lax.scan(step, self.y0, step_propagators)

--- a/dynamiqs/integrators/core/expm_integrator.py
+++ b/dynamiqs/integrators/core/expm_integrator.py
@@ -14,7 +14,7 @@ from dynamiqs._utils import concatenate_sort
 
 from ..._checks import check_hermitian
 from ...qarrays.qarray import QArray
-from ...result import MESolveResult, Result, Saved
+from ...result import MESolveResult, Result, Saved, SolveSaved
 from ...utils.general import expm
 from ...utils.vectorization import slindbladian, unvectorize, vectorize
 from .._utils import ispwc
@@ -165,7 +165,7 @@ class MESolveExpmIntegrator(MEExpmIntegrator, SolveSaveMixin, SolveInterface):
         # convert to vectorized form
         self.y0 = vectorize(self.y0)  # (n^2, 1)
 
-    def save(self, y: PyTree) -> Saved:
+    def save(self, y: PyTree) -> SolveSaved:
         # TODO: implement bexpect for vectorized operators and convert at the end
         # instead of at each step
         y = unvectorize(y)

--- a/dynamiqs/integrators/core/expm_integrator.py
+++ b/dynamiqs/integrators/core/expm_integrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from functools import partial
+from typing import cast
 
 import equinox as eqx
 import jax
@@ -74,9 +75,10 @@ class ExpmIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface):
         step_propagators = expm(delta_ts[:, None, None] * As)  # (ntimes-1, N, N)
 
         # === combine the propagators together
-        def step(carry: QArray, x: QArray) -> tuple[QArray, QArray]:
+        def step(carry: QArray, x: QArray) -> tuple[QArray, Saved]:
             # note the ordering x @ carry: we accumulate propagators from the left
             x_next = x @ carry
+            x_next = cast(QArray, x_next)
             return x_next, self.save(x_next)
 
         ylast, saved = jax.lax.scan(step, self.y0, step_propagators)

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -102,6 +102,8 @@ class StochasticSolveFixedStepIntegrator(
     @property
     def total_nsteps(self) -> int:
         # total number of steps of length dt
+        # Currently ty is not able to infer round returns an int
+        # TODO: Remove the ignore flag when fixed in ty
         return round((self.t1 - self.t0) / self.dt)  # ty: ignore
 
     @abstractmethod

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -197,6 +197,9 @@ class StochasticSolveFixedStepIntegrator(
         saved = jax.tree.map(lambda x, y: jnp.insert(x, 0, y, axis=0), saved, saved0)
 
         # postprocess the saved results
+        saved = self.postprocess_saved(saved, ylast)
+
+        # postprocess the saved results
         return self.result(saved, infos=self.Infos(jnp.asarray(self.total_nsteps)))
 
 

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -2,21 +2,25 @@ from __future__ import annotations
 
 import warnings
 from abc import abstractmethod
+from typing import cast
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+from diffrax._custom_types import RealScalarLike
 from jax import Array
 from jaxtyping import ArrayLike, PRNGKeyArray, PyTree, Scalar
 
+from ...method import _DEFixedStep, Rouchon1
 from ...qarrays.qarray import QArray
 from ...qarrays.utils import stack
-from ...result import DiffusiveSolveSaved, JumpSolveSaved, Result, Saved
-from ...utils.general import expect
+from ...result import DiffusiveSolveSaved, JumpSolveSaved, Result, Saved, SolveSaved
+from ...utils.general import dag, expect
 from ...utils.operators import eye_like
 from .abstract_integrator import StochasticBaseIntegrator
 from .interfaces import (
+    AbstractTimeInterface,
     DSMEInterface,
     DSSEInterface,
     JSMEInterface,
@@ -43,10 +47,11 @@ def _is_linearly_spaced(
 
 class SDEState(eqx.Module):
     """State for the jump/diffusive SSE/SME fixed step integrators."""
+    state: QArray
 
 
 class StochasticSolveFixedStepIntegrator(
-    StochasticBaseIntegrator, SolveInterface, SolveSaveMixin
+    StochasticBaseIntegrator, SolveInterface, SolveSaveMixin, AbstractTimeInterface
 ):
     """Integrator solving the jump/diffusive SSE/SME with a fixed step size
     integrator.
@@ -90,19 +95,20 @@ class StochasticSolveFixedStepIntegrator(
 
     @property
     def dt(self) -> float:
-        return self.method.dt
+        method = cast(_DEFixedStep, self.method)
+        return method.dt
 
     @property
     def total_nsteps(self) -> int:
         # total number of steps of length dt
-        return round((self.t1 - self.t0) / self.dt)
+        return int(round((self.t1 - self.t0) / self.dt))
 
     @abstractmethod
     def sample_rv(self, key: PRNGKeyArray, nsteps: int) -> PyTree:
         pass
 
     @abstractmethod
-    def forward(self, t: Scalar, y: SDEState, dX: Array) -> SDEState:
+    def forward(self, t: RealScalarLike, y: SDEState, dX: Array) -> SDEState:
         # return SDE state y_{t+dt} from a random variable sample dX and the current
         # state y_t
         pass
@@ -188,10 +194,9 @@ class StochasticSolveFixedStepIntegrator(
         # === collect and format results
         # insert the initial saved result
         saved = jax.tree.map(lambda x, y: jnp.insert(x, 0, y, axis=0), saved, saved0)
-        # postprocess the saved results
-        saved = self.postprocess_saved(saved, ylast)
 
-        return self.result(saved, infos=self.Infos(self.total_nsteps))
+        # postprocess the saved results
+        return self.result(saved, infos=self.Infos(jnp.asarray(self.total_nsteps)))
 
 
 class JumpState(SDEState):
@@ -222,10 +227,10 @@ class JumpSolveFixedStepIntegrator(StochasticSolveFixedStepIntegrator):
         # the jump operator when a click occurs.
         return jax.random.uniform(key, (nsteps, 2))
 
-    def save(self, y: PyTree) -> Saved:
+    def save(self, y: PyTree) -> SolveSaved:
         return super().save(y.state)
 
-    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+    def postprocess_saved(self, saved: SolveSaved, ylast: PyTree) -> JumpSolveSaved:
         saved = super().postprocess_saved(saved, ylast.state[None, :])
 
         # convert array of click indicators at each step to array of clicktimes, for
@@ -255,7 +260,7 @@ def _safe_divide(x: ArrayLike, y: ArrayLike) -> ArrayLike:
 
 
 class JSSESolveEulerJumpIntegrator(JSSESolveFixedStepIntegrator):
-    def forward(self, t: Scalar, y: SDEState, dX: Array) -> SDEState:
+    def forward(self, t: RealScalarLike, y: SDEState, dX: Array) -> SDEState:
         psi = y.state
         L, H = self.L(t), self.H(t)
         L = stack(L)  # todo: remove stack
@@ -294,6 +299,7 @@ class JSSESolveEulerJumpIntegrator(JSSESolveFixedStepIntegrator):
 
         # === update click record
         # 0 for no click, i + 1 for click of the i-th jump operator
+        y = cast(JumpState, y)
         clicks = y.clicks.at[y.step_idx].set(dN * (jump_idx + 1))
 
         return JumpState(psi, clicks, y.step_idx + 1)
@@ -309,7 +315,7 @@ class JSMESolveFixedStepIntegrator(JumpSolveFixedStepIntegrator, JSMEInterface):
 
 
 class JSMESolveEulerJumpIntegrator(JSMESolveFixedStepIntegrator):
-    def forward(self, t: Scalar, y: SDEState, dX: Array) -> SDEState:
+    def forward(self, t: RealScalarLike, y: SDEState, dX: Array) -> SDEState:
         # The jump SME for a single detector is:
         #   drho = Lcal(rho) dt
         #        + (Ccal(rho) / Tr[Ccal(rho)] - rho) (dN - Tr[Ccal(rho)] dt)
@@ -355,7 +361,7 @@ class JSMESolveEulerJumpIntegrator(JSMESolveFixedStepIntegrator):
         # `integrators/core/diffrax_integrator.py`
         Hnh = -1j * H - 0.5 * sum(L.dag() @ L)
         tmp = Hnh @ rho + 0.5 * sum(Lm_rho_Lmdag)
-        Lcal_rho = tmp + tmp.dag()
+        Lcal_rho = tmp + dag(tmp)
         rho_noclick = (
             rho
             + Lcal_rho * self.dt
@@ -367,6 +373,7 @@ class JSMESolveEulerJumpIntegrator(JSMESolveFixedStepIntegrator):
 
         # === update click record
         # 0 for no click, i + 1 for click of the i-th jump operator
+        y = cast(JumpState, y)
         clicks = y.clicks.at[y.step_idx].set(dN * (jump_idx + 1))
 
         return JumpState(rho, clicks, y.step_idx + 1)
@@ -397,12 +404,15 @@ class DiffusiveSolveFixedStepIntegrator(StochasticSolveFixedStepIntegrator):
     def sample_rv(self, key: PRNGKeyArray, nsteps: int) -> PyTree:
         return jnp.sqrt(self.dt) * jax.random.normal(key, (nsteps, self.nmeas))
 
-    def save(self, y: PyTree) -> Saved:
+    def save(self, y: PyTree) -> DiffusiveSolveSaved:
         saved = super().save(y.state)
         return DiffusiveSolveSaved(saved.ysave, saved.extra, saved.Esave, y.Y)
 
-    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
-        saved = super().postprocess_saved(saved, ylast.state[None, :])
+    def postprocess_saved(self, saved: SolveSaved, ylast: PyTree) -> DiffusiveSolveSaved:
+        saved = cast(
+            DiffusiveSolveSaved, 
+            super().postprocess_saved(saved, ylast.state[None, :])
+        )
 
         # The averaged measurement I^{(ta, tb)} is recovered by diffing the measurement
         # I which is integrated between ts[0] and ts[-1]
@@ -423,7 +433,7 @@ class DSSEFixedStepIntegrator(DiffusiveSolveFixedStepIntegrator, DSSEInterface):
 class DSSESolveEulerMayuramaIntegrator(DSSEFixedStepIntegrator):
     """Integrator solving the diffusive SSE with the Euler-Mayurama method."""
 
-    def forward(self, t: Scalar, y: SDEState, dX: Array) -> SDEState:
+    def forward(self, t: RealScalarLike, y: SDEState, dX: Array) -> SDEState:
         psi = y.state
         dW = dX
         L, H = self.L(t), self.H(t)
@@ -458,6 +468,7 @@ class DSSESolveEulerMayuramaIntegrator(DSSEFixedStepIntegrator):
             )
         )
 
+        y = cast(DiffusiveState, y)
         return DiffusiveState(psi + dpsi, y.Y + dY)
 
 
@@ -468,21 +479,22 @@ def cholesky_normalize_ket(S: QArray, psi: QArray) -> jax.Array:
 
     T = jnp.linalg.cholesky(S.to_jax())  # T lower triangular
 
-    psi = psi.to_jax()[:, 0]  # (n, 1) -> (n,)
+    _psi = psi.to_jax()[:, 0]  # (n, 1) -> (n,)
     # solve T^† @ x = psi => x = T^{†(-1)} @ psi
     return jax.lax.linalg.triangular_solve(
-        T, psi, lower=True, transpose_a=True, conjugate_a=True, left_side=True
+        T, _psi, lower=True, transpose_a=True, conjugate_a=True, left_side=True
     )[:, None]  # (n,) -> (n, 1)
 
 
 class DSSESolveRouchon1Integrator(RouchonPropertiesMixin, DSSEFixedStepIntegrator):
     """Integrator solving the diffusive SSE with the Rouchon1 method."""
+    method: Rouchon1
 
     @property
     def identity(self) -> QArray:
         return eye_like(self.H(0))
 
-    def forward(self, t: Scalar, y: SDEState, dX: Array) -> SDEState:
+    def forward(self, t: RealScalarLike, y: SDEState, dX: Array) -> SDEState:
         psi = y.state
         dW = dX
         L, H = self.L(t + self.dt / 2), self.H(t + self.dt / 2)
@@ -504,6 +516,8 @@ class DSSESolveRouchon1Integrator(RouchonPropertiesMixin, DSSEFixedStepIntegrato
             )
             M_dY = M0 + sum([_dY * _L for _dY, _L in zip(dY, L, strict=True)])
             S = M0.dag() @ M0 + sum([_L.dag() @ _L for _L in L]) * self.dt
+            S = cast(QArray, S)
+
             psi = cholesky_normalize_ket(S, psi)
             psi = (M_dY @ psi).unit()
 
@@ -527,6 +541,7 @@ class DSSESolveRouchon1Integrator(RouchonPropertiesMixin, DSSEFixedStepIntegrato
             )
             psi = psi.unit()  # normalise by norm
 
+        y = cast(DiffusiveState, y)
         return DiffusiveState(psi, y.Y + dY)
 
 
@@ -543,7 +558,7 @@ class DSMEFixedStepIntegrator(DiffusiveSolveFixedStepIntegrator, DSMEInterface):
 class DSMESolveEulerMayuramaIntegrator(DSMEFixedStepIntegrator):
     """Integrator solving the diffusive SME with the Euler-Mayurama method."""
 
-    def forward(self, t: Scalar, y: SDEState, dX: Array) -> SDEState:
+    def forward(self, t: RealScalarLike, y: SDEState, dX: Array) -> SDEState:
         # The diffusive SME for a single detector is:
         #   drho = Lcal(rho)     dt + (Ccal(rho) - Tr[Ccal(rho)] rho) dW
         #   dY   = Tr[Ccal(rho)] dt + dW
@@ -560,10 +575,10 @@ class DSMESolveEulerMayuramaIntegrator(DSMEFixedStepIntegrator):
         # (see MESolveDiffraxIntegrator in `integrators/core/diffrax_integrator.py`)
         Hnh = -1j * H - 0.5 * LdL
         tmp = Hnh @ rho + sum([0.5 * _L @ rho @ _L.dag() for _L in L])
-        Lcal_rho = tmp + tmp.dag()
+        Lcal_rho = tmp + dag(tmp)
 
         # === Ccal(rho)
-        Lm_rho = stack([_Lm @ rho for _Lm in Lm])
+        Lm_rho = stack([cast(QArray, _Lm @ rho) for _Lm in Lm])
         etas = self.etas[:, None, None]  # (nLm, 1, 1)
         Ccal_rho = jnp.sqrt(etas) * (Lm_rho + Lm_rho.dag())  # (nLm, n, n)
         tr_Ccal_rho = Ccal_rho.trace().real  # (nLm,)
@@ -576,6 +591,7 @@ class DSMESolveEulerMayuramaIntegrator(DSMEFixedStepIntegrator):
         # === measurement Y
         dY = tr_Ccal_rho * self.dt + dW  # (nLm,)
 
+        y = cast(DiffusiveState, y)
         return DiffusiveState(rho + drho, y.Y + dY)
 
 
@@ -583,12 +599,13 @@ class DSMESolveRouchon1Integrator(
     RouchonPropertiesMixin, DSMEFixedStepIntegrator, SolveInterface
 ):
     """Integrator solving the diffusive SME with the Rouchon1 method."""
+    method: Rouchon1
 
     @property
     def identity(self) -> QArray:
         return eye_like(self.H(0))
 
-    def forward(self, t: Scalar, y: SDEState, dX: Array) -> SDEState:
+    def forward(self, t: RealScalarLike, y: SDEState, dX: Array) -> SDEState:
         # The Rouchon update for a single loss channel is:
         #   rho_{k+1} = M_dY @ rho_k @ M_dY^\dag + M1 @ rho_k @ M1d / Tr[...]
         #   dY_{k+1} = sqrt(eta) Tr[(L+Ld) @ rho_k)] dt + dW
@@ -618,6 +635,8 @@ class DSMESolveRouchon1Integrator(
         if self.method.normalize:
             Ms_lindblad = [jnp.sqrt(self.dt) * _L for _L in L]
             S = M0.dag() @ M0 + sum([_M.dag() @ _M for _M in Ms_lindblad])
+            S = cast(QArray, S)
+
             rho = cholesky_normalize(S, rho)
 
         M_dY = M0 + sum(
@@ -638,6 +657,7 @@ class DSMESolveRouchon1Integrator(
         rho = sum([M @ rho @ M.dag() for M in Ms])
         rho = rho / rho.trace()  # normalise by signal probability
 
+        y = cast(DiffusiveState, y)
         return DiffusiveState(rho, y.Y + dY)
 
 

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -10,12 +10,12 @@ import jax.numpy as jnp
 import numpy as np
 from diffrax._custom_types import RealScalarLike
 from jax import Array
-from jaxtyping import ArrayLike, PRNGKeyArray, PyTree, Scalar
+from jaxtyping import ArrayLike, PRNGKeyArray, PyTree
 
-from ...method import _DEFixedStep, Rouchon1
+from ...method import Rouchon1, _DEFixedStep
 from ...qarrays.qarray import QArray
 from ...qarrays.utils import stack
-from ...result import DiffusiveSolveSaved, JumpSolveSaved, Result, Saved, SolveSaved
+from ...result import DiffusiveSolveSaved, JumpSolveSaved, Result, SolveSaved
 from ...utils.general import dag, expect
 from ...utils.operators import eye_like
 from .abstract_integrator import StochasticBaseIntegrator
@@ -47,6 +47,7 @@ def _is_linearly_spaced(
 
 class SDEState(eqx.Module):
     """State for the jump/diffusive SSE/SME fixed step integrators."""
+
     state: QArray
 
 
@@ -101,7 +102,7 @@ class StochasticSolveFixedStepIntegrator(
     @property
     def total_nsteps(self) -> int:
         # total number of steps of length dt
-        return int(round((self.t1 - self.t0) / self.dt))
+        return round((self.t1 - self.t0) / self.dt)  # ty: ignore
 
     @abstractmethod
     def sample_rv(self, key: PRNGKeyArray, nsteps: int) -> PyTree:
@@ -408,10 +409,11 @@ class DiffusiveSolveFixedStepIntegrator(StochasticSolveFixedStepIntegrator):
         saved = super().save(y.state)
         return DiffusiveSolveSaved(saved.ysave, saved.extra, saved.Esave, y.Y)
 
-    def postprocess_saved(self, saved: SolveSaved, ylast: PyTree) -> DiffusiveSolveSaved:
+    def postprocess_saved(
+        self, saved: SolveSaved, ylast: PyTree
+    ) -> DiffusiveSolveSaved:
         saved = cast(
-            DiffusiveSolveSaved, 
-            super().postprocess_saved(saved, ylast.state[None, :])
+            DiffusiveSolveSaved, super().postprocess_saved(saved, ylast.state[None, :])
         )
 
         # The averaged measurement I^{(ta, tb)} is recovered by diffing the measurement
@@ -488,6 +490,7 @@ def cholesky_normalize_ket(S: QArray, psi: QArray) -> jax.Array:
 
 class DSSESolveRouchon1Integrator(RouchonPropertiesMixin, DSSEFixedStepIntegrator):
     """Integrator solving the diffusive SSE with the Rouchon1 method."""
+
     method: Rouchon1
 
     @property
@@ -599,6 +602,7 @@ class DSMESolveRouchon1Integrator(
     RouchonPropertiesMixin, DSMEFixedStepIntegrator, SolveInterface
 ):
     """Integrator solving the diffusive SME with the Rouchon1 method."""
+
     method: Rouchon1
 
     @property

--- a/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
+++ b/dynamiqs/integrators/core/fixed_step_stochastic_integrator.py
@@ -519,7 +519,6 @@ class DSSESolveRouchon1Integrator(RouchonPropertiesMixin, DSSEFixedStepIntegrato
             )
             M_dY = M0 + sum([_dY * _L for _dY, _L in zip(dY, L, strict=True)])
             S = M0.dag() @ M0 + sum([_L.dag() @ _L for _L in L]) * self.dt
-            S = cast(QArray, S)
 
             psi = cholesky_normalize_ket(S, psi)
             psi = (M_dY @ psi).unit()
@@ -581,7 +580,7 @@ class DSMESolveEulerMayuramaIntegrator(DSMEFixedStepIntegrator):
         Lcal_rho = tmp + dag(tmp)
 
         # === Ccal(rho)
-        Lm_rho = stack([cast(QArray, _Lm @ rho) for _Lm in Lm])
+        Lm_rho = stack([_Lm @ rho for _Lm in Lm])
         etas = self.etas[:, None, None]  # (nLm, 1, 1)
         Ccal_rho = jnp.sqrt(etas) * (Lm_rho + Lm_rho.dag())  # (nLm, n, n)
         tr_Ccal_rho = Ccal_rho.trace().real  # (nLm,)
@@ -639,8 +638,6 @@ class DSMESolveRouchon1Integrator(
         if self.method.normalize:
             Ms_lindblad = [jnp.sqrt(self.dt) * _L for _L in L]
             S = M0.dag() @ M0 + sum([_M.dag() @ _M for _M in Ms_lindblad])
-            S = cast(QArray, S)
-
             rho = cholesky_normalize(S, rho)
 
         M_dY = M0 + sum(

--- a/dynamiqs/integrators/core/floquet_integrator.py
+++ b/dynamiqs/integrators/core/floquet_integrator.py
@@ -6,7 +6,7 @@ from jaxtyping import PyTree
 
 from dynamiqs.result import FloquetSaved
 
-from ...result import Result, Saved
+from ...result import FloquetResult, Result
 from ..apis.sepropagator import _sepropagator
 from .abstract_integrator import BaseIntegrator
 from .interfaces import SEInterface
@@ -15,8 +15,8 @@ from .interfaces import SEInterface
 class FloquetIntegrator(BaseIntegrator):
     T: float
 
-    def result(self, saved: Saved, infos: PyTree | None = None) -> Result:
-        return self.result_class(
+    def result(self, saved: FloquetSaved, infos: PyTree | None = None) -> Result:
+        return FloquetResult(
             self.ts, self.method, self.gradient, self.options, saved, infos, self.T
         )
 

--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import abstractmethod
 
 import equinox as eqx
+from diffrax._custom_types import RealScalarLike
 from jax import Array
 from jaxtyping import Scalar
 
@@ -39,7 +40,7 @@ class MEInterface(AbstractTimeInterface):
     H: TimeQArray
     Ls: list[TimeQArray]
 
-    def L(self, t: Scalar) -> list[QArray]:
+    def L(self, t: RealScalarLike) -> list[QArray]:
         return [_L(t) for _L in self.Ls]  # (nLs, n, n)
 
     @property

--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -68,13 +68,13 @@ class SMEInterface(AbstractTimeInterface):
     def Ls(self) -> list[TimeQArray]:
         return self.Lcs + self.Lms  # (nLc + nLm, n, n)
 
-    def L(self, t: Scalar) -> list[QArray]:
+    def L(self, t: RealScalarLike) -> list[QArray]:
         return [_L(t) for _L in self.Ls]  # (nLs, n, n)
 
-    def Lc(self, t: Scalar) -> list[QArray]:
+    def Lc(self, t: RealScalarLike) -> list[QArray]:
         return [_L(t) for _L in self.Lcs]  # (nLc, n, n)
 
-    def Lm(self, t: Scalar) -> list[QArray]:
+    def Lm(self, t: RealScalarLike) -> list[QArray]:
         return [_L(t) for _L in self.Lms]  # (nLm, n, n)
 
     @property

--- a/dynamiqs/integrators/core/interfaces.py
+++ b/dynamiqs/integrators/core/interfaces.py
@@ -5,7 +5,6 @@ from abc import abstractmethod
 import equinox as eqx
 from diffrax._custom_types import RealScalarLike
 from jax import Array
-from jaxtyping import Scalar
 
 from ..._utils import concatenate_sort
 from ...options import Options

--- a/dynamiqs/integrators/core/low_rank_integrator.py
+++ b/dynamiqs/integrators/core/low_rank_integrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 from functools import partial
+from typing import cast
 
 import diffrax as dx
 import equinox as eqx
@@ -12,9 +13,18 @@ from jax import Array
 from jaxtyping import PyTree
 
 from ..._checks import check_hermitian
-from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, LinearSolver, Tsit5
+from ...method import (
+    Dopri5,
+    Dopri8,
+    Euler,
+    Kvaerno3,
+    Kvaerno5,
+    LinearSolver,
+    LowRank,
+    Tsit5,
+)
 from ...qarrays.utils import asqarray
-from ...result import MESolveLowRankResult, Result, Saved, SolveSaved
+from ...result import MESolveLowRankResult, Result, SolveSaved
 from .._utils import assert_method_supported
 from .abstract_integrator import BaseIntegrator
 from .diffrax_integrator import AdaptiveStepInfos, FixedStepInfos, call_diffeqsolve
@@ -126,6 +136,8 @@ class MESolveLowRankIntegrator(
     https://github.com/leogoutte/low_rank/blob/main/src/low_rank.jl
     """
 
+    method: LowRank
+
     @property
     def dims(self) -> tuple[int, ...]:
         return self.H.dims
@@ -214,46 +226,40 @@ class MESolveLowRankIntegrator(
             save=self.save,
         )
 
-        saved = self.postprocess_saved(*solution.ys)
+        ys = cast(tuple, solution.ys)
+        saved = self.postprocess_saved(*ys)
         return self.result(saved, infos=self.infos(solution.stats))
 
-    def save(self, m: PyTree) -> SolveSaved:
-        m = normalize_m(m)
+    def save(self, y: PyTree) -> SolveSaved:
+        y = normalize_m(y)
 
         msave = None
         if self.options.save_states:
-            msave = asqarray(m, dims=self.dims)
+            msave = asqarray(y, dims=self.dims)
 
         extra = None
         if self.options.save_extra:
-            rho = asqarray(rho_from_m(m), dims=self.dims)
+            rho = asqarray(rho_from_m(y), dims=self.dims)
             extra = self.options.save_extra(rho)
 
         if self.Es_jax is not None:
-            Esave = jnp.stack([expval_from_m(m, E) for E in self.Es_jax])
+            Esave = jnp.stack([expval_from_m(y, E) for E in self.Es_jax])
         else:
             Esave = None
 
         return SolveSaved(ysave=msave, extra=extra, Esave=Esave)
 
-    def postprocess_saved(self, saved: Saved, mlast: PyTree) -> Saved:
+    def postprocess_saved(self, saved: SolveSaved, ylast: PyTree) -> SolveSaved:
         if not self.options.save_states:
-            mlast_save = asqarray(normalize_m(mlast), dims=self.dims)
+            ylast_save = asqarray(normalize_m(ylast), dims=self.dims)
             saved = eqx.tree_at(
-                lambda x: x.ysave, saved, mlast_save, is_leaf=lambda x: x is None
+                lambda x: x.ysave, saved, ylast_save, is_leaf=lambda x: x is None
             )
 
         return self.reorder_Esave(saved)
 
     def infos(self, stats: dict[str, Array]) -> PyTree:
-        fixed_step = {
-            Euler: True,
-            Dopri5: False,
-            Dopri8: False,
-            Tsit5: False,
-            Kvaerno3: False,
-            Kvaerno5: False,
-        }[type(self.method.ode_method)]
+        fixed_step = isinstance(self.method.ode_method, Euler)
 
         if fixed_step:
             return FixedStepInfos(stats['num_steps'])

--- a/dynamiqs/integrators/core/low_rank_integrator.py
+++ b/dynamiqs/integrators/core/low_rank_integrator.py
@@ -22,6 +22,7 @@ from ...method import (
     LinearSolver,
     LowRank,
     Tsit5,
+    _DEFixedStep,
 )
 from ...qarrays.utils import asqarray
 from ...result import MESolveLowRankResult, Result, SolveSaved
@@ -231,35 +232,38 @@ class MESolveLowRankIntegrator(
         return self.result(saved, infos=self.infos(solution.stats))
 
     def save(self, y: PyTree) -> SolveSaved:
-        y = normalize_m(y)
+        m = y
+        m = normalize_m(m)
 
         msave = None
         if self.options.save_states:
-            msave = asqarray(y, dims=self.dims)
+            msave = asqarray(m, dims=self.dims)
 
         extra = None
         if self.options.save_extra:
-            rho = asqarray(rho_from_m(y), dims=self.dims)
+            rho = asqarray(rho_from_m(m), dims=self.dims)
             extra = self.options.save_extra(rho)
 
         if self.Es_jax is not None:
-            Esave = jnp.stack([expval_from_m(y, E) for E in self.Es_jax])
+            Esave = jnp.stack([expval_from_m(m, E) for E in self.Es_jax])
         else:
             Esave = None
 
         return SolveSaved(ysave=msave, extra=extra, Esave=Esave)
 
     def postprocess_saved(self, saved: SolveSaved, ylast: PyTree) -> SolveSaved:
+        mlast = ylast
+
         if not self.options.save_states:
-            ylast_save = asqarray(normalize_m(ylast), dims=self.dims)
+            mlast_save = asqarray(normalize_m(mlast), dims=self.dims)
             saved = eqx.tree_at(
-                lambda x: x.ysave, saved, ylast_save, is_leaf=lambda x: x is None
+                lambda x: x.ysave, saved, mlast_save, is_leaf=lambda x: x is None
             )
 
         return self.reorder_Esave(saved)
 
     def infos(self, stats: dict[str, Array]) -> PyTree:
-        fixed_step = isinstance(self.method.ode_method, Euler)
+        fixed_step = isinstance(self.method.ode_method, _DEFixedStep)
 
         if fixed_step:
             return FixedStepInfos(stats['num_steps'])

--- a/dynamiqs/integrators/core/montecarlo_integrator.py
+++ b/dynamiqs/integrators/core/montecarlo_integrator.py
@@ -5,6 +5,7 @@ from functools import partial
 
 import jax.numpy as jnp
 
+from ...method import DiffusiveMonteCarlo, JumpMonteCarlo
 from ...result import MESolveResult, Result, SolveSaved, StochasticSolveResult
 from ..apis.dssesolve import _vectorized_dssesolve
 from ..apis.jssesolve import _vectorized_jssesolve
@@ -54,6 +55,8 @@ class MESolveMonteCarloIntegrator(BaseIntegrator, MEInterface, SolveInterface):
 
 
 class MESolveJumpMonteCarloIntegrator(MESolveMonteCarloIntegrator):
+    method: JumpMonteCarlo
+
     def _run_stochastic(self) -> StochasticSolveResult:
         # modify nmaxclick in the options passed to jssesolve
         jsse_options = replace(
@@ -82,6 +85,8 @@ mesolve_jumpmontecarlo_integrator_constructor = partial(
 
 
 class MESolveDiffusiveMonteCarloIntegrator(MESolveMonteCarloIntegrator):
+    method: DiffusiveMonteCarlo
+
     def _run_stochastic(self) -> StochasticSolveResult:
         keys = jnp.asarray(self.method.keys)
 

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import functools
-import operator
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -23,6 +21,7 @@ from ...qarrays.qarray import QArray
 from ...qarrays.utils import asqarray
 from ...result import MESolveResult
 from ...utils.operators import eye
+from .._utils import sum_qarrays
 from .diffrax_integrator import MESolveDiffraxIntegrator
 
 
@@ -160,9 +159,7 @@ class KrausMapRK(eqx.Module):
 
     def dissipator(self, c: float, rho: QArray) -> QArray:
         r"""Jump map $D_c(\rho) = \sum_k L_k \rho L_k^\dagger$ at $t + c\Delta t$."""
-        return functools.reduce(
-            operator.add, (M_rho_Mdag(L, rho) for L in self.L(self.t + c * self.dt))
-        )
+        return sum_qarrays([M_rho_Mdag(L, rho) for L in self.L(self.t + c * self.dt)])
 
     def compute_stages(self, rho0: QArray) -> list[QArray]:
         r"""Compute all intermediate stages $\rho^{(0)}, \ldots, \rho^{(s-1)}$."""
@@ -198,9 +195,7 @@ class KrausMapRK(eqx.Module):
 
     def adjoint_dissipator(self, c: float, O: QArray) -> QArray:
         r"""Adjoint jump map $D_c^*(O) = \sum_k L_k^\dagger O L_k$."""
-        return functools.reduce(
-            operator.add, (Mdag_O_M(L, O) for L in self.L(self.t + c * self.dt))
-        )
+        return sum_qarrays([Mdag_O_M(L, O) for L in self.L(self.t + c * self.dt)])
 
     def S_stage(self, i: int, O: QArray) -> QArray:
         r"""Backward propagation of observation $O$ through stage $i$.

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -3,21 +3,24 @@ from __future__ import annotations
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import replace
+from typing import ClassVar
 
 import diffrax as dx
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 from diffrax import AbstractRungeKutta, Bosh3, Euler, Midpoint, ODETerm
-from diffrax._custom_types import VF, Args, Control, RealScalarLike, Y
+from diffrax._custom_types import VF, Args, BoolScalarLike, Control, RealScalarLike, Y
 from diffrax._local_interpolation import LocalLinearInterpolation
+from jaxtyping import PyTree
 
-from ...gradient import Forward
+from ...gradient import Forward, Gradient
+from ...method import Rouchon1, Rouchon2, Rouchon3
 from ...qarrays.layout import dense
 from ...qarrays.qarray import QArray
 from ...qarrays.utils import asqarray
 from ...result import MESolveResult
-from ...utils.operators import eye
+from ...utils.operators import eye, zeros_like
 from .diffrax_integrator import MESolveDiffraxIntegrator
 
 
@@ -25,7 +28,7 @@ class AbstractRouchonTerm(dx.AbstractTerm):
     # this class bypasses the typical Diffrax term implementation, as Rouchon schemes
     # don't match the vf/contr/prod structure
 
-    rouchon_step: Callable[[RealScalarLike, RealScalarLike, Y], [Y, Y]]
+    rouchon_step: Callable[[RealScalarLike, RealScalarLike, Y], tuple[Y, Y]]
     # should be defined as `rouchon_step(t0, t1, y0) -> y1, error`
 
     def vf(self, t: RealScalarLike, y: Y, args: Args):
@@ -60,11 +63,11 @@ class RouchonDXSolver(dx.AbstractSolver):
         t1: RealScalarLike,
         y0: Y,
         args: Args,
-        solver_state: None,
-        made_jump: bool,
+        solver_state: PyTree | None,
+        made_jump: BoolScalarLike,
     ) -> tuple:
         del solver_state, made_jump, args
-        y1, error = terms.term.rouchon_step(t0, t1, y0)
+        y1, error = terms.term.rouchon_step(t0, t1, y0)  # ty: ignore
         dense_info = dict(y0=y0, y1=y1)
         return y1, error, dense_info, None, dx.RESULTS.successful
 
@@ -155,7 +158,10 @@ class KrausMapRK(eqx.Module):
 
     def dissipator(self, c: float, rho: QArray) -> QArray:
         r"""Jump map $D_c(\rho) = \sum_k L_k \rho L_k^\dagger$ at $t + c\Delta t$."""
-        return sum(M_rho_Mdag(L, rho) for L in self.L(self.t + c * self.dt))
+        return sum(
+            (M_rho_Mdag(L, rho) for L in self.L(self.t + c * self.dt)),
+            start=zeros_like(rho),
+        )
 
     def compute_stages(self, rho0: QArray) -> list[QArray]:
         r"""Compute all intermediate stages $\rho^{(0)}, \ldots, \rho^{(s-1)}$."""
@@ -191,7 +197,9 @@ class KrausMapRK(eqx.Module):
 
     def adjoint_dissipator(self, c: float, O: QArray) -> QArray:
         r"""Adjoint jump map $D_c^*(O) = \sum_k L_k^\dagger O L_k$."""
-        return sum(Mdag_O_M(L, O) for L in self.L(self.t + c * self.dt))
+        return sum(
+            (Mdag_O_M(L, O) for L in self.L(self.t + c * self.dt)), start=zeros_like(O)
+        )
 
     def S_stage(self, i: int, O: QArray) -> QArray:
         r"""Backward propagation of observation $O$ through stage $i$.
@@ -309,6 +317,12 @@ class RouchonPropertiesMixin:
     Expects ``self.H`` and ``self.L`` to be callable.
     """
 
+    H: Callable[[RealScalarLike], QArray]
+    L: Callable[[RealScalarLike], Sequence[QArray]]
+    gradient: Gradient | None
+
+    method: Rouchon1 | Rouchon2 | Rouchon3
+
     def G(self, t: RealScalarLike) -> QArray:
         LdL = sum(Mdag_M(_L) for _L in self.L(t))
         return -1j * self.H(t) - 0.5 * LdL
@@ -389,6 +403,8 @@ class MESolveFixedRouchonIntegrator(RouchonPropertiesMixin, MESolveDiffraxIntegr
     Subclasses must set ``_kraus_map_cls`` and may override ``nojump_diffrax_solver``.
     """
 
+    _kraus_map_cls: ClassVar[type[KrausMapRK]]
+
     @property
     def terms(self) -> dx.AbstractTerm:
         def rouchon_step(t0, t1, y0):  # noqa: ANN001, ANN202
@@ -462,6 +478,11 @@ class MESolveAdaptiveRouchonIntegrator(
     and ``_fixed_cls_high`` as class attributes, and may override
     ``_build_dense_info_low`` for solvers that need extra interpolation data.
     """
+
+    _solver_low: ClassVar[dx.AbstractSolver]
+    _solver_high: ClassVar[dx.AbstractSolver]
+    _fixed_cls_low: ClassVar[type[MESolveFixedRouchonIntegrator]]
+    _fixed_cls_high: ClassVar[type[MESolveFixedRouchonIntegrator]]
 
     def _build_dense_info_low(
         self,
@@ -556,7 +577,7 @@ class MESolveAdaptiveRouchonIntegrator(
         return replace(stepsize_controller, step_ts=self.ts)
 
 
-def cholesky_normalize(S: QArray, rho: QArray) -> jax.Array:
+def cholesky_normalize(S: QArray, rho: QArray) -> QArray:
     # To normalize the scheme, we compute
     #   S = sum_k Mk^† @ Mk
     # and replace
@@ -578,15 +599,19 @@ def cholesky_normalize(S: QArray, rho: QArray) -> jax.Array:
     # computing all ~Mks.
 
     T = jnp.linalg.cholesky(S.to_jax())  # T lower triangular
+    dims = rho.dims
+    layout = rho.layout
 
     # we want T^{†(-1)} @ y0 @ T^{-1}
-    rho = rho.to_jax()
+    rho_jax = rho.to_jax()
+
     # solve T^† @ x = rho => x = T^{†(-1)} @ rho
-    rho = jax.lax.linalg.triangular_solve(
-        T, rho, lower=True, transpose_a=True, conjugate_a=True, left_side=True
+    rho_jax = jax.lax.linalg.triangular_solve(
+        T, rho_jax, lower=True, transpose_a=True, conjugate_a=True, left_side=True
     )
     # solve x @ T = rho => x = rho @ T^{-1}
-    return jax.lax.linalg.triangular_solve(T, rho, lower=True, left_side=False)
+    rho_jax = jax.lax.linalg.triangular_solve(T, rho_jax, lower=True, left_side=False)
+    return asqarray(rho_jax, dims=dims, layout=layout)
 
 
 class MESolveAdaptiveRouchon2Integrator(MESolveAdaptiveRouchonIntegrator):

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import functools
+import operator
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import replace
@@ -20,7 +22,7 @@ from ...qarrays.layout import dense
 from ...qarrays.qarray import QArray
 from ...qarrays.utils import asqarray
 from ...result import MESolveResult
-from ...utils.operators import eye, zeros_like
+from ...utils.operators import eye
 from .diffrax_integrator import MESolveDiffraxIntegrator
 
 
@@ -158,9 +160,8 @@ class KrausMapRK(eqx.Module):
 
     def dissipator(self, c: float, rho: QArray) -> QArray:
         r"""Jump map $D_c(\rho) = \sum_k L_k \rho L_k^\dagger$ at $t + c\Delta t$."""
-        return sum(
-            (M_rho_Mdag(L, rho) for L in self.L(self.t + c * self.dt)),
-            start=zeros_like(rho),
+        return functools.reduce(
+            operator.add, (M_rho_Mdag(L, rho) for L in self.L(self.t + c * self.dt))
         )
 
     def compute_stages(self, rho0: QArray) -> list[QArray]:
@@ -197,8 +198,8 @@ class KrausMapRK(eqx.Module):
 
     def adjoint_dissipator(self, c: float, O: QArray) -> QArray:
         r"""Adjoint jump map $D_c^*(O) = \sum_k L_k^\dagger O L_k$."""
-        return sum(
-            (Mdag_O_M(L, O) for L in self.L(self.t + c * self.dt)), start=zeros_like(O)
+        return functools.reduce(
+            operator.add, (Mdag_O_M(L, O) for L in self.L(self.t + c * self.dt))
         )
 
     def S_stage(self, i: int, O: QArray) -> QArray:

--- a/dynamiqs/integrators/core/save_mixin.py
+++ b/dynamiqs/integrators/core/save_mixin.py
@@ -7,7 +7,6 @@ import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import PyTree
 
-from ...qarrays.qarray import QArray
 from ...result import PropagatorSaved, Saved, SolveSaved
 from ...utils.general import expect
 from .interfaces import OptionsInterface
@@ -35,7 +34,9 @@ class PropagatorSaveMixin(AbstractSaveMixin[PropagatorSaved]):
         extra = self.options.save_extra(y) if self.options.save_extra else None
         return PropagatorSaved(ysave, extra)
 
-    def postprocess_saved(self, saved: PropagatorSaved, ylast: PyTree) -> PropagatorSaved:
+    def postprocess_saved(
+        self, saved: PropagatorSaved, ylast: PyTree
+    ) -> PropagatorSaved:
         # if save_propagators is False save only last propagator
         if not self.options.save_propagators:
             saved = eqx.tree_at(

--- a/dynamiqs/integrators/core/save_mixin.py
+++ b/dynamiqs/integrators/core/save_mixin.py
@@ -1,37 +1,41 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from typing import Generic, TypeVar
 
 import equinox as eqx
 import jax.numpy as jnp
 from jaxtyping import PyTree
 
+from ...qarrays.qarray import QArray
 from ...result import PropagatorSaved, Saved, SolveSaved
 from ...utils.general import expect
 from .interfaces import OptionsInterface
 
+_SavedT = TypeVar('_SavedT', bound=Saved)
 
-class AbstractSaveMixin(OptionsInterface):
+
+class AbstractSaveMixin(OptionsInterface, Generic[_SavedT]):
     """Mixin to assist integrators with data saving."""
 
     @abstractmethod
-    def save(self, y: PyTree) -> Saved:
+    def save(self, y: PyTree) -> _SavedT:
         pass
 
     @abstractmethod
-    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+    def postprocess_saved(self, saved: _SavedT, ylast: PyTree) -> _SavedT:
         pass
 
 
-class PropagatorSaveMixin(AbstractSaveMixin):
+class PropagatorSaveMixin(AbstractSaveMixin[PropagatorSaved]):
     """Mixin to assist integrators computing propagators with data saving."""
 
-    def save(self, y: PyTree) -> Saved:
+    def save(self, y: PyTree) -> PropagatorSaved:
         ysave = y if self.options.save_propagators else None
         extra = self.options.save_extra(y) if self.options.save_extra else None
         return PropagatorSaved(ysave, extra)
 
-    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+    def postprocess_saved(self, saved: PropagatorSaved, ylast: PyTree) -> PropagatorSaved:
         # if save_propagators is False save only last propagator
         if not self.options.save_propagators:
             saved = eqx.tree_at(
@@ -41,10 +45,12 @@ class PropagatorSaveMixin(AbstractSaveMixin):
         return saved
 
 
-class SolveSaveMixin(AbstractSaveMixin):
+class SolveSaveMixin(AbstractSaveMixin[SolveSaved]):
     """Mixin to assist integrators computing time evolution with data saving."""
 
-    def save(self, y: PyTree) -> Saved:
+    Es: list[PyTree] | None
+
+    def save(self, y: PyTree) -> SolveSaved:
         ysave = y if self.options.save_states else None
         extra = self.options.save_extra(y) if self.options.save_extra else None
         if self.Es is not None:
@@ -53,13 +59,13 @@ class SolveSaveMixin(AbstractSaveMixin):
             Esave = None
         return SolveSaved(ysave, extra, Esave)
 
-    def reorder_Esave(self, saved: Saved) -> Saved:
+    def reorder_Esave(self, saved: SolveSaved) -> SolveSaved:
         # reorder Esave after jax.lax.scan stacking (ntsave, nE) -> (nE, ntsave)
         if saved.Esave is not None:
             saved = eqx.tree_at(lambda x: x.Esave, saved, saved.Esave.swapaxes(-1, -2))
         return saved
 
-    def postprocess_saved(self, saved: Saved, ylast: PyTree) -> Saved:
+    def postprocess_saved(self, saved: SolveSaved, ylast: PyTree) -> SolveSaved:
         # if save_states is False save only last state
         if not self.options.save_states:
             saved = eqx.tree_at(

--- a/dynamiqs/integrators/core/save_mixin.py
+++ b/dynamiqs/integrators/core/save_mixin.py
@@ -11,18 +11,22 @@ from ...result import PropagatorSaved, Saved, SolveSaved
 from ...utils.general import expect
 from .interfaces import OptionsInterface
 
-_SavedT = TypeVar('_SavedT', bound=Saved)
+# SavedT lets BaseIntegrator subclasses specify which concrete Saved type they work
+# with (e.g. SolveSaved, PropagatorSaved). Making BaseIntegrator generic over
+# SavedT, methods like `result()` and `postprocess_saved()` gets per-subclass
+# type signatures instead of accepting/returning the broad Saved base class.
+SavedT = TypeVar('SavedT', bound=Saved)
 
 
-class AbstractSaveMixin(OptionsInterface, Generic[_SavedT]):
+class AbstractSaveMixin(OptionsInterface, Generic[SavedT]):
     """Mixin to assist integrators with data saving."""
 
     @abstractmethod
-    def save(self, y: PyTree) -> _SavedT:
+    def save(self, y: PyTree) -> SavedT:
         pass
 
     @abstractmethod
-    def postprocess_saved(self, saved: _SavedT, ylast: PyTree) -> _SavedT:
+    def postprocess_saved(self, saved: SavedT, ylast: PyTree) -> SavedT:
         pass
 
 

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -289,6 +289,7 @@ class Rouchon2(_DEFixedStep, _DEAdaptiveStep):
         normalize: bool = True,
     ):
         _DEFixedStep.__init__(self, dt)  # ty: ignore[invalid-argument-type]
+
         _DEAdaptiveStep.__init__(
             self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
         )
@@ -347,6 +348,7 @@ class Rouchon3(_DEFixedStep, _DEAdaptiveStep):
         normalize: bool = True,
     ):
         _DEFixedStep.__init__(self, dt)  # ty: ignore[invalid-argument-type]
+
         _DEAdaptiveStep.__init__(
             self, rtol, atol, safety_factor, min_factor, max_factor, max_steps
         )

--- a/dynamiqs/plot/fock_plots.py
+++ b/dynamiqs/plot/fock_plots.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import math
+
 import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
@@ -70,6 +72,8 @@ def fock(
 
         ![plot_fock_coherent](../../figs_code/plot_fock_coherent.png){.fig}
     """
+    assert ax is not None
+
     state = to_jax(state)
     check_shape(state, 'state', '(n, 1)', '(n, n)')
 
@@ -127,6 +131,8 @@ def fock_evolution(
 
         ![plot_fock_evolution_log](../../figs_code/plot_fock_evolution_log.png){.fig}
     """
+    assert ax is not None
+
     states = to_jax(states)
     times = jnp.asarray(times) if times is not None else None
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
@@ -142,14 +148,15 @@ def fock_evolution(
     if logscale:
         norm = LogNorm(vmin=logvmin, vmax=1.0, clip=True)
         # stepped cmap
-        ncolors = jnp.round(jnp.log10(1 / logvmin)).astype(int)
+        ncolors = round(math.log10(1 / logvmin))
         clist = sample_cmap(cmap, ncolors + 2)[1:-1]  # remove extremal colors
-        cmap = ListedColormap(clist)
+        _cmap = ListedColormap(clist)
     else:
         norm = Normalize(vmin=0.0, vmax=1.0)
+        _cmap = cmap
 
     # plot
-    ax.pcolormesh(x, y, z, cmap=cmap, norm=norm)
+    ax.pcolormesh(x, y, z, cmap=_cmap, norm=norm)
     ax.grid(False)
 
     # set y ticks
@@ -157,4 +164,4 @@ def fock_evolution(
     ket_ticks(ax.yaxis)
 
     if colorbar:
-        add_colorbar(ax, cmap, norm, size=0.02, pad=0.02)
+        add_colorbar(ax, _cmap, norm, size=0.02, pad=0.02)

--- a/dynamiqs/plot/hinton_plots.py
+++ b/dynamiqs/plot/hinton_plots.py
@@ -84,6 +84,8 @@ def _plot_hinton(
     ecolor: str = 'white',
     ewidth: float = 0.5,
 ):
+    assert ax is not None
+
     # areas: 2D array (n, n) with real values in [0, 1]
     # colors: 2D array (n, n) with real values in [0, 1]
     areas = jnp.asarray(areas)
@@ -109,14 +111,14 @@ def _plot_hinton(
     # squares areas
     areas = areas.T.flatten()
     # squares colors
-    cmap = mpl.colormaps[cmap]
-    colors = cmap(colors.T).reshape(-1, 4)
+    _cmap = mpl.colormaps[cmap]
+    colors = np.asarray(_cmap(colors.T)).reshape(-1, 4)
     _plot_squares(ax, areas, colors, offsets, ecolor=ecolor, ewidth=ewidth)
 
     # === colorbar
     if colorbar:
         norm = Normalize(colors_vmin, colors_vmax)
-        cax = add_colorbar(ax, cmap, norm, size=0.04, pad=0.04)
+        cax = add_colorbar(ax, _cmap, norm, size=0.04, pad=0.04)
         if colors_vmin == -jnp.pi and colors_vmax == jnp.pi:
             cax.set_yticks([-jnp.pi, 0.0, jnp.pi], labels=[r'$-\pi$', r'$0$', r'$\pi$'])
 
@@ -193,6 +195,8 @@ def hinton(
 
         ![plot_hinton_large](../../figs_code/plot_hinton_large.png){.fig}
     """
+    assert ax is not None
+
     x = to_jax(x)
     check_shape(x, 'x', '(n, n)')
 
@@ -206,9 +210,9 @@ def hinton(
             # sequential colormap for positive data, diverging colormap otherwise
             cmap = 'Blues' if all_positive else 'dq'
         if vmin is None:
-            vmin = 0.0 if all_positive else jnp.min(x)
+            vmin = 0.0 if all_positive else jnp.min(x).item()
 
-        vmax = jnp.max(x) if vmax is None else vmax
+        vmax = jnp.max(x).item() if vmax is None else vmax
 
         # areas: absolute value of x
         area_max = max(abs(vmin), abs(vmax))
@@ -217,7 +221,8 @@ def hinton(
         # colors: value of x
         colors = _normalize(x, vmin, vmax)
         colors_vmin, colors_vmax = vmin, vmax
-    elif jnp.iscomplexobj(x):
+
+    else:
         # x: 2D array with complex data
 
         # cyclic colormap for the phase
@@ -225,7 +230,7 @@ def hinton(
 
         # areas: magnitude of x
         magnitude = jnp.abs(x)
-        areas_max = jnp.max(magnitude) if vmax is None else vmax
+        areas_max = jnp.max(magnitude).item() if vmax is None else vmax
         areas = _normalize(magnitude, 0.0, areas_max)
 
         # colors: phase of x

--- a/dynamiqs/plot/misc_plots.py
+++ b/dynamiqs/plot/misc_plots.py
@@ -15,7 +15,7 @@ def pwc_pulse(
     times: ArrayLike,
     values: ArrayLike,
     *,
-    ax: Axes = None,
+    ax: Axes | None = None,
     ycenter: bool = True,
     real_color: str = colors['blue'],
     imag_color: str = colors['purple'],
@@ -35,6 +35,8 @@ def pwc_pulse(
 
         ![plot_pwc_pulse](../../figs_code/plot_pwc_pulse.png){.fig}
     """
+    assert ax is not None
+
     times = jnp.asarray(times)  # (n + 1)
     values = jnp.asarray(values)  # (n)
     times = check_times(times, 'times')

--- a/dynamiqs/plot/qubit_plots.py
+++ b/dynamiqs/plot/qubit_plots.py
@@ -39,6 +39,8 @@ def xyz(
 
         ![plot_xyz](../../figs_code/plot_xyz.png){.fig}
     """
+    assert ax is not None
+
     states = to_jax(states)
     times = jnp.asarray(times) if times is not None else None
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')

--- a/dynamiqs/plot/utils.py
+++ b/dynamiqs/plot/utils.py
@@ -305,9 +305,6 @@ def add_colorbar(
     return cax
 
 
-T = TypeVar('T')
-
-
 def gif_indices(nitems: int, nframes: int) -> np.ndarray:
     # generate indices for GIF frames
     if nframes < nitems:
@@ -387,7 +384,6 @@ def gifit(
         for idx in tqdm(indices):
             plt.close()
             plot_function(items[idx], *args, **kwargs)  # plot frame
-            canvas = plt.gcf().canvas
             canvas = cast(FigureCanvasAgg, plt.gcf().canvas)
             canvas.draw()  # ensure the figure is drawn
             frame = np.array(canvas.buffer_rgba())  # capture the RGBA buffer

--- a/dynamiqs/plot/utils.py
+++ b/dynamiqs/plot/utils.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable, Sequence
 from functools import wraps
 from io import BytesIO
 from math import ceil
-from typing import TypeVar
+from typing import Concatenate, ParamSpec, TypeVar, cast
 
 import matplotlib
 import matplotlib as mpl
@@ -14,7 +14,8 @@ from IPython.display import Image
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.axis import Axis
-from matplotlib.colors import Normalize
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.colors import Colormap, Normalize
 from matplotlib.figure import Figure
 from matplotlib.ticker import FixedLocator, MaxNLocator, MultipleLocator, NullLocator
 from PIL import Image as PILImage
@@ -48,7 +49,7 @@ def figax(w: float = 7.0, h: float | None = None, **kwargs) -> tuple[Figure, Axe
     return plt.subplots(1, 1, figsize=(w, h), constrained_layout=True, **kwargs)
 
 
-def optional_ax(func: callable) -> callable:
+def optional_ax(func: Callable) -> Callable:
     """Decorator to build an `Axes` object to pass as an argument to a plot
     function if it wasn't passed by the user.
 
@@ -262,7 +263,7 @@ def integer_ticks(axis: Axis, n: int, all: bool = True):  # noqa: A002
 
 def ket_ticks(axis: Axis):
     # fix ticks location
-    axis.set_major_locator(FixedLocator(axis.get_ticklocs()))
+    axis.set_major_locator(FixedLocator(axis.get_ticklocs().tolist()))
 
     # format ticks as ket
     new_labels = [rf'$| {label.get_text()} \rangle$' for label in axis.get_ticklabels()]
@@ -271,7 +272,7 @@ def ket_ticks(axis: Axis):
 
 def bra_ticks(axis: Axis):
     # fix ticks location
-    axis.set_major_locator(FixedLocator(axis.get_ticklocs()))
+    axis.set_major_locator(FixedLocator(axis.get_ticklocs().tolist()))
 
     # format ticks as ket
     new_labels = [rf'$\langle {label.get_text()} |$' for label in axis.get_ticklabels()]
@@ -289,10 +290,15 @@ def minorticks_off(axis: Axis):
 
 
 def add_colorbar(
-    ax: Axes, cmap: str, norm: Normalize, *, size: float = 0.05, pad: float = 0.05
+    ax: Axes,
+    cmap: str | Colormap,
+    norm: Normalize,
+    *,
+    size: float = 0.05,
+    pad: float = 0.05,
 ) -> Axes:
     # insert a new axes on the right with the same height
-    cax = ax.inset_axes([1 + size, 0, pad, 1])
+    cax = ax.inset_axes((1 + size, 0, pad, 1))
     mappable = mpl.cm.ScalarMappable(norm=norm, cmap=cmap)
     plt.colorbar(mappable=mappable, cax=cax)
     cax.grid(False)
@@ -310,9 +316,13 @@ def gif_indices(nitems: int, nframes: int) -> np.ndarray:
         return np.arange(nitems)
 
 
+T = TypeVar('T')
+P = ParamSpec('P')
+
+
 def gifit(
-    plot_function: Callable[[T, ...], None],
-) -> Callable[[Sequence[T], ...], Image]:
+    plot_function: Callable[Concatenate[T, P], None],
+) -> Callable[Concatenate[Sequence[T], P], Image]:
     """Transform a plot function into a new function that returns an animated GIF.
 
     This function takes a plot function that normally operates on a single input and
@@ -378,6 +388,7 @@ def gifit(
             plt.close()
             plot_function(items[idx], *args, **kwargs)  # plot frame
             canvas = plt.gcf().canvas
+            canvas = cast(FigureCanvasAgg, plt.gcf().canvas)
             canvas.draw()  # ensure the figure is drawn
             frame = np.array(canvas.buffer_rgba())  # capture the RGBA buffer
             frames.append(frame)

--- a/dynamiqs/plot/wigner_plots.py
+++ b/dynamiqs/plot/wigner_plots.py
@@ -44,6 +44,8 @@ def wigner_data(
         - [`dq.plot.wigner()`][dynamiqs.plot.wigner]: plot the Wigner function of a
             state.
     """
+    assert ax is not None
+
     w = to_jax(wigner)
     check_shape(w, 'wigner', '(n, n)')
     if w.dtype not in (jnp.float32, jnp.float64):
@@ -67,7 +69,7 @@ def wigner_data(
         origin='lower',
         aspect='equal',
         interpolation=interpolation,
-        extent=[-xmax, xmax, -ymax, ymax],
+        extent=(-xmax, xmax, -ymax, ymax),
     )
 
     # remove grid by default
@@ -150,6 +152,8 @@ def wigner(
 
         ![plot_wigner_4legged](../../figs_code/plot_wigner_4legged.png){.fig-half}
     """
+    assert ax is not None
+
     state = asqarray(state)
     check_shape(state, 'state', '(n, 1)', '(n, n)')
 
@@ -320,7 +324,7 @@ def wigner_gif(
     _, _, wig = compute_wigner(states[indices], xmax, ymax, npixels, hbar=hbar)
 
     return gifit(wigner_data)(
-        wig,
+        list(wig),
         w=w,
         h=ymax / xmax * w,
         xmax=xmax,

--- a/dynamiqs/qarrays/dataarray.py
+++ b/dynamiqs/qarrays/dataarray.py
@@ -24,7 +24,7 @@ IndexType: TypeAlias = (
     | ArrayLike
     | EllipsisType
     | None
-    | tuple[int | slice | EllipsisType | None, ...]
+    | tuple[int | slice | ArrayLike | EllipsisType | None, ...]
 )
 
 

--- a/dynamiqs/qarrays/dataarray.py
+++ b/dynamiqs/qarrays/dataarray.py
@@ -19,7 +19,12 @@ if TYPE_CHECKING:
     from .sparsedia_dataarray import SparseDIADataArray
 
 IndexType: TypeAlias = (
-    int | slice | EllipsisType | None | tuple[int | slice | EllipsisType | None, ...]
+    int
+    | slice
+    | ArrayLike
+    | EllipsisType
+    | None
+    | tuple[int | slice | EllipsisType | None, ...]
 )
 
 

--- a/dynamiqs/qarrays/dataarray.py
+++ b/dynamiqs/qarrays/dataarray.py
@@ -204,7 +204,7 @@ class DataArray(eqx.Module):
         return self * y
 
     def __truediv__(self, y: ArrayLike) -> DataArray:
-        return self * (1 / y)
+        return self * (1 / jnp.asarray(y))
 
     @abstractmethod
     def __add__(self, y: DataArrayLike) -> DataArray:
@@ -214,6 +214,8 @@ class DataArray(eqx.Module):
         return self.__add__(y)
 
     def __sub__(self, y: DataArrayLike) -> DataArray:
+        if not isinstance(y, DataArray):
+            y = jnp.asarray(y)
         return self + (-y)
 
     def __rsub__(self, y: DataArrayLike) -> DataArray:

--- a/dynamiqs/qarrays/dense_dataarray.py
+++ b/dynamiqs/qarrays/dense_dataarray.py
@@ -42,27 +42,27 @@ class DenseDataArray(DataArray):
     @property
     def mT(self) -> DataArray:
         data = self.data.mT
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def conj(self) -> DataArray:
         data = self.data.conj()
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def _reshape_unchecked(self, *shape: int) -> DataArray:
         data = jnp.reshape(self.data, shape)
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def broadcast_to(self, *shape: int) -> DataArray:
         data = jnp.broadcast_to(self.data, shape)
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def powm(self, n: int) -> DataArray:
         data = jnp.linalg.matrix_power(self.data, n)
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def expm(self, *, max_squarings: int = 16) -> DataArray:
         data = jax.scipy.linalg.expm(self.data, max_squarings=max_squarings)
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def norm(self, *, psd: bool = False) -> Array:
         from ..utils.general import norm  # noqa: PLC0415
@@ -79,7 +79,7 @@ class DenseDataArray(DataArray):
         if in_last_two_dims(axis, self.ndim):
             return data
         else:
-            return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+            return replace(self, data=data)
 
     def squeeze(self, axis: int | tuple[int, ...] | None = None) -> DataArray | Array:
         data = self.data.squeeze(axis=axis)
@@ -88,11 +88,11 @@ class DenseDataArray(DataArray):
         if in_last_two_dims(axis, self.ndim):
             return data
         else:
-            return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+            return replace(self, data=data)
 
     def _eig(self) -> tuple[Array, DataArray]:
         evals, evecs = jax.lax.linalg.eig(self.data, compute_left_eigenvectors=False)
-        return evals, replace(self, data=evecs)  # ty: ignore[invalid-argument-type]
+        return evals, replace(self, data=evecs)
 
     def _eigh(self) -> tuple[Array, Array]:
         return jnp.linalg.eigh(self.data)
@@ -106,7 +106,7 @@ class DenseDataArray(DataArray):
     def devices(self) -> set[Device]:
         return self.data.devices()
 
-    def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+    def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> Array[bool]:
         return jnp.allclose(self.data, self.data.mT.conj(), rtol=rtol, atol=atol)
 
     def to_jax(self) -> Array:
@@ -144,7 +144,7 @@ class DenseDataArray(DataArray):
         else:
             return NotImplemented
 
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def __add__(self, y: DataArrayLike) -> DataArray:
         if isinstance(y, int | float) and y == 0:
@@ -157,13 +157,10 @@ class DenseDataArray(DataArray):
         else:
             return NotImplemented
 
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def __matmul__(self, y: DataArrayLike) -> DataArray | Array:
-        if (
-            hasattr(y, '_matmul_priority')
-            and self._matmul_priority < y._matmul_priority
-        ):
+        if isinstance(y, DataArray) and self._matmul_priority < y._matmul_priority:
             return NotImplemented
 
         if isinstance(y, DenseDataArray):
@@ -173,7 +170,7 @@ class DenseDataArray(DataArray):
         else:
             return NotImplemented
 
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def __rmatmul__(self, y: DataArrayLike) -> DataArray:
         if isinstance(y, DenseDataArray):
@@ -183,7 +180,7 @@ class DenseDataArray(DataArray):
         else:
             return NotImplemented
 
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def __and__(self, y: DataArray) -> DataArray:
         if isinstance(y, DenseDataArray):
@@ -191,7 +188,7 @@ class DenseDataArray(DataArray):
         else:
             return NotImplemented
 
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def __pow__(self, power: int | _Metaω) -> DataArray:
         # to deal with the x**ω notation from equinox (used in diffrax internals)
@@ -199,25 +196,25 @@ class DenseDataArray(DataArray):
             return _Metaω.__rpow__(power, self)
 
         data = self.data**power
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def __getitem__(self, key: IndexType) -> DataArray:
         data = self.data[key]
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
 
 def array_to_qobj_list(x: Array, dims: tuple[int, ...]) -> Qobj | list[Qobj]:
     # convert dims to qutip
-    dims = list(dims)
+    qobj_dims = list(dims)
     if x.shape[-1] == 1:  # [[3], [1]] or [[3, 4], [1, 1]]
-        dims = [dims, [1] * len(dims)]
+        qobj_dims = [qobj_dims, [1] * len(qobj_dims)]
     elif x.shape[-2] == 1:  # [[1], [3]] or [[1, 1], [3, 4]]
-        dims = [[1] * len(dims), dims]
+        qobj_dims = [[1] * len(qobj_dims), qobj_dims]
     elif x.shape[-1] == x.shape[-2]:  # [[3], [3]] or [[3, 4], [3, 4]]
-        dims = [dims, dims]
+        qobj_dims = [qobj_dims, qobj_dims]
 
     return jax.tree.map(
-        lambda x: Qobj(x, dims=dims),
+        lambda x: Qobj(x, dims=qobj_dims),
         x.tolist(),
         is_leaf=lambda x: jnp.asarray(x).ndim == 2,
     )

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from math import prod
+from typing import cast, overload
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -65,7 +66,7 @@ class MaterializedQArray(QArray):
                 f"Attribute 'ndiags' is only defined for sparse diagonal layouts; "
                 f'got layout {self.layout!r}.'
             )
-        return self.data.ndiags
+        return cast(int, self.data.ndiags)
 
     # === Array methods delegated to DataArray ===
 
@@ -223,7 +224,7 @@ class MaterializedQArray(QArray):
                 ' To add a scalar, use `x.addscalar(scalar)`.'
             )
 
-        if isinstance(y, QArray):
+        if isinstance(y, MaterializedQArray):
             check_compatible_dims(self.dims, y.dims)
             result = self.data + y.data
         elif isqarraylike(y):
@@ -237,8 +238,14 @@ class MaterializedQArray(QArray):
             return replace(self, data=result)
         return result
 
+    @overload
+    def __matmul__(self, y: QArray) -> QArray: ...
+
+    @overload
+    def __matmul__(self, y: ArrayLike) -> Array: ...
+
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
-        if isinstance(y, QArray):
+        if isinstance(y, MaterializedQArray):
             check_compatible_dims(self.dims, y.dims)
             y_data = y.data
         elif is_batched_scalar(y):
@@ -252,7 +259,7 @@ class MaterializedQArray(QArray):
         if result is NotImplemented:
             # try reverse dispatch
             if hasattr(y_data, '__rmatmul__'):
-                result = y_data.__rmatmul__(self.data)
+                result = y_data.__rmatmul__(self.data.to_jax())
             # if still NotImplemented, raise it
             if result is NotImplemented:
                 return NotImplemented
@@ -270,8 +277,14 @@ class MaterializedQArray(QArray):
             return replace(self, data=result)
         return result
 
-    def __rmatmul__(self, y: QArrayLike) -> QArray:
-        if isinstance(y, QArray):
+    @overload
+    def __rmatmul__(self, y: QArray) -> QArray: ...
+
+    @overload
+    def __rmatmul__(self, y: ArrayLike) -> Array: ...
+
+    def __rmatmul__(self, y: QArrayLike) -> QArray | Array:
+        if isinstance(y, MaterializedQArray):
             check_compatible_dims(self.dims, y.dims)
             y_data = y.data
         elif is_batched_scalar(y):
@@ -296,7 +309,7 @@ class MaterializedQArray(QArray):
         return result
 
     def __and__(self, y: QArray) -> QArray:
-        if not isinstance(y, QArray):
+        if not isinstance(y, MaterializedQArray):
             return NotImplemented
 
         result = self.data & y.data
@@ -331,7 +344,7 @@ class MaterializedQArray(QArray):
         Returns:
             New qarray resulting from the element-wise multiplication.
         """
-        if isinstance(y, QArray):
+        if isinstance(y, MaterializedQArray):
             check_compatible_dims(self.dims, y.dims)
             result = self.data * y.data
         elif isqarraylike(y):

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import replace
 from math import prod
-from typing import Any, TypeAlias, TypeGuard, cast, get_args
+from typing import Any, TypeAlias, TypeGuard, cast, get_args, overload
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -553,6 +553,12 @@ class QArray(eqx.Module):
 
     def __rsub__(self, y: QArrayLike) -> QArray:
         return -self + y
+
+    @overload
+    def __matmul__(self, y: QArray) -> QArray: ...
+
+    @overload
+    def __matmul__(self, y: ArrayLike) -> Array: ...
 
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
         if isinstance(y, QArray):

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -258,14 +258,10 @@ class QArray(eqx.Module):
         pass
 
     @property
+    @abstractmethod
     def ndiags(self) -> int:
         """Number of stored diagonals (only for sparse diagonal layout)."""
-        if not hasattr(self.data, 'ndiags'):
-            raise AttributeError(
-                f"Attribute 'ndiags' is only defined for sparse diagonal layouts; "
-                f'got layout {self.layout!r}.'
-            )
-        return cast(int, self.data.ndiags)
+        ...
 
     # === Array methods delegated to DataArray ===
 
@@ -529,11 +525,18 @@ class QArray(eqx.Module):
     @overload
     def __matmul__(self, y: ArrayLike) -> Array: ...
 
+    @abstractmethod
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
         pass
 
+    @overload
+    def __rmatmul__(self, y: QArray) -> QArray: ...
+
+    @overload
+    def __rmatmul__(self, y: ArrayLike) -> Array: ...
+
     @abstractmethod
-    def __rmatmul__(self, y: QArrayLike) -> QArray:
+    def __rmatmul__(self, y: QArrayLike) -> QArray | Array:
         pass
 
     @abstractmethod

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import replace
 from math import prod
-from typing import Any, TypeAlias, get_args
+from typing import Any, TypeAlias, TypeGuard, get_args
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -20,7 +20,7 @@ from .layout import Layout
 __all__ = ['QArray']
 
 
-def isqarraylike(x: Any) -> bool:
+def isqarraylike(x: Any) -> TypeGuard[QArrayLike]:
     r"""Returns True if the input is a qarray-like.
 
     Args:
@@ -547,6 +547,8 @@ class QArray(eqx.Module):
         return self.__add__(y)
 
     def __sub__(self, y: QArrayLike) -> QArray:
+        if not isinstance(y, QArray) and isqarraylike(y):
+            y = to_jax(y)
         return self + (-y)
 
     def __rsub__(self, y: QArrayLike) -> QArray:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import replace
 from math import prod
-from typing import Any, TypeAlias, TypeGuard, get_args
+from typing import Any, TypeAlias, TypeGuard, cast, get_args
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -78,21 +78,21 @@ def to_jax(x: QArrayLike) -> Array:
     elif isinstance(x, Qobj):
         return jnp.asarray(x.full())
     elif isinstance(x, Sequence):
-        return jnp.asarray([to_jax(sub_x) for sub_x in x])
+        return jnp.asarray([to_jax(cast(QArrayLike, sub_x)) for sub_x in x])
     else:
         return jnp.asarray(x)
 
 
 def get_dims(x: QArrayLike) -> tuple[int, ...] | None:
     if isinstance(x, Sequence):
-        sub_dims = [get_dims(sub_x) for sub_x in x]
+        sub_dims = [get_dims(cast(QArrayLike, sub_x)) for sub_x in x]
         return sub_dims[0] if all(sd == sub_dims[0] for sd in sub_dims) else None
     if isinstance(x, QArray):
         return x.dims
     elif isinstance(x, Qobj):
         # handle [[3, 2], [1, 1]] or [[1, 1], [3, 2]] when `auto_tidyup_dims=False`
         # or [[3, 2], [1]] or [[1], [3, 2]] when `auto_tidyup_dims=True`
-        return tuple(next(dims for dims in x.dims if set(dims) != {1}))
+        return tuple(cast(list[int], next(dims for dims in x.dims if set(dims) != {1})))
     else:
         return None
 
@@ -126,7 +126,7 @@ def to_numpy(x: QArrayLike) -> np.ndarray:
     elif isinstance(x, Qobj):
         return np.asarray(x.full())
     elif isinstance(x, Sequence):
-        return np.asarray([to_numpy(sub_x) for sub_x in x])
+        return np.asarray([to_numpy(cast(QArrayLike, sub_x)) for sub_x in x])
     else:
         return np.asarray(x)
 
@@ -270,7 +270,7 @@ class QArray(eqx.Module):
                 f"Attribute 'ndiags' is only defined for sparse diagonal layouts; "
                 f'got layout {self.layout!r}.'
             )
-        return self.data.ndiags
+        return cast(int, self.data.ndiags)
 
     # === Array methods delegated to DataArray ===
 
@@ -503,7 +503,7 @@ class QArray(eqx.Module):
         result = self.data * y
         return replace(self, data=result)
 
-    def __rmul__(self, y: QArrayLike) -> QArray:
+    def __rmul__(self, y: ArrayLike) -> QArray:
         return self * y
 
     def __truediv__(self, y: ArrayLike) -> QArray:
@@ -547,7 +547,7 @@ class QArray(eqx.Module):
         return self.__add__(y)
 
     def __sub__(self, y: QArrayLike) -> QArray:
-        if not isinstance(y, QArray) and isqarraylike(y):
+        if not isinstance(y, QArray):
             y = to_jax(y)
         return self + (-y)
 
@@ -587,7 +587,7 @@ class QArray(eqx.Module):
             return replace(self, data=result)
         return result
 
-    def __rmatmul__(self, y: QArrayLike) -> QArray:
+    def __rmatmul__(self, y: QArrayLike) -> QArray | Array:
         if isinstance(y, QArray):
             check_compatible_dims(self.dims, y.dims)
             y_data = y.data

--- a/dynamiqs/qarrays/sparsedia_dataarray.py
+++ b/dynamiqs/qarrays/sparsedia_dataarray.py
@@ -352,10 +352,11 @@ def _check_key_in_batch_dims(key: IndexType, ndim: int):
         valid_key = ndim > 2
     if isinstance(key, Array):
         valid_key = key.ndim == 0 and ndim > 2
+
     elif isinstance(key, tuple):
         if Ellipsis in key:
             ellipsis_key = key.index(Ellipsis)
-            key = (
+            _key = (
                 key[:ellipsis_key]
                 + (full_slice,) * (ndim - len(key) + 1)
                 + key[ellipsis_key + 1 :]

--- a/dynamiqs/qarrays/sparsedia_dataarray.py
+++ b/dynamiqs/qarrays/sparsedia_dataarray.py
@@ -85,7 +85,7 @@ class SparseDIADataArray(DataArray):
     @property
     def mT(self) -> DataArray:
         offsets, diags = transpose_sparsedia(self.offsets, self.diags)
-        return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, offsets=offsets, diags=diags)
 
     @property
     def ndiags(self) -> int:
@@ -93,11 +93,11 @@ class SparseDIADataArray(DataArray):
 
     def conj(self) -> DataArray:
         diags = self.diags.conj()
-        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, diags=diags)
 
     def _reshape_unchecked(self, *shape: int) -> DataArray:
         offsets, diags = reshape_sparsedia(self.offsets, self.diags, shape)
-        return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, offsets=offsets, diags=diags)
 
     def broadcast_to(self, *shape: int) -> DataArray:
         if shape[-2:] != self.shape[-2:]:
@@ -107,11 +107,11 @@ class SparseDIADataArray(DataArray):
             )
 
         offsets, diags = broadcast_sparsedia(self.offsets, self.diags, shape)
-        return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, offsets=offsets, diags=diags)
 
     def powm(self, n: int) -> DataArray:
         offsets, diags = powm_sparsedia(self.offsets, self.diags, n)
-        return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, offsets=offsets, diags=diags)
 
     def expm(self, *, max_squarings: int = 16) -> DataArray:
         warnings.warn(
@@ -141,7 +141,7 @@ class SparseDIADataArray(DataArray):
                 return self.to_jax().sum(axis)
         else:
             diags = self.diags.sum(axis)
-            return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+            return replace(self, diags=diags)
 
     def squeeze(self, axis: int | tuple[int, ...] | None = None) -> DataArray | Array:
         # return array if last two dimensions are modified, DataArray otherwise
@@ -152,7 +152,7 @@ class SparseDIADataArray(DataArray):
                 return self.to_jax().squeeze(axis)
         else:
             diags = self.diags.squeeze(axis)
-            return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+            return replace(self, diags=diags)
 
     def _eig(self) -> tuple[Array, DataArray]:
         warnings.warn(
@@ -239,10 +239,10 @@ class SparseDIADataArray(DataArray):
             offsets, diags = mul_sparsedia_sparsedia(
                 self.offsets, self.diags, y.offsets, y.diags
             )
-            return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+            return replace(self, offsets=offsets, diags=diags)
         elif isinstance(y, DenseDataArray):
             offsets, diags = mul_sparsedia_array(self.offsets, self.diags, y.data)
-            return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+            return replace(self, offsets=offsets, diags=diags)
         elif isinstance(y, get_args(ArrayLike)):
             y_arr = jnp.asarray(y)
             if (
@@ -252,11 +252,11 @@ class SparseDIADataArray(DataArray):
             ):
                 # scalar or batched scalar: broadcast onto diags directly
                 diags = y_arr * self.diags
-                return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+                return replace(self, diags=diags)
             else:
                 # full matrix: extract matching diagonals and multiply
                 offsets, diags = mul_sparsedia_array(self.offsets, self.diags, y_arr)
-                return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+                return replace(self, offsets=offsets, diags=diags)
 
         return NotImplemented
 
@@ -268,7 +268,7 @@ class SparseDIADataArray(DataArray):
             offsets, diags = add_sparsedia_sparsedia(
                 self.offsets, self.diags, y.offsets, y.diags
             )
-            return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+            return replace(self, offsets=offsets, diags=diags)
         elif isinstance(y, DenseDataArray):
             warnings.warn(
                 'A sparse data array has been converted to dense layout due to '
@@ -291,7 +291,7 @@ class SparseDIADataArray(DataArray):
             offsets, diags = matmul_sparsedia_sparsedia(
                 self.offsets, self.diags, y.offsets, y.diags
             )
-            return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+            return replace(self, offsets=offsets, diags=diags)
         elif isinstance(y, DenseDataArray):
             data = matmul_sparsedia_array(self.offsets, self.diags, y.data)
             return DenseDataArray(data)
@@ -316,7 +316,7 @@ class SparseDIADataArray(DataArray):
             offsets, diags = and_sparsedia_sparsedia(
                 self.offsets, self.diags, y.offsets, y.diags
             )
-            return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
+            return replace(self, offsets=offsets, diags=diags)
         elif isinstance(y, DenseDataArray):
             return self.asdense() & y
 
@@ -334,7 +334,7 @@ class SparseDIADataArray(DataArray):
             return _Metaω.__rpow__(power, self)
 
         diags = self.diags**power
-        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, diags=diags)
 
     def __getitem__(self, key: IndexType) -> DataArray:
         if key in (slice(None, None, None), Ellipsis):
@@ -342,7 +342,7 @@ class SparseDIADataArray(DataArray):
 
         _check_key_in_batch_dims(key, self.ndim)
         diags = self.diags[key]
-        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, diags=diags)
 
 
 def _check_key_in_batch_dims(key: IndexType, ndim: int):

--- a/dynamiqs/qarrays/sparsedia_primitives.py
+++ b/dynamiqs/qarrays/sparsedia_primitives.py
@@ -269,9 +269,11 @@ def and_sparsedia_sparsedia(
 ) -> tuple[tuple[int, ...], Array]:
     # compute new offsets
     n = right_diags.shape[-1]
-    left_offsets = np.asarray(left_offsets)
-    right_offsets = np.asarray(right_offsets)
-    out_offsets = _numpy_to_tuple(np.ravel(left_offsets[:, None] * n + right_offsets))
+    left_offsets_np = np.asarray(left_offsets)
+    right_offsets_np = np.asarray(right_offsets)
+    out_offsets = _numpy_to_tuple(
+        np.ravel(left_offsets_np[:, None] * n + right_offsets_np)
+    )
 
     # compute new diagonals
     out_diags = jnp.kron(left_diags, right_diags)
@@ -306,7 +308,7 @@ def stack_sparsedia(
     axis: int,
 ) -> tuple[tuple[int, ...], Array]:
     # compute unique offsets of the output
-    out_offsets = np.asarray(reduce(np.union1d, offsets_sequence))
+    out_offsets = np.unique(np.concatenate(offsets_sequence))
     offset_to_index = {offset: idx for idx, offset in enumerate(out_offsets)}
 
     # prepare output diagonals with the correct shape and dtype
@@ -326,9 +328,7 @@ def stack_sparsedia(
     return _numpy_to_tuple(out_offsets), out_diags
 
 
-def autopad_sparsedia_diags(
-    offsets: tuple[int, ...], diags: Sequence[Array]
-) -> tuple[Array]:
+def autopad_sparsedia_diags(offsets: tuple[int, ...], diags: Sequence[Array]) -> Array:
     # stack diags in a square matrix by padding each according to its offset
     pads_width = [(abs(k), 0) if k >= 0 else (0, abs(k)) for k in offsets]
     diags = [
@@ -336,5 +336,5 @@ def autopad_sparsedia_diags(
         for pad_width, diag in zip(pads_width, diags, strict=True)
     ]
     dtype = reduce(jnp.promote_types, [diag.dtype for diag in diags])
-    diags = jnp.stack(diags, dtype=dtype)
-    return jnp.moveaxis(diags, 0, -2)
+    stacked_diags = jnp.stack(diags, dtype=dtype)
+    return jnp.moveaxis(stacked_diags, 0, -2)

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Sequence
+from typing import cast
 
 import jax.numpy as jnp
 import numpy as np
@@ -188,12 +189,14 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
 
     # stack inputs depending on data type
     if all(isinstance(q.data, DenseDataArray) for q in qarrays):
-        data = jnp.stack([q.data.data for q in qarrays], axis=axis)
+        data = jnp.stack(
+            [cast(DenseDataArray, q.data).data for q in qarrays], axis=axis
+        )
         return QArray(dims, False, DenseDataArray(data))
     elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays):
         offsets, diags = stack_sparsedia(
-            [q.data.offsets for q in qarrays],
-            [q.data.diags for q in qarrays],
+            [cast(SparseDIADataArray, q.data).offsets for q in qarrays],
+            [cast(SparseDIADataArray, q.data).diags for q in qarrays],
             axis=axis,
         )
         return QArray(dims, False, SparseDIADataArray(offsets, diags))

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -193,18 +193,20 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
         isinstance(q, MaterializedQArray) and isinstance(q.data, DenseDataArray)
         for q in qarrays
     ):
-        mats = cast(list[MaterializedQArray], qarrays)
-        data = jnp.stack([cast(DenseDataArray, q.data).data for q in mats], axis=axis)
+        _qarrays = cast(list[MaterializedQArray], qarrays)
+        data = jnp.stack(
+            [cast(DenseDataArray, q.data).data for q in _qarrays], axis=axis
+        )
         return MaterializedQArray(dims, False, DenseDataArray(data))
 
     elif all(
         isinstance(q, MaterializedQArray) and isinstance(q.data, SparseDIADataArray)
         for q in qarrays
     ):
-        mats = cast(list[MaterializedQArray], qarrays)
+        _qarrays = cast(list[MaterializedQArray], qarrays)
         offsets, diags = stack_sparsedia(
-            [cast(SparseDIADataArray, q.data).offsets for q in mats],
-            [cast(SparseDIADataArray, q.data).diags for q in mats],
+            [cast(SparseDIADataArray, q.data).offsets for q in _qarrays],
+            [cast(SparseDIADataArray, q.data).diags for q in _qarrays],
             axis=axis,
         )
         return MaterializedQArray(dims, False, SparseDIADataArray(offsets, diags))

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -91,7 +91,7 @@ def asqarray(
 
 
 def _asdense(x: QArrayLike, dims: tuple[int, ...] | None) -> QArray:
-    if isinstance(x, QArray):
+    if isinstance(x, MaterializedQArray):
         if isinstance(x.data, DenseDataArray):
             return x
         else:
@@ -108,7 +108,7 @@ def _assparsedia(
 ) -> QArray:
     # TODO: improve this by directly extracting the diags and offsets in case
     # the Qobj is already in sparse DIA format (only for QuTiP 5)
-    if isinstance(x, QArray):
+    if isinstance(x, MaterializedQArray):
         if isinstance(x.data, SparseDIADataArray):
             return x
         # convert dense to sparse
@@ -189,15 +189,22 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
         raise ValueError('All input qarrays must have the same shape.')
 
     # stack inputs depending on data type
-    if all(isinstance(q.data, DenseDataArray) for q in qarrays):
-        data = jnp.stack(
-            [cast(DenseDataArray, q.data).data for q in qarrays], axis=axis
-        )
+    if all(
+        isinstance(q, MaterializedQArray) and isinstance(q.data, DenseDataArray)
+        for q in qarrays
+    ):
+        mats = cast(list[MaterializedQArray], qarrays)
+        data = jnp.stack([cast(DenseDataArray, q.data).data for q in mats], axis=axis)
         return MaterializedQArray(dims, False, DenseDataArray(data))
-    elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays):
+
+    elif all(
+        isinstance(q, MaterializedQArray) and isinstance(q.data, SparseDIADataArray)
+        for q in qarrays
+    ):
+        mats = cast(list[MaterializedQArray], qarrays)
         offsets, diags = stack_sparsedia(
-            [cast(SparseDIADataArray, q.data).offsets for q in qarrays],
-            [cast(SparseDIADataArray, q.data).diags for q in qarrays],
+            [cast(SparseDIADataArray, q.data).offsets for q in mats],
+            [cast(SparseDIADataArray, q.data).diags for q in mats],
             axis=axis,
         )
         return MaterializedQArray(dims, False, SparseDIADataArray(offsets, diags))

--- a/dynamiqs/random/core.py
+++ b/dynamiqs/random/core.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from math import prod
+from typing import cast
 
 import jax
 from jax import Array
@@ -148,7 +149,7 @@ def psd(key: PRNGKeyArray, shape: tuple[int, ...]) -> QArray:
             f'Argument `shape` must be of the form (..., n, n), but is shape={shape}.'
         )
     x = complex(key, shape)
-    return x @ dag(x)
+    return cast(QArray, x @ dag(x))
 
 
 def dm(

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -225,12 +225,11 @@ class StochasticSolveResult(SolveResult):
 
     @classmethod
     def out_axes(cls) -> StochasticSolveResult:
-        return cls(None, None, None, None, 0, 0, 0)   # ty: ignore[invalid-argument-type]
+        return cls(None, None, None, None, 0, 0, 0)  # ty: ignore[invalid-argument-type]
 
     def mean_states(self) -> QArray:
         # todo: document
-        result = cast(QArray, self.states.todm().mean(axis=-4))
-        return result
+        return cast(QArray, self.states.todm().mean(axis=-4))
 
     def mean_expects(self) -> Array | None:
         # todo: document

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -53,7 +53,7 @@ def _array_str(x: Array | QArray | None) -> str | None:
 
 # the Saved object holds quantities saved during the equation integration
 class Saved(eqx.Module):
-    ysave: QArray
+    ysave: PyTree | None
     extra: PyTree | None
 
 

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -86,6 +86,11 @@ class Result(eqx.Module):
     infos: PyTree | None
 
     @property
+    def _ysave(self) -> QArray:
+        ysave = self._saved.ysave
+        return cast(QArray, ysave)
+
+    @property
     def extra(self) -> PyTree | None:
         return self._saved.extra
 
@@ -96,7 +101,7 @@ class Result(eqx.Module):
         raise NotImplementedError
 
     def block_until_ready(self) -> Result:
-        _ = self._saved.ysave.block_until_ready()
+        _ = self._ysave.block_until_ready()
         return self
 
     def _str_parts(self) -> dict[str, str | None]:
@@ -130,7 +135,7 @@ class SolveResult(Result):
 
     @property
     def states(self) -> QArray:
-        return self._saved.ysave
+        return self._ysave
 
     @property
     def final_state(self) -> QArray:
@@ -153,7 +158,7 @@ class PropagatorResult(Result):
 
     @property
     def propagators(self) -> QArray:
-        return self._saved.ysave
+        return self._ysave
 
     @property
     def final_propagator(self) -> QArray:
@@ -170,7 +175,7 @@ class FloquetResult(Result):
 
     @property
     def modes(self) -> QArray:
-        return self._saved.ysave
+        return self._ysave
 
     @property
     def quasienergies(self) -> Array:
@@ -199,7 +204,7 @@ class MESolveResult(SolveResult):
 class MESolveLowRankResult(MESolveResult):
     @property
     def lowrank_states(self) -> QArray:
-        return self._saved.ysave
+        return self._ysave
 
     @property
     def states(self) -> QArray:

--- a/dynamiqs/result.py
+++ b/dynamiqs/result.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import cast
+
 import equinox as eqx
 import jax.numpy as jnp
 from jax import Array
@@ -223,11 +225,12 @@ class StochasticSolveResult(SolveResult):
 
     @classmethod
     def out_axes(cls) -> StochasticSolveResult:
-        return cls(None, None, None, None, 0, 0, 0)  # ty: ignore[invalid-argument-type]
+        return cls(None, None, None, None, 0, 0, 0)   # ty: ignore[invalid-argument-type]
 
     def mean_states(self) -> QArray:
         # todo: document
-        return self.states.todm().mean(axis=-4)  # ty: ignore[invalid-return-type]
+        result = cast(QArray, self.states.todm().mean(axis=-4))
+        return result
 
     def mean_expects(self) -> Array | None:
         # todo: document
@@ -255,9 +258,10 @@ class JumpSolveResult(StochasticSolveResult):
         mean_states = super().mean_states()
 
         if isinstance(self.method, Event) and self.method.smart_sampling:
-            noclick_prob = self.infos.noclick_prob[..., None, None, None]  # ty: ignore[unresolved-attribute]
+            assert self.infos is not None
+            noclick_prob = self.infos.noclick_prob[..., None, None, None]
             return unit(
-                noclick_prob * self.infos.noclick_states.todm()  # ty: ignore[unresolved-attribute]
+                noclick_prob * self.infos.noclick_states.todm()
                 + (1 - noclick_prob) * mean_states,
                 psd=True,
             )
@@ -271,9 +275,10 @@ class JumpSolveResult(StochasticSolveResult):
         mean_expect = super().mean_expects()
 
         if isinstance(self.method, Event) and self.method.smart_sampling:
-            noclick_prob = self.infos.noclick_prob[..., None, None]  # ty: ignore[unresolved-attribute]
+            assert self.infos is not None
+            noclick_prob = self.infos.noclick_prob[..., None, None]
             return (
-                noclick_prob * self.infos.noclick_expects  # ty: ignore[unresolved-attribute]
+                noclick_prob * self.infos.noclick_expects
                 + (1 - noclick_prob) * mean_expect
             )
         else:

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -10,6 +10,7 @@ import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 from jax import Array
+from diffrax._custom_types import RealScalarLike
 from jaxtyping import ArrayLike, PyTree, Scalar, ScalarLike
 
 from ._checks import check_shape, check_times
@@ -232,9 +233,8 @@ def timecallable(
     )
 
     # make f a valid PyTree that is vmap-compatible
-    f = BatchedCallable(f)
-
-    return CallableTimeQArray(f, discontinuity_ts)
+    pytree_f = BatchedCallable(f)
+    return CallableTimeQArray(pytree_f, discontinuity_ts)
 
 
 class TimeQArray(eqx.Module):
@@ -347,7 +347,7 @@ class TimeQArray(eqx.Module):
         Returns:
             New timeqarray with the given time bounds.
         """
-        return replace(self, tstart=tstart, tend=tend)  # ty: ignore[invalid-argument-type]
+        return replace(self, tstart=tstart, tend=tend)
 
     @abstractmethod
     def shift(self, tshift: float) -> TimeQArray:
@@ -427,7 +427,7 @@ class TimeQArray(eqx.Module):
         tend = None if self.tend is None else self.tend + tshift
         return tstart, tend
 
-    def _prefactor(self, t: ScalarLike) -> Array:
+    def _prefactor(self, t: RealScalarLike) -> Array:
         clip = False
         if self.tstart is not None:
             clip |= t < self.tstart
@@ -447,11 +447,11 @@ class TimeQArray(eqx.Module):
         ts = jnp.asarray(ts)
         return jnp.vectorize(self._prefactor)(ts)
 
-    def __call__(self, t: ScalarLike) -> QArray:
+    def __call__(self, t: RealScalarLike) -> QArray:
         return self._prefactor(t)[..., None, None] * self._operator(t)
 
     @abstractmethod
-    def _operator(self, t: ScalarLike) -> QArray:
+    def _operator(self, t: RealScalarLike) -> QArray:
         pass
 
     def __neg__(self) -> TimeQArray:
@@ -477,6 +477,8 @@ class TimeQArray(eqx.Module):
         return self + y
 
     def __sub__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
+        if isqarraylike(y):
+            y = asqarray(y)
         return self + (-y)
 
     def __rsub__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
@@ -530,7 +532,7 @@ class ConstantTimeQArray(TimeQArray):
     @property
     def mT(self) -> TimeQArray:
         qarray = self.qarray.mT
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
     @property
     def in_axes(self) -> PyTree[int | None]:
@@ -538,26 +540,26 @@ class ConstantTimeQArray(TimeQArray):
 
     def shift(self, tshift: float) -> TimeQArray:
         tstart, tend = self._shift_bounds(tshift)
-        return replace(self, tstart=tstart, tend=tend)  # ty: ignore[invalid-argument-type]
+        return replace(self, tstart=tstart, tend=tend)
 
     def reshape(self, *shape: int) -> TimeQArray:
         qarray = self.qarray.reshape(*shape)
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
     def broadcast_to(self, *shape: int) -> TimeQArray:
         qarray = self.qarray.broadcast_to(*shape)
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
     def conj(self) -> TimeQArray:
         qarray = self.qarray.conj()
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
-    def _operator(self, t: ScalarLike) -> QArray:  # noqa: ARG002
+    def _operator(self, t: RealScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray
 
     def __mul__(self, y: QArrayLike) -> TimeQArray:
         qarray = self.qarray * y
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
     def __add__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
         # handle addition with a constant object as a special case
@@ -621,7 +623,7 @@ class PWCTimeQArray(TimeQArray):
     @property
     def mT(self) -> TimeQArray:
         qarray = self.qarray.mT
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
     @property
     def in_axes(self) -> PyTree[int | None]:
@@ -633,36 +635,36 @@ class PWCTimeQArray(TimeQArray):
 
     def shift(self, tshift: float) -> TimeQArray:
         tstart, tend = self._shift_bounds(tshift)
-        return replace(self, times=self.times + tshift, tstart=tstart, tend=tend)  # ty: ignore[invalid-argument-type]
+        return replace(self, times=self.times + tshift, tstart=tstart, tend=tend)
 
     def reshape(self, *shape: int) -> TimeQArray:
         shape = shape[:-2] + self.values.shape[-1:]  # (..., nv)
         values = self.values.reshape(*shape)
-        return replace(self, values=values)  # ty: ignore[invalid-argument-type]
+        return replace(self, values=values)
 
     def broadcast_to(self, *shape: int) -> TimeQArray:
         shape = shape[:-2] + self.values.shape[-1:]  # (..., nv)
         values = jnp.broadcast_to(self.values, shape)
-        return replace(self, values=values)  # ty: ignore[invalid-argument-type]
+        return replace(self, values=values)
 
     def conj(self) -> TimeQArray:
         values = self.values.conj()
         qarray = self.qarray.conj()
-        return replace(self, values=values, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, values=values, qarray=qarray)
 
-    def _prefactor(self, t: ScalarLike) -> Array:
+    def _prefactor(self, t: RealScalarLike) -> Array:
         intervals = self._times_reshaped
         active = (t >= intervals[:, 0]) & (t < intervals[:, 1])  # (nv,)
         pwc_prefactor = jnp.sum(self.values * active, axis=-1)  # (...)
 
         return super()._prefactor(t) * pwc_prefactor
 
-    def _operator(self, t: ScalarLike) -> QArray:  # noqa: ARG002
+    def _operator(self, t: RealScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray
 
     def __mul__(self, y: QArrayLike) -> TimeQArray:
         qarray = self.qarray * y
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
 
 class ModulatedTimeQArray(TimeQArray):
@@ -711,7 +713,7 @@ class ModulatedTimeQArray(TimeQArray):
     @property
     def mT(self) -> TimeQArray:
         qarray = self.qarray.mT
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
     @property
     def in_axes(self) -> PyTree[int | None]:
@@ -726,30 +728,30 @@ class ModulatedTimeQArray(TimeQArray):
         f = BatchedCallable(lambda t: self.f(t - tshift))
         return replace(
             self, f=f, _disc_ts=self._disc_ts + tshift, tstart=tstart, tend=tend
-        )  # ty: ignore[invalid-argument-type]
+        )
 
     def reshape(self, *shape: int) -> TimeQArray:
         f = self.f.reshape(*shape[:-2])
-        return replace(self, f=f)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f)
 
     def broadcast_to(self, *shape: int) -> TimeQArray:
         f = self.f.broadcast_to(*shape[:-2])
-        return replace(self, f=f)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f)
 
     def conj(self) -> TimeQArray:
         f = self.f.conj()
         qarray = self.qarray.conj()
-        return replace(self, f=f, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f, qarray=qarray)
 
-    def _prefactor(self, t: ScalarLike) -> Array:
+    def _prefactor(self, t: RealScalarLike) -> Array:
         return super()._prefactor(t) * self.f(t)
 
-    def _operator(self, t: ScalarLike) -> QArray:  # noqa: ARG002
+    def _operator(self, t: RealScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray
 
     def __mul__(self, y: QArrayLike) -> TimeQArray:
         qarray = self.qarray * y
-        return replace(self, qarray=qarray)  # ty: ignore[invalid-argument-type]
+        return replace(self, qarray=qarray)
 
 
 class CallableTimeQArray(TimeQArray):
@@ -795,7 +797,7 @@ class CallableTimeQArray(TimeQArray):
     @property
     def mT(self) -> TimeQArray:
         f = jtu.Partial(lambda t: self.f(t).mT)
-        return replace(self, f=f)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f)
 
     @property
     def in_axes(self) -> PyTree[int | None]:
@@ -810,26 +812,26 @@ class CallableTimeQArray(TimeQArray):
         f = BatchedCallable(lambda t: self.f(t - tshift))
         return replace(
             self, f=f, _disc_ts=self._disc_ts + tshift, tstart=tstart, tend=tend
-        )  # ty: ignore[invalid-argument-type]
+        )
 
     def reshape(self, *shape: int) -> TimeQArray:
         f = self.f.reshape(*shape)
-        return replace(self, f=f)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f)
 
     def broadcast_to(self, *shape: int) -> TimeQArray:
         f = self.f.broadcast_to(*shape)
-        return replace(self, f=f)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f)
 
     def conj(self) -> TimeQArray:
         f = self.f.conj()
-        return replace(self, f=f)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f)
 
-    def _operator(self, t: ScalarLike) -> QArray:
+    def _operator(self, t: RealScalarLike) -> QArray:
         return self.f(t)
 
     def __mul__(self, y: QArrayLike) -> TimeQArray:
         f = self.f * y
-        return replace(self, f=f)  # ty: ignore[invalid-argument-type]
+        return replace(self, f=f)
 
 
 class SummedTimeQArray(TimeQArray):
@@ -891,7 +893,7 @@ class SummedTimeQArray(TimeQArray):
     @property
     def mT(self) -> TimeQArray:
         timeqarrays = [tqarray.mT for tqarray in self.timeqarrays]
-        return replace(self, timeqarrays=timeqarrays)  # ty: ignore[invalid-argument-type]
+        return replace(self, timeqarrays=timeqarrays)
 
     @property
     def in_axes(self) -> PyTree[int | None]:
@@ -905,37 +907,37 @@ class SummedTimeQArray(TimeQArray):
 
     def shift(self, tshift: float) -> TimeQArray:
         timeqarrays = [tqarray.shift(tshift) for tqarray in self.timeqarrays]
-        return replace(self, timeqarrays=timeqarrays)  # ty: ignore[invalid-argument-type]
+        return replace(self, timeqarrays=timeqarrays)
 
     def reshape(self, *shape: int) -> TimeQArray:
         timeqarrays = [tqarray.reshape(*shape) for tqarray in self.timeqarrays]
-        return replace(self, timeqarrays=timeqarrays)  # ty: ignore[invalid-argument-type]
+        return replace(self, timeqarrays=timeqarrays)
 
     def broadcast_to(self, *shape: int) -> TimeQArray:
         timeqarrays = [tqarray.broadcast_to(*shape) for tqarray in self.timeqarrays]
-        return replace(self, timeqarrays=timeqarrays)  # ty: ignore[invalid-argument-type]
+        return replace(self, timeqarrays=timeqarrays)
 
     def conj(self) -> TimeQArray:
         timeqarrays = [tqarray.conj() for tqarray in self.timeqarrays]
-        return replace(self, timeqarrays=timeqarrays)  # ty: ignore[invalid-argument-type]
+        return replace(self, timeqarrays=timeqarrays)
 
     def prefactor(self, ts: ArrayLike) -> Array:
         raise NotImplementedError(
             'SummedTimeQArray does not support the `prefactor` method. '
         )
 
-    def __call__(self, t: ScalarLike) -> QArray:
+    def __call__(self, t: RealScalarLike) -> QArray:
         return self._prefactor(t)[..., None, None] * ft.reduce(
             lambda x, y: x + y, [tqarray(t) for tqarray in self.timeqarrays]
         )
 
-    def _operator(self, t: ScalarLike) -> QArray:
+    def _operator(self, t: RealScalarLike) -> QArray:
         # this will never be called because we directly override __call__
         raise NotImplementedError
 
     def __mul__(self, y: QArrayLike) -> TimeQArray:
         timeqarrays = [tqarray * y for tqarray in self.timeqarrays]
-        return replace(self, timeqarrays=timeqarrays)  # ty: ignore[invalid-argument-type]
+        return replace(self, timeqarrays=timeqarrays)
 
     def __add__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
         if isqarraylike(y):
@@ -971,7 +973,7 @@ class BatchedCallable(eqx.Module):
             shape = eval_shape.shape
         self.indices = list(jnp.indices(shape))
 
-    def __call__(self, t: ScalarLike) -> QArrayLike:
+    def __call__(self, t: RealScalarLike) -> QArrayLike:
         if len(self.indices) == 0:
             return self.f(t)
         else:
@@ -1015,5 +1017,5 @@ class BatchedCallable(eqx.Module):
         return BatchedCallable(lambda t: self.f(t) + y)
 
     def __mul__(self, y: ArrayLike) -> BatchedCallable:
-        f = lambda t: self.f(t) * y
+        f = lambda t: self.f(t) * y  # ty: ignore[unsupported-operator]
         return BatchedCallable(f)

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -12,7 +12,7 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 from diffrax._custom_types import RealScalarLike
 from jax import Array
-from jaxtyping import ArrayLike, PyTree, Scalar, ScalarLike
+from jaxtyping import ArrayLike, PyTree, ScalarLike
 
 from ._checks import check_shape, check_times
 from ._utils import cdtype, concatenate_sort, obj_type_str

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -529,7 +529,7 @@ class ConstantTimeQArray(TimeQArray):
 
     @property
     def vectorized(self) -> bool:
-        return self.qarray.vectorized
+        return getattr(self.qarray, 'vectorized', False)
 
     @property
     def layout(self) -> Layout:
@@ -620,7 +620,7 @@ class PWCTimeQArray(TimeQArray):
 
     @property
     def vectorized(self) -> bool:
-        return self.qarray.vectorized
+        return getattr(self.qarray, 'vectorized', False)
 
     @property
     def layout(self) -> Layout:
@@ -716,7 +716,7 @@ class ModulatedTimeQArray(TimeQArray):
 
     @property
     def vectorized(self) -> bool:
-        return self.qarray.vectorized
+        return getattr(self.qarray, 'vectorized', False)
 
     @property
     def layout(self) -> Layout:

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -480,6 +480,8 @@ class TimeQArray(eqx.Module):
         return self + y
 
     def __sub__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
+        if isqarraylike(y):
+            y = ConstantTimeQArray(asqarray(y))
         if isinstance(y, TimeQArray):
             return self + (-y)
         else:

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -10,8 +10,8 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
-from jax import Array
 from diffrax._custom_types import RealScalarLike
+from jax import Array
 from jaxtyping import ArrayLike, PyTree, Scalar, ScalarLike
 
 from ._checks import check_shape, check_times
@@ -481,7 +481,7 @@ class TimeQArray(eqx.Module):
         if isinstance(y, TimeQArray):
             return self + (-y)
         else:
-            return NotImplemented 
+            return NotImplemented
 
     def __rsub__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
         return y + (-self)

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -481,7 +481,7 @@ class TimeQArray(eqx.Module):
 
     def __sub__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
         if isqarraylike(y):
-            y = ConstantTimeQArray(asqarray(y))
+            return self + (-asqarray(y))
         if isinstance(y, TimeQArray):
             return self + (-y)
         else:

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -124,7 +124,7 @@ def pwc(times: ArrayLike, values: ArrayLike, qarray: QArrayLike) -> PWCTimeQArra
 
 
 def modulated(
-    f: Callable[[float], Scalar | Array],
+    f: Callable[[RealScalarLike], Array | QArray],
     qarray: QArrayLike,
     *,
     discontinuity_ts: ArrayLike | None = None,
@@ -184,7 +184,9 @@ def modulated(
 
 
 def timecallable(
-    f: Callable[[float], QArray], *, discontinuity_ts: ArrayLike | None = None
+    f: Callable[[RealScalarLike], Array | QArray],
+    *,
+    discontinuity_ts: ArrayLike | None = None,
 ) -> CallableTimeQArray:
     r"""Instantiate a callable timeqarray.
 
@@ -459,10 +461,10 @@ class TimeQArray(eqx.Module):
         return self * (-1)
 
     @abstractmethod
-    def __mul__(self, y: QArrayLike) -> TimeQArray:
+    def __mul__(self, y: ArrayLike) -> TimeQArray:
         pass
 
-    def __rmul__(self, y: QArrayLike) -> TimeQArray:
+    def __rmul__(self, y: ArrayLike) -> TimeQArray:
         return self * y
 
     def __add__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
@@ -559,7 +561,7 @@ class ConstantTimeQArray(TimeQArray):
     def _operator(self, t: RealScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray
 
-    def __mul__(self, y: QArrayLike) -> TimeQArray:
+    def __mul__(self, y: ArrayLike) -> TimeQArray:
         qarray = self.qarray * y
         return replace(self, qarray=qarray)
 
@@ -629,7 +631,13 @@ class PWCTimeQArray(TimeQArray):
 
     @property
     def in_axes(self) -> PyTree[int | None]:
-        return PWCTimeQArray(None, 0, cast(QArray, None), tstart=None, tend=None)
+        return PWCTimeQArray(
+            cast(Array, None),
+            cast(Array, 0),
+            cast(QArray, None),
+            tstart=None,
+            tend=None,
+        )
 
     @property
     def discontinuity_ts(self) -> Array:
@@ -664,7 +672,7 @@ class PWCTimeQArray(TimeQArray):
     def _operator(self, t: RealScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray
 
-    def __mul__(self, y: QArrayLike) -> TimeQArray:
+    def __mul__(self, y: ArrayLike) -> TimeQArray:
         qarray = self.qarray * y
         return replace(self, qarray=qarray)
 
@@ -719,7 +727,13 @@ class ModulatedTimeQArray(TimeQArray):
 
     @property
     def in_axes(self) -> PyTree[int | None]:
-        return ModulatedTimeQArray(0, cast(QArray, None), None, tstart=None, tend=None)
+        return ModulatedTimeQArray(
+            cast(BatchedCallable, 0),
+            cast(QArray, None),
+            cast(Array, None),
+            tstart=None,
+            tend=None,
+        )
 
     @property
     def discontinuity_ts(self) -> Array:
@@ -746,12 +760,12 @@ class ModulatedTimeQArray(TimeQArray):
         return replace(self, f=f, qarray=qarray)
 
     def _prefactor(self, t: RealScalarLike) -> Array:
-        return super()._prefactor(t) * self.f(t)
+        return super()._prefactor(t) * jnp.asarray(self.f(t))
 
     def _operator(self, t: RealScalarLike) -> QArray:  # noqa: ARG002
         return self.qarray
 
-    def __mul__(self, y: QArrayLike) -> TimeQArray:
+    def __mul__(self, y: ArrayLike) -> TimeQArray:
         qarray = self.qarray * y
         return replace(self, qarray=qarray)
 
@@ -803,7 +817,9 @@ class CallableTimeQArray(TimeQArray):
 
     @property
     def in_axes(self) -> PyTree[int | None]:
-        return CallableTimeQArray(0, None, tstart=None, tend=None)
+        return CallableTimeQArray(
+            cast(BatchedCallable, 0), cast(Array, None), tstart=None, tend=None
+        )
 
     @property
     def discontinuity_ts(self) -> Array:
@@ -829,9 +845,9 @@ class CallableTimeQArray(TimeQArray):
         return replace(self, f=f)
 
     def _operator(self, t: RealScalarLike) -> QArray:
-        return self.f(t)
+        return asqarray(self.f(t))
 
-    def __mul__(self, y: QArrayLike) -> TimeQArray:
+    def __mul__(self, y: ArrayLike) -> TimeQArray:
         f = self.f * y
         return replace(self, f=f)
 
@@ -937,7 +953,7 @@ class SummedTimeQArray(TimeQArray):
         # this will never be called because we directly override __call__
         raise NotImplementedError
 
-    def __mul__(self, y: QArrayLike) -> TimeQArray:
+    def __mul__(self, y: ArrayLike) -> TimeQArray:
         timeqarrays = [tqarray * y for tqarray in self.timeqarrays]
         return replace(self, timeqarrays=timeqarrays)
 
@@ -953,19 +969,22 @@ class SummedTimeQArray(TimeQArray):
                 tqarray.clip(y.tstart, y.tend) for tqarray in y.timeqarrays
             ]
             return SummedTimeQArray(self_timeqarrays + y_timeqarrays)
+
         self_timeqarrays = [
             tqarray.clip(self.tstart, self.tend) for tqarray in self.timeqarrays
         ]
+        if not isinstance(y, TimeQArray):
+            return NotImplemented
         return SummedTimeQArray([*self_timeqarrays, y])
 
 
 class BatchedCallable(eqx.Module):
     # this class turns a callable into a PyTree that is vmap-compatible
 
-    f: Callable[[float], QArrayLike]
+    f: Callable[[RealScalarLike], Array | QArray]
     indices: list[Array]
 
-    def __init__(self, f: Callable[[float], QArrayLike]):
+    def __init__(self, f: Callable[[RealScalarLike], Array | QArray]):
         # make f a valid PyTree with `Partial` and convert its output to a qarray
         self.f = jtu.Partial(f)
         eval_shape = jax.eval_shape(f, 0.0)
@@ -975,7 +994,7 @@ class BatchedCallable(eqx.Module):
             shape = eval_shape.shape
         self.indices = list(jnp.indices(shape))
 
-    def __call__(self, t: RealScalarLike) -> QArrayLike:
+    def __call__(self, t: RealScalarLike) -> Array | QArray:
         if len(self.indices) == 0:
             return self.f(t)
         else:
@@ -998,7 +1017,7 @@ class BatchedCallable(eqx.Module):
         return BatchedCallable(f)
 
     def broadcast_to(self, *shape: int) -> BatchedCallable:
-        def f(t: float) -> QArrayLike:
+        def f(t: RealScalarLike) -> Array | QArray:
             res = self.f(t)
             if isinstance(res, QArray):
                 return res.broadcast_to(*shape)
@@ -1012,12 +1031,17 @@ class BatchedCallable(eqx.Module):
         return BatchedCallable(f)
 
     def squeeze(self, i: int) -> BatchedCallable:
-        f = lambda t: jnp.squeeze(self.f(t), i)
+        def f(t: RealScalarLike) -> Array | QArray:
+            res = self.f(t)
+            if isinstance(res, QArray):
+                return res.squeeze(i)
+            return jnp.squeeze(res, i)
+
         return BatchedCallable(f)
 
     def __add__(self, y: ScalarLike) -> BatchedCallable:
         return BatchedCallable(lambda t: self.f(t) + y)
 
     def __mul__(self, y: ArrayLike) -> BatchedCallable:
-        f = lambda t: self.f(t) * y  # ty: ignore[unsupported-operator]
+        f = lambda t: self.f(t) * y
         return BatchedCallable(f)

--- a/dynamiqs/time_qarray.py
+++ b/dynamiqs/time_qarray.py
@@ -4,6 +4,7 @@ import functools as ft
 from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import replace
+from typing import cast
 
 import equinox as eqx
 import jax
@@ -477,9 +478,10 @@ class TimeQArray(eqx.Module):
         return self + y
 
     def __sub__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
-        if isqarraylike(y):
-            y = asqarray(y)
-        return self + (-y)
+        if isinstance(y, TimeQArray):
+            return self + (-y)
+        else:
+            return NotImplemented 
 
     def __rsub__(self, y: QArrayLike | TimeQArray) -> TimeQArray:
         return y + (-self)
@@ -536,7 +538,7 @@ class ConstantTimeQArray(TimeQArray):
 
     @property
     def in_axes(self) -> PyTree[int | None]:
-        return ConstantTimeQArray(0, tstart=None, tend=None)
+        return ConstantTimeQArray(cast(QArray, 0), tstart=None, tend=None)
 
     def shift(self, tshift: float) -> TimeQArray:
         tstart, tend = self._shift_bounds(tshift)
@@ -627,7 +629,7 @@ class PWCTimeQArray(TimeQArray):
 
     @property
     def in_axes(self) -> PyTree[int | None]:
-        return PWCTimeQArray(None, 0, None, tstart=None, tend=None)
+        return PWCTimeQArray(None, 0, cast(QArray, None), tstart=None, tend=None)
 
     @property
     def discontinuity_ts(self) -> Array:
@@ -717,7 +719,7 @@ class ModulatedTimeQArray(TimeQArray):
 
     @property
     def in_axes(self) -> PyTree[int | None]:
-        return ModulatedTimeQArray(0, None, None, tstart=None, tend=None)
+        return ModulatedTimeQArray(0, cast(QArray, None), None, tstart=None, tend=None)
 
     @property
     def discontinuity_ts(self) -> Array:

--- a/dynamiqs/utils/general.py
+++ b/dynamiqs/utils/general.py
@@ -336,27 +336,27 @@ def ptrace(
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)', '(..., n, n)')
 
     # convert keep and dims to numpy arrays
-    keep = np.asarray([keep] if isinstance(keep, int) else keep)  # e.g. [1, 2]
-    dims = np.asarray(dims)  # e.g. [20, 2, 5]
-    ndims = len(dims)  # e.g. 3
+    _keep = np.asarray([keep] if isinstance(keep, int) else keep)  # e.g. [1, 2]
+    _dims = np.asarray(dims)  # e.g. [20, 2, 5]
+    ndims = len(_dims)  # e.g. 3
 
     # check that input dimensions match
     hdim = _hdim(x)
-    prod_dims = np.prod(dims)
+    prod_dims = np.prod(_dims)
     if prod_dims != hdim:
-        dims_prod_str = '*'.join(str(d) for d in dims) + f'={prod_dims}'
+        dims_prod_str = '*'.join(str(d) for d in _dims) + f'={prod_dims}'
         raise ValueError(
             'Argument `dims` must match the Hilbert space dimension of `x` of'
             f' {hdim}, but the product of its values is {dims_prod_str}.'
         )
-    if np.any(keep < 0) or np.any(keep > len(dims) - 1):
+    if np.any(_keep < 0) or np.any(_keep > len(_dims) - 1):
         raise ValueError(
             'Argument `keep` must match the Hilbert space structure specified by'
             ' `dims`.'
         )
 
     # sort keep
-    keep.sort()
+    _keep.sort()
 
     # create einsum alphabet
     alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
@@ -365,22 +365,22 @@ def ptrace(
     eq1 = alphabet[:ndims]  # e.g. 'abc'
     unused = iter(alphabet[ndims:])
     eq2 = ''.join(
-        [next(unused) if i in keep else eq1[i] for i in range(ndims)]
+        [next(unused) if i in _keep else eq1[i] for i in range(ndims)]
     )  # e.g. 'ade'
 
     bshape = x.shape[:-2]
 
     # trace out x over unkept dimensions
     if isket(x) or isbra(x):
-        x = x.reshape(*bshape, *dims)  # e.g. (..., 20, 2, 5)
+        x = x.reshape(*bshape, *_dims)  # e.g. (..., 20, 2, 5)
         eq = f'...{eq1},...{eq2}'  # e.g. '...abc,...ade'
         x = jnp.einsum(eq, x, x.conj())  # e.g. (..., 2, 5, 2, 5)
     else:
-        x = x.reshape(*bshape, *dims, *dims)  # e.g. (..., 20, 2, 5, 20, 2, 5)
+        x = x.reshape(*bshape, *_dims, *_dims)  # e.g. (..., 20, 2, 5, 20, 2, 5)
         eq = f'...{eq1}{eq2}'  # e.g. '...abcade'
         x = jnp.einsum(eq, x)  # e.g. (..., 2, 5, 2, 5)
 
-    new_dims = tuple(dims[keep].tolist())
+    new_dims = tuple(_dims[_keep].tolist())
     prod_new_dims = np.prod(new_dims)  # e.g. 10
     x = x.reshape(*bshape, prod_new_dims, prod_new_dims)  # e.g. (..., 10, 10)
 
@@ -413,8 +413,8 @@ def tensor(*args: QArrayLike) -> QArray:
         >>> psi.shape
         (60, 1)
     """
-    args = [asqarray(arg) for arg in args]
-    return reduce(lambda x, y: x & y, args)  # TODO: (guilmin) use jax.lax.reduce
+    _args = [asqarray(arg) for arg in args]
+    return reduce(lambda x, y: x & y, _args)  # TODO: (guilmin) use jax.lax.reduce
 
 
 def expect(O: QArrayLike, x: QArrayLike) -> Array:
@@ -467,9 +467,9 @@ def expect(O: QArrayLike, x: QArrayLike) -> Array:
 def _expect_single(O: QArray, x: QArray) -> Array:
     # O: (n, n), x: (..., n, m)
     if isket(x):
-        return (dag(x) @ O @ x).squeeze((-1, -2))  # <x|O|x>
+        return to_jax(dag(x) @ O @ x).squeeze((-1, -2))  # <x|O|x>
     elif isbra(x):
-        return (x @ O @ dag(x)).squeeze((-1, -2))
+        return to_jax(x @ O @ dag(x)).squeeze((-1, -2))
     else:
         return tracemm(O, x)  # tr(Ox)
 
@@ -594,7 +594,7 @@ def dissipator(L: QArrayLike, rho: QArrayLike) -> QArray:
 
     Ldag = dag(L)
     LdagL = Ldag @ L
-    return L @ rho @ Ldag - 0.5 * LdagL @ rho - 0.5 * rho @ LdagL
+    return asqarray(L @ rho @ Ldag - 0.5 * LdagL @ rho - 0.5 * rho @ LdagL)
 
 
 def lindbladian(H: QArrayLike, jump_ops: list[QArrayLike], rho: QArrayLike) -> QArray:
@@ -638,20 +638,22 @@ def lindbladian(H: QArrayLike, jump_ops: list[QArrayLike], rho: QArrayLike) -> Q
          [ 0.+0.j  0.+0.j  0.+0.j  0.+0.j]]
     """
     H = asqarray(H)
-    jump_ops = [asqarray(L) for L in jump_ops]
+    _jump_ops = [asqarray(L) for L in jump_ops]
     rho = asqarray(rho)
 
     # === check H shape
     check_shape(H, 'H', '(..., n, n)')
 
     # === check jump_ops shape
-    for i, L in enumerate(jump_ops):
+    for i, L in enumerate(_jump_ops):
         check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
 
     # === check rho shape
     check_shape(rho, 'rho', '(..., n, n)')
 
-    return -1j * H @ rho + 1j * rho @ H + sum([dissipator(L, rho) for L in jump_ops])
+    return asqarray(
+        -1j * H @ rho + 1j * rho @ H + sum([dissipator(L, rho) for L in _jump_ops])
+    )
 
 
 def isket(x: QArrayLike) -> bool:
@@ -878,9 +880,9 @@ def proj(x: QArrayLike) -> QArray:
     check_shape(x, 'x', '(..., n, 1)', '(..., 1, n)')
 
     if isbra(x):
-        return dag(x) @ x
+        return asqarray(dag(x) @ x)
     else:
-        return x @ dag(x)
+        return asqarray(x @ dag(x))
 
 
 def braket(x: QArrayLike, y: QArrayLike) -> Array:
@@ -904,7 +906,7 @@ def braket(x: QArrayLike, y: QArrayLike) -> Array:
     check_shape(x, 'x', '(..., n, 1)')
     check_shape(y, 'y', '(..., n, 1)')
 
-    return (dag(x) @ y).squeeze((-1, -2))
+    return to_jax(dag(x) @ y).squeeze((-1, -2))
 
 
 def overlap(x: QArrayLike, y: QArrayLike) -> Array:
@@ -940,11 +942,11 @@ def overlap(x: QArrayLike, y: QArrayLike) -> Array:
     check_shape(y, 'y', '(..., n, 1)', '(..., n, n)')
 
     if isket(x) and isket(y):
-        return jnp.abs((dag(x) @ y).squeeze((-1, -2))) ** 2
+        return jnp.abs(to_jax(dag(x) @ y).squeeze((-1, -2))) ** 2
     elif isket(x):
-        return jnp.abs((dag(x) @ y @ x).squeeze((-1, -2)))
+        return jnp.abs(to_jax(dag(x) @ y @ x).squeeze((-1, -2)))
     elif isket(y):
-        return jnp.abs((dag(y) @ x @ y).squeeze((-1, -2)))
+        return jnp.abs(to_jax(dag(y) @ x @ y).squeeze((-1, -2)))
     else:
         return tracemm(dag(x), y).real
 
@@ -1003,7 +1005,7 @@ def _dm_fidelity(x: QArray, y: QArray) -> Array:
     # F = (\sum_i \sqrt{w_i})^2.
 
     # note that we can't use `eigvalsh` here because x @ y is not necessarily Hermitian
-    w = (x @ y)._eigvals().real
+    w = asqarray(x @ y)._eigvals().real
     # we set small negative eigenvalues errors to zero to avoid `nan` propagation
     w = jnp.where(w < 0, 0, w)
     return jnp.sqrt(w).sum(-1) ** 2
@@ -1229,7 +1231,8 @@ def bloch_coordinates(x: QArrayLike) -> Array:
         r = 1  # for a pure state
         theta = 2 * jnp.acos(ra)
         phi = jax.lax.select(rb != 0, tb - ta, 0.0)
-    elif isdm(x):
+
+    else:
         # cartesian coordinates
         # see https://en.wikipedia.org/wiki/Bloch_sphere#u,_v,_w_representation
         rx = 2 * x[0, 1].real

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -135,11 +135,11 @@ def eye_like(
         - [`dq.eye()`][dynamiqs.eye]: returns the identity operator.
     """
     xdims = get_dims(x)
-    layout = layout or x.layout
+    _layout = layout or getattr(x, 'layout', None)
     # todo: we should rather use a _get_shape util that never converts to a jax array
     x = to_jax(x)
     dims = init_dims(xdims, dims, x.shape)
-    return eye(*dims, layout=layout)
+    return eye(*dims, layout=_layout)
 
 
 def zeros(*dims: int, layout: Layout | None = None) -> QArray:
@@ -233,11 +233,11 @@ def zeros_like(
         - [`dq.zeros()`][dynamiqs.zeros]: returns the null operator.
     """
     xdims = get_dims(x)
-    layout = layout or x.layout
+    _layout = layout or getattr(x, 'layout', None)
     # todo: we should rather use a _get_shape util that never converts to a jax array
     x = to_jax(x)
     dims = init_dims(xdims, dims, x.shape)
-    return zeros(*dims, layout=layout)
+    return zeros(*dims, layout=_layout)
 
 
 @overload
@@ -553,7 +553,7 @@ def squeeze(dim: int, z: ArrayLike) -> QArray:
     z = jnp.asarray(z, dtype=cdtype())
     z = z[..., None, None]  # (..., 1, 1)
     a = destroy(dim, layout=dense)  # (n, n)
-    a2 = a @ a
+    a2 = asqarray(a @ a)
     return (0.5 * (z.conj() * a2 - z * a2.dag())).expm()
 
 
@@ -662,7 +662,9 @@ def sigmax(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, 1], [1, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia_from_dict({-1: [1], 1: [1]}, dtype=cdtype())
+        return sparsedia_from_dict(
+            {-1: jnp.array([1]), 1: jnp.array([1])}, dtype=cdtype()
+        )
 
 
 def sigmay(*, layout: Layout | None = None) -> QArray:
@@ -687,7 +689,9 @@ def sigmay(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, -1j], [1j, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia_from_dict({-1: [1j], 1: [-1j]}, dtype=cdtype())
+        return sparsedia_from_dict(
+            {-1: jnp.array([1j]), 1: jnp.array([-1j])}, dtype=cdtype()
+        )
 
 
 def sigmaz(*, layout: Layout | None = None) -> QArray:
@@ -712,7 +716,7 @@ def sigmaz(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[1, 0], [0, -1]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia_from_dict({0: [1, -1]}, dtype=cdtype())
+        return sparsedia_from_dict({0: jnp.array([1, -1])}, dtype=cdtype())
 
 
 def sigmap(*, layout: Layout | None = None) -> QArray:
@@ -738,7 +742,7 @@ def sigmap(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, 1], [0, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia_from_dict({1: [1]}, dtype=cdtype())
+        return sparsedia_from_dict({1: jnp.array([1])}, dtype=cdtype())
 
 
 def sigmam(*, layout: Layout | None = None) -> QArray:
@@ -764,7 +768,7 @@ def sigmam(*, layout: Layout | None = None) -> QArray:
         array = jnp.array([[0, 0], [1, 0]], dtype=cdtype())
         return asqarray(array)
     else:
-        return sparsedia_from_dict({-1: [1]}, dtype=cdtype())
+        return sparsedia_from_dict({-1: jnp.array([1])}, dtype=cdtype())
 
 
 def xyz(*, layout: Layout | None = None) -> QArray:

--- a/dynamiqs/utils/states.py
+++ b/dynamiqs/utils/states.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from math import prod
+from typing import cast
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -82,22 +84,22 @@ def fock(dim: int | tuple[int, ...], number: ArrayLike) -> QArray:
         >>> dq.fock((3, 2), number).shape
         (4, 6, 1)
     """
-    dim = np.asarray(dim)
+    _dim = np.asarray(dim)
     number = jnp.asarray(number)
-    check_type_int(dim, 'dim')
+    check_type_int(_dim, 'dim')
     check_type_int(number, 'number')
 
     # check if dim is a single value or a tuple
-    if dim.ndim > 1:
+    if _dim.ndim > 1:
         raise ValueError('Argument `dim` must be an integer or a tuple of integers.')
 
     # if dim is an integer, convert shapes dim: () -> (1,) and number: (...) -> (..., 1)
-    if dim.ndim == 0:
-        dim = dim[None]
+    if _dim.ndim == 0:
+        _dim = _dim[None]
         number = number[..., None]
 
     # check if number has shape (..., len(ndim))
-    if number.shape[-1] != dim.shape[-1]:
+    if number.shape[-1] != _dim.shape[-1]:
         raise ValueError(
             'Argument `number` must have shape `(...)` or `(..., len(dim))`, but'
             f' has shape number.shape={number.shape}.'
@@ -106,7 +108,7 @@ def fock(dim: int | tuple[int, ...], number: ArrayLike) -> QArray:
     # check if 0 <= number[..., i] < dim[i] for all i
     number = eqx.error_if(
         number,
-        dim - number <= 0,
+        _dim - number <= 0,
         'Argument `number` must be in the range [0, dim[i]) for each mode i:'
         ' 0 <= number[..., i] < dim[i].',
     )
@@ -117,11 +119,11 @@ def fock(dim: int | tuple[int, ...], number: ArrayLike) -> QArray:
         # has shape (ndim,), number has shape (ndim,) and number = [n0, n1,..., nf]
         # this is the unbatched version of fock()
         idx = 0
-        for d, n in zip(dim, number, strict=True):
+        for d, n in zip(_dim, number, strict=True):
             idx = d * idx + n
-        ket = jnp.zeros((prod(dim), 1), dtype=cdtype())
+        ket = jnp.zeros((prod(_dim), 1), dtype=cdtype())
         array = ket.at[idx].set(1.0)
-        return asqarray(array, dims=tuple(dim.tolist()))
+        return asqarray(array, dims=tuple(_dim.tolist()))
 
     _vectorized_fock = jnp.vectorize(_fock, signature='(ndim)->(prod_ndim,1)')
     return _vectorized_fock(number)
@@ -249,19 +251,21 @@ def coherent(dim: int | tuple[int, ...], alpha: ArrayLike | list[ArrayLike]) -> 
         >>> dq.coherent((8, 8), (alpha1[None, :], alpha2[:, None])).shape
         (7, 5, 64, 1)
     """
-    dim = np.asarray(dim)
-    check_type_int(dim, 'dim')
+    _dim = np.asarray(dim)
+    check_type_int(_dim, 'dim')
 
     # check if dim is a single value or a tuple
-    if dim.ndim > 1:
+    if _dim.ndim > 1:
         raise ValueError('Argument `dim` must be an integer or a tuple of integers.')
 
     # tackle multi-modes
-    if dim.ndim == 1:
-        return tensor(*[coherent(d, a) for d, a in zip(dim, alpha, strict=True)])
+    if _dim.ndim == 1:
+        return tensor(
+            *[coherent(d, a) for d, a in zip(_dim, cast(Iterable, alpha), strict=True)]
+        )
 
     # fact: dim is now an integer
-    return displace(int(dim), alpha) @ fock(int(dim), 0)
+    return asqarray(displace(int(_dim), jnp.asarray(alpha)) @ fock(int(_dim), 0))
 
 
 def coherent_dm(dim: int | tuple[int, ...], alpha: ArrayLike) -> QArray:
@@ -435,21 +439,21 @@ def thermal_dm(dim: int | tuple[int, ...], nth: ArrayLike) -> QArray:
         >>> dq.thermal_dm((4, 3), nth).shape
         (3, 12, 12)
     """
-    dim = np.asarray(dim)
+    _dim = np.asarray(dim)
     nth = jnp.asarray(nth)
-    check_type_int(dim, 'dim')
+    check_type_int(_dim, 'dim')
 
     # check if dim is a single value or a tuple
-    if dim.ndim > 1:
+    if _dim.ndim > 1:
         raise ValueError('Argument `dim` must be an integer or a tuple of integers.')
 
     # if dim is an integer, convert shapes dim: () -> (1,) and nth: (...) -> (..., 1)
-    if dim.ndim == 0:
-        dim = dim[None]
+    if _dim.ndim == 0:
+        _dim = _dim[None]
         nth = nth[..., None]
 
     # check if nth has shape (..., len(ndim))
-    if nth.shape[-1] != dim.shape[-1]:
+    if nth.shape[-1] != _dim.shape[-1]:
         raise ValueError(
             'Argument `nth` must have shape `(...)` or `(..., len(dim))`, but'
             f' has shape nth.shape={nth.shape}.'
@@ -457,7 +461,7 @@ def thermal_dm(dim: int | tuple[int, ...], nth: ArrayLike) -> QArray:
 
     # compute all density matrices
     def _thermal_dm(nth: Array) -> QArray:
-        dms = [_single_thermal_dm(d, n) for d, n in zip(dim, nth, strict=True)]
+        dms = [_single_thermal_dm(int(d), n) for d, n in zip(_dim, nth, strict=True)]
         return tensor(*dms)
 
     _vectorized_thermal_dm = jnp.vectorize(
@@ -477,7 +481,7 @@ def _single_thermal_dm(dim: int, nth: Array) -> QArray:
 
     # construct the density matrix
     bdiag = jnp.vectorize(jnp.diag, signature='(a)->(a,a)')
-    rho = asqarray(bdiag(rho_diag), dims=(dim.item(),))
+    rho = asqarray(bdiag(rho_diag), dims=(dim,))
 
     # normalize the density matrix
     return rho / rho.trace()

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import replace
 
 import numpy as np
@@ -210,7 +211,7 @@ def sdissipator(L: QArrayLike) -> QArray:
     return sprepost(L, Ldag) - 0.5 * spre(LdagL) - 0.5 * spost(LdagL)
 
 
-def slindbladian(H: QArrayLike, jump_ops: list[QArrayLike]) -> QArray:
+def slindbladian(H: QArrayLike, jump_ops: Sequence[QArrayLike]) -> QArray:
     r"""Returns the Lindbladian superoperator (in matrix form).
 
     The Lindbladian superoperator $\mathcal{L}$ is defined by:

--- a/dynamiqs/utils/vectorization.py
+++ b/dynamiqs/utils/vectorization.py
@@ -247,13 +247,13 @@ def slindbladian(H: QArrayLike, jump_ops: list[QArrayLike]) -> QArray:
             superoperator to a state using only $n\times n$ matrix multiplications.
     """
     H = asqarray(H)
-    jump_ops = [asqarray(L) for L in jump_ops]
+    _jump_ops = [asqarray(L) for L in jump_ops]
 
     # === check H shape
     check_shape(H, 'H', '(..., n, n)')
 
     # === check jump_ops shape
-    for i, L in enumerate(jump_ops):
+    for i, L in enumerate(_jump_ops):
         check_shape(L, f'jump_ops[{i}]', '(..., n, n)')
 
-    return -1j * spre(H) + 1j * spost(H) + sum([sdissipator(L) for L in jump_ops])
+    return -1j * spre(H) + 1j * spost(H) + sum([sdissipator(L) for L in _jump_ops])

--- a/dynamiqs/utils/wigner_utils.py
+++ b/dynamiqs/utils/wigner_utils.py
@@ -98,14 +98,16 @@ def _wigner(state: Array, xvec: Array, yvec: Array, g: float = 2.0) -> Array:
     return w.real * jnp.exp(-2 * a2) * 0.5 * g**2 / jnp.pi
 
 
-def _diag_element(mat: jnp.array, diag: int, element: int) -> float:
+def _diag_element(mat: Array, diag: int, element: int) -> Array:
     r"""Return the element of a matrix `mat` at `jnp.diag(mat, diag)[element]`.
     This function is jittable for `diag` while it is not for the `jnp.diag` version.
     """
     assert mat.shape[0] == mat.shape[1], 'Matrix must be square.'
     n = mat.shape[0]
-    element = jax.lax.select(element < 0, n - jnp.abs(diag) - jnp.abs(element), element)
-    return mat[jnp.maximum(-diag, 0) + element, jnp.maximum(diag, 0) + element]
+    _element = jax.lax.select(
+        element < 0, n - jnp.abs(diag) - jnp.abs(element), element
+    )
+    return mat[jnp.maximum(-diag, 0) + _element, jnp.maximum(diag, 0) + _element]
 
 
 def _laguerre_series(i: int, x: Array, rho: Array, n: int) -> Array:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ ignore-words-list = "ket, braket, SME"
 
 [tool.ty.src]
 exclude = [
-    "dynamiqs/integrators",
+    # "dynamiqs/integrators",
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,6 @@ ignore-words-list = "ket, braket, SME"
 [tool.ty.src]
 exclude = [
     "dynamiqs/integrators",
-    "dynamiqs/plot",
     "dynamiqs/utils",
     "dynamiqs/time_qarray.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,8 +124,6 @@ ignore-words-list = "ket, braket, SME"
 [tool.ty.src]
 exclude = [
     "dynamiqs/integrators",
-    # "dynamiqs/utils",
-    "dynamiqs/time_qarray.py",
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,6 +128,7 @@ exclude = [
     "dynamiqs/qarrays",
     "dynamiqs/random",
     "dynamiqs/utils",
+    "dynamiqs/time_qarray.py",
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ ignore-words-list = "ket, braket, SME"
 [tool.ty.src]
 exclude = [
     "dynamiqs/integrators",
-    "dynamiqs/utils",
+    # "dynamiqs/utils",
     "dynamiqs/time_qarray.py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,6 @@ exclude = [
     "dynamiqs/random",
     "dynamiqs/utils",
     "dynamiqs/time_qarray.py",
-    "dynamiqs/conftest.py"
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,7 +128,6 @@ exclude = [
     "dynamiqs/qarrays",
     "dynamiqs/random",
     "dynamiqs/utils",
-    "dynamiqs/time_qarray.py",
 ]
 
 [tool.ty.rules]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ ignore-words-list = "ket, braket, SME"
 exclude = [
     "dynamiqs/integrators",
     "dynamiqs/plot",
-    "dynamiqs/qarrays",
     "dynamiqs/utils",
     "dynamiqs/time_qarray.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,11 +121,6 @@ convention = "google"
 skip = ".git,*.ipynb"
 ignore-words-list = "ket, braket, SME"
 
-[tool.ty.src]
-exclude = [
-    # "dynamiqs/integrators",
-]
-
 [tool.ty.rules]
 division-by-zero = "error"
 possibly-unresolved-reference = "error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ exclude = [
     "dynamiqs/integrators",
     "dynamiqs/plot",
     "dynamiqs/qarrays",
-    "dynamiqs/random",
     "dynamiqs/utils",
     "dynamiqs/time_qarray.py",
 ]

--- a/tests/dsmesolve/test_batching.py
+++ b/tests/dsmesolve/test_batching.py
@@ -33,7 +33,7 @@ def test_keys_batching(cartesian_batching, H_batch, rho0_batch, ntrajs):
             pytest.skip('non-broadcastable shapes for flat batching')
 
     H = dq.random.herm(jax.random.key(0), (*H_batch, n, n))
-    jump_ops = [dq.destroy(n)]
+    jump_ops = [dq.destroy(n, layout=dq.dense)]
     etas = jnp.ones(1)
     rho0 = dq.fock_dm(n, 1)
     if rho0_batch:

--- a/tests/dssesolve/test_batching.py
+++ b/tests/dssesolve/test_batching.py
@@ -33,7 +33,7 @@ def test_keys_batching(cartesian_batching, H_batch, psi0_batch, ntrajs):
             pytest.skip('non-broadcastable shapes for flat batching')
 
     H = dq.random.herm(jax.random.key(0), (*H_batch, n, n))
-    jump_ops = [dq.destroy(n)]
+    jump_ops = [dq.destroy(n, layout=dq.dense)]
     psi0 = dq.fock(n, 1)
     if psi0_batch:
         psi0 = psi0.broadcast_to(*psi0_batch, n, 1)

--- a/tests/jsmesolve/test_batching.py
+++ b/tests/jsmesolve/test_batching.py
@@ -33,7 +33,7 @@ def test_keys_batching(cartesian_batching, H_batch, rho0_batch, ntrajs):
             pytest.skip('non-broadcastable shapes for flat batching')
 
     H = dq.random.herm(jax.random.key(0), (*H_batch, n, n))
-    jump_ops = [dq.destroy(n)]
+    jump_ops = [dq.destroy(n, layout=dq.dense)]
     thetas = jnp.zeros(1)
     etas = jnp.ones(1)
     rho0 = dq.fock_dm(n, 1)

--- a/tests/jssesolve/test_batching.py
+++ b/tests/jssesolve/test_batching.py
@@ -104,7 +104,7 @@ def test_keys_batching(cartesian_batching, H_batch, psi0_batch, ntrajs):
             pytest.skip('non-broadcastable shapes for flat batching')
 
     H = dq.random.herm(jax.random.key(0), (*H_batch, n, n))
-    jump_ops = [dq.destroy(n)]
+    jump_ops = [dq.destroy(n, layout=dq.dense)]
     psi0 = dq.fock(n, 1)
     if psi0_batch:
         psi0 = psi0.broadcast_to(*psi0_batch, n, 1)


### PR DESCRIPTION
FIxes #1081 

Couple of notes to the reviewer:

1. I noticed `a = f(a)`, if the data type of `a` previously was different from when the function `f` was applied. The type checker is not able to infer that. Half of the changes are essentially converting `a` to `a_` on the LHS.

2. In time qarray, t is taken to be `ScalarLike` but this includes `complex` which is not feasible for Open Quantum System (unless we are doing Quantum Field Theory calculations or Wick's rotation). This should be replaced with `RealScalarLike` in the entire codebase I believe.

3. Default types like `QArray`, `QArrayLike`  lack proper documentation. Also overload should be used in dunder methods like `__mul__`, `__matmul__` etc. to handle interoperability between `QArray` and `Array`.

4. Not related to this PR, but a general note about ty. Unlike ruff, uv by astral, ty isn't yet ready and there is no stable beta yet (0.1 version). Also there are a lot of functionality missing in ty and its not really accurate in type checking as of now (check first comparison table at this [link](https://pyrefly.org/blog/typing-conformance-comparison/)). It might be better to switch to Pyrefly (its also written in rust and is stable) or pyright (low false positives and speed should not be an issue given that this codebase is not too big).