### PR TITLE
split QArray into an abstract base + MaterializedQArray [CompositeQArray prerequisite]

### DIFF
--- a/dynamiqs/integrators/apis/mepropagator.py
+++ b/dynamiqs/integrators/apis/mepropagator.py
@@ -14,7 +14,8 @@ from ...method import Dopri5, Dopri8, Euler, Expm, Kvaerno3, Kvaerno5, Method, T
 from ...options import Options, check_options
 from ...progress_meter import AbstractProgressMeter
 from ...qarrays.dense_dataarray import DenseDataArray
-from ...qarrays.qarray import QArray, QArrayLike
+from ...qarrays.materialized_qarray import MaterializedQArray
+from ...qarrays.qarray import QArrayLike
 from ...result import MEPropagatorResult
 from ...time_qarray import TimeQArray
 from .._utils import (
@@ -288,7 +289,7 @@ def _mepropagator(
     # === init integrator
     # todo: replace with vectorized utils constructor for eye
     data = jnp.eye(H.shape[-1] ** 2, dtype=H.dtype)
-    y0 = QArray(H.dims, True, DenseDataArray(data))
+    y0 = MaterializedQArray(H.dims, True, DenseDataArray(data))
     integrator = integrator_constructor(
         ts=tsave,
         y0=y0,

--- a/dynamiqs/qarrays/__init__.py
+++ b/dynamiqs/qarrays/__init__.py
@@ -1,3 +1,4 @@
+from .materialized_qarray import *  # registers MaterializedQArray (not exported)
 from .qarray import *
 from .qarray import QArrayLike  # excluded from documentation
 from .utils import *

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -23,6 +23,9 @@ class MaterializedQArray(QArray):
     data: DataArray
 
     def __check_init__(self):
+
+        super().__check_init__()
+
         # === ensure dims is compatible with the shape
         # for vectorized superoperators, we allow that the shape is the square
         # of the product of all dims

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -23,14 +23,6 @@ class MaterializedQArray(QArray):
     data: DataArray
 
     def __check_init__(self):
-        # === ensure dims is a tuple of ints
-        if not isinstance(self.dims, tuple) or not all(
-            isinstance(d, int) for d in self.dims
-        ):
-            raise TypeError(
-                f'Argument `dims` must be a tuple of ints, but is {self.dims}.'
-            )
-
         # === ensure dims is compatible with the shape
         # for vectorized superoperators, we allow that the shape is the square
         # of the product of all dims

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from math import prod
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jax import Array, Device
+from jaxtyping import ArrayLike
+from qutip import Qobj
+
+from .._utils import is_batched_scalar
+from .dataarray import DataArray, IndexType
+from .layout import Layout
+from .qarray import QArray, QArrayLike, check_compatible_dims, isqarraylike, to_jax
+
+__all__ = []
+
+
+class MaterializedQArray(QArray):
+    vectorized: bool = eqx.field(static=True)
+    data: DataArray
+
+    def __check_init__(self):
+        # === ensure dims is a tuple of ints
+        if not isinstance(self.dims, tuple) or not all(
+            isinstance(d, int) for d in self.dims
+        ):
+            raise TypeError(
+                f'Argument `dims` must be a tuple of ints, but is {self.dims}.'
+            )
+
+        # === ensure dims is compatible with the shape
+        # for vectorized superoperators, we allow that the shape is the square
+        # of the product of all dims
+        shape = self.data.shape
+        allowed_shapes = (prod(self.dims), prod(self.dims) ** 2)
+        if not (shape[-1] in allowed_shapes or shape[-2] in allowed_shapes):
+            raise ValueError(
+                'Argument `dims` must be compatible with the shape of the qarray, but '
+                f'got dims {self.dims} and shape {shape}.'
+            )
+
+    @property
+    def dtype(self) -> jnp.dtype:
+        return self.data.dtype
+
+    @property
+    def layout(self) -> Layout:
+        return self.data.layout
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.data.shape
+
+    @property
+    def mT(self) -> QArray:
+        return replace(self, data=self.data.mT)
+
+    @property
+    def ndim(self) -> int:
+        return self.data.ndim
+
+    @property
+    def ndiags(self) -> int:
+        """Number of stored diagonals (only for sparse diagonal layout)."""
+        if not hasattr(self.data, 'ndiags'):
+            raise AttributeError(
+                f"Attribute 'ndiags' is only defined for sparse diagonal layouts; "
+                f'got layout {self.layout!r}.'
+            )
+        return self.data.ndiags
+
+    # === Array methods delegated to DataArray ===
+
+    def conj(self) -> QArray:
+        """Returns the element-wise complex conjugate of the qarray.
+
+        Returns:
+            New qarray with element-wise complex conjuguated values.
+        """
+        return replace(self, data=self.data.conj())
+
+    def reshape(self, *shape: int) -> QArray:
+        """Returns a reshaped copy of a qarray.
+
+        Args:
+            *shape: New shape, which must match the original size.
+
+        Returns:
+            New qarray with the given shape.
+        """
+        return replace(self, data=self.data.reshape(*shape))
+
+    def _reshape_unchecked(self, *shape: int) -> QArray:
+        return replace(self, data=self.data._reshape_unchecked(*shape))
+
+    def broadcast_to(self, *shape: int) -> QArray:
+        """Broadcasts a qarray to a new shape.
+
+        Args:
+            *shape: New shape, which must be compatible with the original shape.
+
+        Returns:
+            New qarray with the given shape.
+        """
+        return replace(self, data=self.data.broadcast_to(*shape))
+
+    def powm(self, n: int) -> QArray:
+        return replace(self, data=self.data.powm(n))
+
+    def expm(self, *, max_squarings: int = 16) -> QArray:
+        return replace(self, data=self.data.expm(max_squarings=max_squarings))
+
+    def norm(self, *, psd: bool = False) -> Array:
+        return self.data.norm(psd=psd)
+
+    def trace(self) -> Array:
+        return self.data.trace()
+
+    def sum(self, axis: int | tuple[int, ...] | None = None) -> QArray | Array:
+        result = self.data.sum(axis=axis)
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def squeeze(self, axis: int | tuple[int, ...] | None = None) -> QArray | Array:
+        result = self.data.squeeze(axis=axis)
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def _eig(self) -> tuple[Array, QArray]:
+        evals, evecs = self.data._eig()
+        return evals, replace(self, data=evecs)
+
+    def _eigh(self) -> tuple[Array, Array]:
+        return self.data._eigh()
+
+    def _eigvals(self) -> Array:
+        return self.data._eigvals()
+
+    def _eigvalsh(self) -> Array:
+        return self.data._eigvalsh()
+
+    def devices(self) -> set[Device]:
+        return self.data.devices()
+
+    def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
+        return self.data.isherm(rtol=rtol, atol=atol)
+
+    def block_until_ready(self) -> QArray:
+        self.data.block_until_ready()
+        return self
+
+    # === Quantum methods ===
+
+    def ptrace(self, *keep: int) -> QArray:
+        from ..utils.general import ptrace  # noqa: PLC0415
+
+        return ptrace(self.data.to_jax(), keep, self.dims)
+
+    def to_qutip(self) -> Qobj | list[Qobj]:
+        from .dense_dataarray import array_to_qobj_list  # noqa: PLC0415
+
+        return array_to_qobj_list(self.data.to_jax(), self.dims)
+
+    def to_jax(self) -> Array:
+        return self.data.to_jax()
+
+    def to_numpy(self) -> np.ndarray:
+        return np.asarray(self.data)
+
+    def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
+        return self.data.__array__(dtype=dtype, copy=copy)
+
+    def asdense(self) -> QArray:
+        """Converts to a dense layout.
+
+        Returns:
+            A qarray with dense data layout.
+        """
+        return replace(self, data=self.data.asdense())
+
+    def assparsedia(self, offsets: tuple[int, ...] | None = None) -> QArray:
+        """Converts to a sparse diagonal layout.
+
+        Args:
+            offsets: Offsets of the stored diagonals. If `None`, offsets are determined
+                automatically from the matrix structure. This argument can also be
+                explicitly specified to ensure compatibility with JAX transformations,
+                which require static offset values.
+
+        Returns:
+            A qarray with sparse diagonal data layout.
+        """
+        return replace(self, data=self.data.assparsedia(offsets))
+
+    def __repr__(self) -> str:
+        res = (
+            f'QArray: shape={self.shape}, dims={self.dims}, dtype={self.dtype}, '
+            f'layout={self.layout}'
+        )
+        if self.vectorized:
+            res += f', vectorized={self.vectorized}'
+        res += self.data._repr_extra()
+        return res
+
+    def __mul__(self, y: ArrayLike) -> QArray:
+        if not is_batched_scalar(y):
+            raise NotImplementedError(
+                'Element-wise multiplication of two qarrays with the `*` operator is '
+                'not supported. For matrix multiplication, use `x @ y`. For '
+                'element-wise multiplication, use `x.elmul(y)`.'
+            )
+        result = self.data * y
+        return replace(self, data=result)
+
+    def __add__(self, y: QArrayLike) -> QArray:
+        if isinstance(y, int | float) and y == 0:
+            return self
+
+        if is_batched_scalar(y):
+            raise NotImplementedError(
+                'Adding a scalar to a qarray with the `+` operator is not supported. '
+                'To add a scaled identity matrix, use `x + scalar * dq.eye_like(x)`.'
+                ' To add a scalar, use `x.addscalar(scalar)`.'
+            )
+
+        if isinstance(y, QArray):
+            check_compatible_dims(self.dims, y.dims)
+            result = self.data + y.data
+        elif isqarraylike(y):
+            result = self.data + to_jax(y)
+        else:
+            return NotImplemented
+
+        if result is NotImplemented:
+            return NotImplemented
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def __matmul__(self, y: QArrayLike) -> QArray | Array:
+        if isinstance(y, QArray):
+            check_compatible_dims(self.dims, y.dims)
+            y_data = y.data
+        elif is_batched_scalar(y):
+            raise TypeError('Attempted matrix product between a scalar and a qarray.')
+        elif isqarraylike(y):
+            y_data = to_jax(y)
+        else:
+            return NotImplemented
+
+        result = self.data @ y_data
+        if result is NotImplemented:
+            # try reverse dispatch
+            if hasattr(y_data, '__rmatmul__'):
+                result = y_data.__rmatmul__(self.data)
+            # if still NotImplemented, raise it
+            if result is NotImplemented:
+                return NotImplemented
+
+        # bra @ ket → scalar
+        if (
+            isinstance(y, QArray)
+            and self.isbra()
+            and y.isket()
+            and isinstance(result, DataArray)
+        ):
+            result = result.to_jax()
+
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def __rmatmul__(self, y: QArrayLike) -> QArray:
+        if isinstance(y, QArray):
+            check_compatible_dims(self.dims, y.dims)
+            y_data = y.data
+        elif is_batched_scalar(y):
+            raise TypeError('Attempted matrix product between a scalar and a qarray.')
+        elif isqarraylike(y):
+            y_data = to_jax(y)
+        else:
+            return NotImplemented
+
+        # y_data @ self.data
+        if isinstance(y_data, DataArray):
+            result = y_data @ self.data
+        else:
+            # y_data is a raw array; use DataArray's __rmatmul__
+            result = self.data.__rmatmul__(y_data)
+
+        if result is NotImplemented:
+            return NotImplemented
+
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def __and__(self, y: QArray) -> QArray:
+        if not isinstance(y, QArray):
+            return NotImplemented
+
+        result = self.data & y.data
+        if result is NotImplemented:
+            # try reverse dispatch
+            if hasattr(y.data, '__rand__'):
+                result = y.data.__rand__(self.data)
+            # if still NotImplemented, raise it
+            if result is NotImplemented:
+                return NotImplemented
+
+        new_dims = self.dims + y.dims
+        return replace(self, dims=new_dims, data=result)
+
+    def addscalar(self, y: ArrayLike) -> QArray:
+        """Adds a scalar.
+
+        Args:
+            y: Scalar to add, whose shape should be broadcastable with the qarray.
+
+        Returns:
+            New qarray resulting from the addition with the scalar.
+        """
+        return replace(self, data=self.data + jnp.asarray(y))
+
+    def elmul(self, y: QArrayLike) -> QArray:
+        """Computes the element-wise multiplication.
+
+        Args:
+            y: Qarray-like to multiply with element-wise.
+
+        Returns:
+            New qarray resulting from the element-wise multiplication.
+        """
+        if isinstance(y, QArray):
+            check_compatible_dims(self.dims, y.dims)
+            result = self.data * y.data
+        elif isqarraylike(y):
+            result = self.data * to_jax(y)
+        else:
+            return NotImplemented
+
+        if result is NotImplemented:
+            return NotImplemented
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def elpow(self, power: int) -> QArray:
+        """Computes the element-wise power.
+
+        Args:
+            power: Power to raise to.
+
+        Returns:
+            New qarray with elements raised to the specified power.
+        """
+        return replace(self, data=self.data**power)
+
+    def __getitem__(self, key: IndexType) -> QArray:
+        result = self.data[key]
+        return replace(self, data=result)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from abc import abstractmethod
 from collections.abc import Sequence
-from dataclasses import replace
 from math import prod
 from typing import Any, TypeAlias, get_args
 
@@ -13,8 +13,7 @@ from jax import Array, Device
 from jaxtyping import ArrayLike
 from qutip import Qobj
 
-from .._utils import is_batched_scalar
-from .dataarray import DataArray, IndexType
+from .dataarray import IndexType
 from .layout import Layout
 
 __all__ = ['QArray']
@@ -212,79 +211,57 @@ class QArray(eqx.Module):
     """  # noqa: E501
 
     dims: tuple[int, ...] = eqx.field(static=True)
-    vectorized: bool = eqx.field(static=True)
-    data: DataArray
 
     # Increase __array_priority__ to ensure that a qarray is always returned during an
     # arithmetic operation with a NumPy array. In JAX, it is set to 100 for arrays, and
     # in NumPy it is set to 0.
     __array_priority__ = 200
 
+    @abstractmethod
     def __check_init__(self):
-        # === ensure dims is a tuple of ints
-        if not isinstance(self.dims, tuple) or not all(
-            isinstance(d, int) for d in self.dims
-        ):
-            raise TypeError(
-                f'Argument `dims` must be a tuple of ints, but is {self.dims}.'
-            )
-
-        # === ensure dims is compatible with the shape
-        # for vectorized superoperators, we allow that the shape is the square
-        # of the product of all dims
-        shape = self.data.shape
-        allowed_shapes = (prod(self.dims), prod(self.dims) ** 2)
-        if not (shape[-1] in allowed_shapes or shape[-2] in allowed_shapes):
-            raise ValueError(
-                'Argument `dims` must be compatible with the shape of the qarray, but '
-                f'got dims {self.dims} and shape {shape}.'
-            )
+        pass
 
     # === Properties delegated to DataArray ===
 
     @property
+    @abstractmethod
     def dtype(self) -> jnp.dtype:
-        return self.data.dtype
+        pass
 
     @property
+    @abstractmethod
     def layout(self) -> Layout:
-        return self.data.layout
+        pass
 
     @property
+    @abstractmethod
     def shape(self) -> tuple[int, ...]:
-        return self.data.shape
+        pass
 
     @property
+    @abstractmethod
     def mT(self) -> QArray:
-        return replace(self, data=self.data.mT)
+        pass
 
     @property
+    @abstractmethod
     def ndim(self) -> int:
-        return self.data.ndim
-
-    @property
-    def ndiags(self) -> int:
-        """Number of stored diagonals (only for sparse diagonal layout)."""
-        if not hasattr(self.data, 'ndiags'):
-            raise AttributeError(
-                f"Attribute 'ndiags' is only defined for sparse diagonal layouts; "
-                f'got layout {self.layout!r}.'
-            )
-        return self.data.ndiags
+        pass
 
     # === Array methods delegated to DataArray ===
 
+    @abstractmethod
     def conj(self) -> QArray:
         """Returns the element-wise complex conjugate of the qarray.
 
         Returns:
             New qarray with element-wise complex conjuguated values.
         """
-        return replace(self, data=self.data.conj())
 
     def dag(self) -> QArray:
         return self.mT.conj()
 
+    @abstractmethod
     def reshape(self, *shape: int) -> QArray:
         """Returns a reshaped copy of a qarray.
 
@@ -294,11 +271,12 @@ class QArray(eqx.Module):
         Returns:
             New qarray with the given shape.
         """
-        return replace(self, data=self.data.reshape(*shape))
 
+    @abstractmethod
     def _reshape_unchecked(self, *shape: int) -> QArray:
-        return replace(self, data=self.data._reshape_unchecked(*shape))
+        pass
 
+    @abstractmethod
     def broadcast_to(self, *shape: int) -> QArray:
         """Broadcasts a qarray to a new shape.
 
@@ -308,25 +286,26 @@ class QArray(eqx.Module):
         Returns:
             New qarray with the given shape.
         """
-        return replace(self, data=self.data.broadcast_to(*shape))
 
+    @abstractmethod
     def powm(self, n: int) -> QArray:
-        return replace(self, data=self.data.powm(n))
+        pass
 
+    @abstractmethod
     def expm(self, *, max_squarings: int = 16) -> QArray:
-        return replace(self, data=self.data.expm(max_squarings=max_squarings))
+        pass
 
+    @abstractmethod
     def norm(self, *, psd: bool = False) -> Array:
-        return self.data.norm(psd=psd)
+        pass
 
+    @abstractmethod
     def trace(self) -> Array:
-        return self.data.trace()
+        pass
 
+    @abstractmethod
     def sum(self, axis: int | tuple[int, ...] | None = None) -> QArray | Array:
-        result = self.data.sum(axis=axis)
-        if isinstance(result, DataArray):
-            return replace(self, data=result)
-        return result
+        pass
 
     def mean(self, axis: int | tuple[int, ...] | None = None) -> QArray | Array:
         numerator = self.sum(axis=axis)
@@ -338,41 +317,43 @@ class QArray(eqx.Module):
             denominator = prod(self.shape[i % self.ndim] for i in axis)
         return numerator / denominator
 
+    @abstractmethod
     def squeeze(self, axis: int | tuple[int, ...] | None = None) -> QArray | Array:
-        result = self.data.squeeze(axis=axis)
-        if isinstance(result, DataArray):
-            return replace(self, data=result)
-        return result
+        pass
 
+    @abstractmethod
     def _eig(self) -> tuple[Array, QArray]:
-        evals, evecs = self.data._eig()
-        return evals, replace(self, data=evecs)
+        pass
 
+    @abstractmethod
     def _eigh(self) -> tuple[Array, Array]:
-        return self.data._eigh()
+        pass
 
+    @abstractmethod
     def _eigvals(self) -> Array:
-        return self.data._eigvals()
+        pass
 
+    @abstractmethod
     def _eigvalsh(self) -> Array:
-        return self.data._eigvalsh()
+        pass
 
+    @abstractmethod
     def devices(self) -> set[Device]:
-        return self.data.devices()
+        pass
 
+    @abstractmethod
     def isherm(self, rtol: float = 1e-5, atol: float = 1e-8) -> bool:
-        return self.data.isherm(rtol=rtol, atol=atol)
+        pass
 
+    @abstractmethod
     def block_until_ready(self) -> QArray:
-        self.data.block_until_ready()
-        return self
+        pass
 
     # === Quantum methods ===
 
+    @abstractmethod
     def ptrace(self, *keep: int) -> QArray:
-        from ..utils.general import ptrace  # noqa: PLC0415
-
-        return ptrace(self.data.to_jax(), keep, self.dims)
+        pass
 
     def cosm(self) -> QArray:
         from ..utils import cosm  # noqa: PLC0415
@@ -434,28 +415,31 @@ class QArray(eqx.Module):
 
     # === Conversion methods ===
 
+    @abstractmethod
     def to_qutip(self) -> Qobj | list[Qobj]:
-        from .dense_dataarray import array_to_qobj_list  # noqa: PLC0415
+        pass
 
-        return array_to_qobj_list(self.data.to_jax(), self.dims)
-
+    @abstractmethod
     def to_jax(self) -> Array:
-        return self.data.to_jax()
+        pass
 
+    @abstractmethod
     def to_numpy(self) -> np.ndarray:
-        return np.asarray(self.data)
+        pass
 
+    @abstractmethod
     def __array__(self, dtype=None, copy=None) -> np.ndarray:  # noqa: ANN001
-        return self.data.__array__(dtype=dtype, copy=copy)
+        pass
 
+    @abstractmethod
     def asdense(self) -> QArray:
         """Converts to a dense layout.
 
         Returns:
             A qarray with dense data layout.
         """
-        return replace(self, data=self.data.asdense())
 
+    @abstractmethod
     def assparsedia(self, offsets: tuple[int, ...] | None = None) -> QArray:
         """Converts to a sparse diagonal layout.
 
@@ -468,7 +452,6 @@ class QArray(eqx.Module):
         Returns:
             A qarray with sparse diagonal data layout.
         """
-        return replace(self, data=self.data.assparsedia(offsets))
 
     def __len__(self) -> int:
         try:
@@ -478,30 +461,18 @@ class QArray(eqx.Module):
 
     # === Repr ===
 
+    @abstractmethod
     def __repr__(self) -> str:
-        res = (
-            f'QArray: shape={self.shape}, dims={self.dims}, dtype={self.dtype}, '
-            f'layout={self.layout}'
-        )
-        if self.vectorized:
-            res += f', vectorized={self.vectorized}'
-        res += self.data._repr_extra()
-        return res
+        pass
 
     # === Arithmetic operations ===
 
     def __neg__(self) -> QArray:
         return self * (-1)
 
+    @abstractmethod
     def __mul__(self, y: ArrayLike) -> QArray:
-        if not is_batched_scalar(y):
-            raise NotImplementedError(
-                'Element-wise multiplication of two qarrays with the `*` operator is '
-                'not supported. For matrix multiplication, use `x @ y`. For '
-                'element-wise multiplication, use `x.elmul(y)`.'
-            )
-        result = self.data * y
-        return replace(self, data=result)
+        pass
 
     def __rmul__(self, y: QArrayLike) -> QArray:
         return self * y
@@ -518,30 +489,9 @@ class QArray(eqx.Module):
         for i in range(self.shape[0]):
             yield self[i]
 
+    @abstractmethod
     def __add__(self, y: QArrayLike) -> QArray:
-        if isinstance(y, int | float) and y == 0:
-            return self
-
-        if is_batched_scalar(y):
-            raise NotImplementedError(
-                'Adding a scalar to a qarray with the `+` operator is not supported. '
-                'To add a scaled identity matrix, use `x + scalar * dq.eye_like(x)`.'
-                ' To add a scalar, use `x.addscalar(scalar)`.'
-            )
-
-        if isinstance(y, QArray):
-            check_compatible_dims(self.dims, y.dims)
-            result = self.data + y.data
-        elif isqarraylike(y):
-            result = self.data + to_jax(y)
-        else:
-            return NotImplemented
-
-        if result is NotImplemented:
-            return NotImplemented
-        if isinstance(result, DataArray):
-            return replace(self, data=result)
-        return result
+        pass
 
     def __radd__(self, y: QArrayLike) -> QArray:
         return self.__add__(y)
@@ -552,79 +502,17 @@ class QArray(eqx.Module):
     def __rsub__(self, y: QArrayLike) -> QArray:
         return -self + y
 
+    @abstractmethod
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
-        if isinstance(y, QArray):
-            check_compatible_dims(self.dims, y.dims)
-            y_data = y.data
-        elif is_batched_scalar(y):
-            raise TypeError('Attempted matrix product between a scalar and a qarray.')
-        elif isqarraylike(y):
-            y_data = to_jax(y)
-        else:
-            return NotImplemented
+        pass
 
-        result = self.data @ y_data
-        if result is NotImplemented:
-            # try reverse dispatch
-            if hasattr(y_data, '__rmatmul__'):
-                result = y_data.__rmatmul__(self.data)
-            # if still NotImplemented, raise it
-            if result is NotImplemented:
-                return NotImplemented
-
-        # bra @ ket → scalar
-        if (
-            isinstance(y, QArray)
-            and self.isbra()
-            and y.isket()
-            and isinstance(result, DataArray)
-        ):
-            result = result.to_jax()
-
-        if isinstance(result, DataArray):
-            return replace(self, data=result)
-        return result
-
+    @abstractmethod
     def __rmatmul__(self, y: QArrayLike) -> QArray:
-        if isinstance(y, QArray):
-            check_compatible_dims(self.dims, y.dims)
-            y_data = y.data
-        elif is_batched_scalar(y):
-            raise TypeError('Attempted matrix product between a scalar and a qarray.')
-        elif isqarraylike(y):
-            y_data = to_jax(y)
-        else:
-            return NotImplemented
+        pass
 
-        # y_data @ self.data
-        if isinstance(y_data, DataArray):
-            result = y_data @ self.data
-        else:
-            # y_data is a raw array; use DataArray's __rmatmul__
-            result = self.data.__rmatmul__(y_data)
-
-        if result is NotImplemented:
-            return NotImplemented
-
-        if isinstance(result, DataArray):
-            return replace(self, data=result)
-        return result
-
+    @abstractmethod
     def __and__(self, y: QArray) -> QArray:
-        if not isinstance(y, QArray):
-            return NotImplemented
-
-        result = self.data & y.data
-        if result is NotImplemented:
-            # try reverse dispatch
-            if hasattr(y.data, '__rand__'):
-                result = y.data.__rand__(self.data)
-            # if still NotImplemented, raise it
-            if result is NotImplemented:
-                return NotImplemented
-
-        new_dims = self.dims + y.dims
-        return replace(self, dims=new_dims, data=result)
+        pass
 
     def __pow__(self, power: int | _Metaω) -> QArray:
         # to deal with the x**ω notation from equinox (used in diffrax internals)
@@ -637,6 +525,7 @@ class QArray(eqx.Module):
             'element-wise power, use `x.elpow(power)`.'
         )
 
+    @abstractmethod
     def addscalar(self, y: ArrayLike) -> QArray:
         """Adds a scalar.
 
@@ -646,8 +535,8 @@ class QArray(eqx.Module):
         Returns:
             New qarray resulting from the addition with the scalar.
         """
-        return replace(self, data=self.data + jnp.asarray(y))
 
+    @abstractmethod
     def elmul(self, y: QArrayLike) -> QArray:
         """Computes the element-wise multiplication.
 
@@ -657,20 +546,8 @@ class QArray(eqx.Module):
         Returns:
             New qarray resulting from the element-wise multiplication.
         """
-        if isinstance(y, QArray):
-            check_compatible_dims(self.dims, y.dims)
-            result = self.data * y.data
-        elif isqarraylike(y):
-            result = self.data * to_jax(y)
-        else:
-            return NotImplemented
 
-        if result is NotImplemented:
-            return NotImplemented
-        if isinstance(result, DataArray):
-            return replace(self, data=result)
-        return result
-
+    @abstractmethod
     def elpow(self, power: int) -> QArray:
         """Computes the element-wise power.
 
@@ -680,11 +557,10 @@ class QArray(eqx.Module):
         Returns:
             New qarray with elements raised to the specified power.
         """
-        return replace(self, data=self.data**power)
 
+    @abstractmethod
     def __getitem__(self, key: IndexType) -> QArray:
-        result = self.data[key]
-        return replace(self, data=result)
+        pass
 
 
 def check_compatible_dims(dims1: tuple[int, ...], dims2: tuple[int, ...]):

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -211,15 +211,24 @@ class QArray(eqx.Module):
     """  # noqa: E501
 
     dims: tuple[int, ...] = eqx.field(static=True)
+    # TODO: make `vectorized` compatible with `CompositeQArray`. For now, the two
+    # are mutually exclusive (a composite qarray cannot be vectorized), so this
+    # attribute lives only on `MaterializedQArray`. Supporting both together will
+    # require careful handling of shapes and indexing across subsystems.
 
     # Increase __array_priority__ to ensure that a qarray is always returned during an
     # arithmetic operation with a NumPy array. In JAX, it is set to 100 for arrays, and
     # in NumPy it is set to 0.
     __array_priority__ = 200
 
-    @abstractmethod
     def __check_init__(self):
-        pass
+        # === ensure dims is a tuple of ints
+        if not isinstance(self.dims, tuple) or not all(
+            isinstance(d, int) for d in self.dims
+        ):
+            raise TypeError(
+                f'Argument `dims` must be a tuple of ints, but is {self.dims}.'
+            )
 
     # === Properties delegated to DataArray ===
 

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -10,6 +10,7 @@ from qutip import Qobj
 
 from .dense_dataarray import DenseDataArray, array_to_qobj_list
 from .layout import Layout, dense
+from .materialized_qarray import MaterializedQArray
 from .qarray import QArray, QArrayLike, get_dims, isqarraylike, to_jax, to_numpy
 from .sparsedia_dataarray import SparseDIADataArray
 from .sparsedia_primitives import (
@@ -98,7 +99,7 @@ def _asdense(x: QArrayLike, dims: tuple[int, ...] | None) -> QArray:
     xdims = get_dims(x)
     x = to_jax(x)
     dims = init_dims(xdims, dims, x.shape)
-    return QArray(dims, False, DenseDataArray(x))
+    return MaterializedQArray(dims, False, DenseDataArray(x))
 
 
 def _assparsedia(
@@ -114,13 +115,13 @@ def _assparsedia(
         x_jax = x.to_jax()
         dims = init_dims(xdims, dims, x_jax.shape)
         offsets, diags = array_to_sparsedia(x_jax, offsets)
-        return QArray(dims, False, SparseDIADataArray(offsets, diags))
+        return MaterializedQArray(dims, False, SparseDIADataArray(offsets, diags))
 
     xdims = get_dims(x)
     x = to_jax(x)
     dims = init_dims(xdims, dims, x.shape)
     offsets, diags = array_to_sparsedia(x, offsets)
-    return QArray(dims, False, SparseDIADataArray(offsets, diags))
+    return MaterializedQArray(dims, False, SparseDIADataArray(offsets, diags))
 
 
 def init_dims(
@@ -189,14 +190,14 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
     # stack inputs depending on data type
     if all(isinstance(q.data, DenseDataArray) for q in qarrays):
         data = jnp.stack([q.data.data for q in qarrays], axis=axis)
-        return QArray(dims, False, DenseDataArray(data))
+        return MaterializedQArray(dims, False, DenseDataArray(data))
     elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays):
         offsets, diags = stack_sparsedia(
             [q.data.offsets for q in qarrays],
             [q.data.diags for q in qarrays],
             axis=axis,
         )
-        return QArray(dims, False, SparseDIADataArray(offsets, diags))
+        return MaterializedQArray(dims, False, SparseDIADataArray(offsets, diags))
     else:
         raise NotImplementedError(
             'Stacking qarrays with different data types is not implemented.'
@@ -305,7 +306,7 @@ def sparsedia_from_dict(
     dims = (shape[-1],) if dims is None else dims
     _assert_dims_match_shape(dims, shape)
 
-    return QArray(dims, False, SparseDIADataArray(offsets, diags))
+    return MaterializedQArray(dims, False, SparseDIADataArray(offsets, diags))
 
 
 def _assert_dims_match_shape(dims: tuple[int, ...], shape: tuple[int, ...]):

--- a/dynamiqs/utils/operators.py
+++ b/dynamiqs/utils/operators.py
@@ -8,6 +8,7 @@ from jax.typing import ArrayLike
 
 from .._utils import cdtype
 from ..qarrays.layout import Layout, dense, get_layout
+from ..qarrays.materialized_qarray import MaterializedQArray
 from ..qarrays.qarray import QArray, QArrayLike, get_dims
 from ..qarrays.sparsedia_dataarray import SparseDIADataArray
 from ..qarrays.utils import asqarray, init_dims, sparsedia_from_dict, stack, to_jax
@@ -188,7 +189,7 @@ def zeros(*dims: int, layout: Layout | None = None) -> QArray:
         return asqarray(array, dims=dims)
     else:
         diags = jnp.zeros((0, dim), dtype=cdtype())
-        return QArray(dims, False, SparseDIADataArray((), diags))
+        return MaterializedQArray(dims, False, SparseDIADataArray((), diags))
 
 
 def zeros_like(

--- a/tests/qarrays/test_sparse_dia_qarray.py
+++ b/tests/qarrays/test_sparse_dia_qarray.py
@@ -6,6 +6,7 @@ import pytest
 from equinox import EquinoxRuntimeError
 
 import dynamiqs as dq
+from dynamiqs.qarrays.materialized_qarray import MaterializedQArray
 from dynamiqs.qarrays.sparsedia_dataarray import SparseDIADataArray
 
 from ..order import TEST_SHORT
@@ -52,7 +53,7 @@ class TestSparseDIAQArray:
             batch_broadcast=dq.stack([x, 2 * x]).reshape(2, 1, N, N),
         )
 
-        sparseA = dq.QArray((N,), False, SparseDIADataArray(offsetsA, diagsA))
+        sparseA = MaterializedQArray((N,), False, SparseDIADataArray(offsetsA, diagsA))
         denseA = sparseA.asdense()
 
         self.denseA = make_dictA(denseA)
@@ -65,7 +66,7 @@ class TestSparseDIAQArray:
             batch_broadcast=dq.stack([x, 2 * x, 3 * x]).reshape(1, 3, N, N),
         )
 
-        sparseB = dq.QArray((N,), False, SparseDIADataArray(offsetsB, diagsB))
+        sparseB = MaterializedQArray((N,), False, SparseDIADataArray(offsetsB, diagsB))
         denseB = sparseB.asdense()
 
         self.denseB = make_dictB(denseB)


### PR DESCRIPTION
**Prerequisite for the composite QArray feature. This PR does *not* implement `CompositeQArray`.**

linked to https://github.com/dynamiqs/dynamiqs/pull/1091 and https://github.com/dynamiqs/dynamiqs/pull/1091#pullrequestreview-4407719420

It turns the old concrete `QArray` into an abstract base class and moves the existing
implementation, unchanged in behavior, into a new concrete `MaterializedQArray`. The
target structure (PR implemnets only the first branch) :

```
QArray (abstract)
│
├── MaterializedQArray (concrete)
│   └── data : DataArray (abstract)
│       ├── DenseDataArray (concrete)
│       └── SparseDIADataArray (concrete)
│
└── CompositeQArray (concrete)
    └── terms : list[CompositeTerm]
        └── operators : list[MaterializedQArray]
            └── data : DataArray (abstract)
                ├── DenseDataArray (concrete)
                └── SparseDIADataArray (concrete)
```

The point of review is the placement decision made for every member of the old `QArray`.
Each was classified as **materialized-specific** (stays out of the base),
**abstract** (shared signature, per-subclass impl), or **concrete** (defined once in the
base, inherited). Lists below.

## Attributes (fields / class attrs)

- `dims` (static `eqx.field`) — **concrete in base**
- `__array_priority__ = 200` — **concrete in base**
- `data: DataArray` — **materialized-specific**
- `vectorized: bool` — **materialized-specific**

## Properties

- `dtype`, `layout`, `shape`, `mT`, `ndim` — **abstract**
- `ndiags` — **materialized-specific** (sparse-dia only)

## Methods

Abstract (signature in base, implemented per subclass):

- structure/shape: `reshape`, `_reshape_unchecked`, `broadcast_to`, `squeeze`, `sum`,
  `__getitem__`
- linalg: `conj`, `powm`, `expm`, `norm`, `trace`, `_eig`, `_eigh`, `_eigvals`,
  `_eigvalsh`, `isherm`
- element-wise: `addscalar`, `elmul`, `elpow`
- arithmetic primitives: `__mul__`, `__add__`, `__matmul__`, `__rmatmul__`, `__and__`
- quantum: `ptrace`
- conversion: `to_qutip`, `to_jax`, `to_numpy`, `__array__`, `asdense`, `assparsedia`
- infra: `__check_init__`, `__repr__`, `devices`, `block_until_ready`

Concrete in base (written purely on top of the abstract primitives — subclasses get them
for free):

- `dag` (← `mT` + `conj`)
- `mean` (← `sum`, `shape`, `ndim`) — promoted from the concrete override this PR
- `unit` (← `norm`)
- derived arithmetic: `__neg__`, `__rmul__`, `__truediv__`, `__rtruediv__`, `__radd__`,
  `__sub__`, `__rsub__`, `__pow__` (handles the diffrax `_Metaω` case)
- iteration: `__len__`, `__iter__`
- utils shortcuts: `cosm`, `sinm`, `signm`, `isket`, `isbra`, `isdm`, `isop`, `toket`,
  `tobra`, `todm`, `proj`

## Notes for reviewers

- Choice of most uncertainty is the utils shortcut just above i am not sure if we can keep them concrete.

## Other changed files

`mepropagator.py`, `qarrays/__init__.py`, `qarrays/utils.py`, `utils/operators.py`,
`test_sparse_dia_qarray.py` are stale `QArray` constructions/imports updated to
`MaterializedQArray`.