### PR TITLE
Add HigherOrder gradient mode for Hessian computation in sesolve and mesolve

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ docs/figs_docs/**
 
 # uv lock file
 uv.lock
+
+dynamiqs/bin/
+dynamiqs/lib/
+dynamiqs/share/
+dynamiqs/pyvenv.cfg
+dynamiqs1/
+.venv/

--- a/dynamiqs/gradient.py
+++ b/dynamiqs/gradient.py
@@ -4,7 +4,7 @@ import equinox as eqx
 
 from ._utils import tree_str_inline
 
-__all__ = ['Direct', 'BackwardCheckpointed', 'Forward', 'Gradient']
+__all__ = ['Direct', 'BackwardCheckpointed', 'Forward', 'Gradient', 'HigherOrder']
 
 
 class Gradient(eqx.Module):
@@ -106,5 +106,16 @@ class Forward(Gradient):
     """
 
     # dummy init to have the signature in the documentation
+    def __init__(self):
+        pass
+
+
+class HigherOrder(Gradient):
+    """Gradient mode supporting higher-order autodiff (e.g. Hessians).
+
+    Uses diffrax.DirectAdjoint with scan_kind="bounded" internally so that the
+    solve can be differentiated more than once (e.g. via jax.hessian).
+    """
+
     def __init__(self):
         pass

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -11,7 +11,7 @@ from jaxtyping import PyTree, Scalar
 
 from ..._checks import check_hermitian
 from ..._utils import obj_type_str
-from ...gradient import BackwardCheckpointed, Direct, Forward, Gradient
+from ...gradient import BackwardCheckpointed, Direct, Forward, Gradient, HigherOrder
 from ...method import Dopri5, Dopri8, Euler, Kvaerno3, Kvaerno5, Method, Tsit5
 from ...options import Options
 from ...result import MESolveResult, Result, Saved
@@ -71,6 +71,17 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             )
 
     @property
+    def solver(self) -> dx.AbstractSolver:
+        if isinstance(self.gradient, HigherOrder) and not self.fixed_step:
+            return eqx.tree_at(
+                lambda s: s.scan_kind,
+                self.diffrax_solver,
+                'bounded',
+                is_leaf=lambda x: x is None,
+            )
+        return self.diffrax_solver
+
+    @property
     def dt0(self) -> float | None:
         return self.method.dt if self.fixed_step else None
 
@@ -92,7 +103,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             return dx.RecursiveCheckpointAdjoint(self.gradient.ncheckpoints)
         elif isinstance(self.gradient, Forward):
             return dx.ForwardMode()
-        elif isinstance(self.gradient, Direct):
+        elif isinstance(self.gradient, (Direct, HigherOrder)):
             return dx.DirectAdjoint()
         else:
             raise TypeError(f'Unknown gradient type {obj_type_str(self.gradient)}.')
@@ -127,7 +138,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
             # === solve differential equation with diffrax
             return dx.diffeqsolve(
                 self.terms,
-                self.diffrax_solver,
+                self.solver,
                 t0=t0,
                 t1=t1,
                 dt0=self.dt0,

--- a/dynamiqs/method.py
+++ b/dynamiqs/method.py
@@ -9,7 +9,7 @@ from jaxtyping import PRNGKeyArray
 from optimistix import AbstractRootFinder
 
 from ._utils import tree_str_inline
-from .gradient import BackwardCheckpointed, Direct, Forward, Gradient
+from .gradient import BackwardCheckpointed, Direct, Forward, Gradient, HigherOrder
 
 __all__ = [
     'Dopri5',
@@ -152,6 +152,7 @@ class Euler(_DEFixedStep):
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -379,6 +380,7 @@ class Dopri5(_DEAdaptiveStep):
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -420,6 +422,7 @@ class Dopri8(_DEAdaptiveStep):
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation
@@ -461,6 +464,7 @@ class Tsit5(_DEAdaptiveStep):
         Direct,
         BackwardCheckpointed,
         Forward,
+        HigherOrder,
     )
 
     # dummy init to have the signature in the documentation

--- a/tests/integrator_tester.py
+++ b/tests/integrator_tester.py
@@ -95,3 +95,32 @@ class IntegratorTester:
         logging.warning(f'grads_Esave      = {grads_Esave}')
 
         assert_allclose(true_grads_ysave, grads_ysave)
+
+    def _test_hessian(
+        self, system, method, gradient, *, rtol: float = 1e-2, atol: float = 1e-2
+    ):
+        # index of the observable to test (HQubit has a single observable)
+        i_expect = 0
+        t_final = system.tsave[-1]
+
+        # scalar loss: final-time loss of the chosen expectation value, as a
+        # function of the system parameters
+        def loss(params):
+            result = system.run(method, gradient=gradient, params=params)
+            # result.expects has shape (n_expect, ntsave)
+            expect = result.expects[i_expect, -1]
+            return system.loss_expect(expect)
+
+        # computed Hessian wrt the parameters PyTree
+        computed = jax.hessian(loss)(system.params_default)
+
+        # analytical Hessian for this observable at the final time
+        expected = system.hess_expect(t_final)
+
+        # compare leaf-by-leaf over the Params PyTree
+        for c_leaf, e_leaf in zip(
+            jax.tree_util.tree_leaves(computed),
+            jax.tree_util.tree_leaves(expected),
+            strict=False,
+        ):
+            assert jnp.allclose(c_leaf, jnp.asarray(e_leaf), rtol=rtol, atol=atol)

--- a/tests/mesolve/test_hessian.py
+++ b/tests/mesolve/test_hessian.py
@@ -1,0 +1,15 @@
+import pytest
+
+from dynamiqs.gradient import HigherOrder
+from dynamiqs.method import Dopri5, Dopri8, Tsit5
+
+from ..integrator_tester import IntegratorTester
+from ..order import TEST_LONG
+from ..systems import mesolve_hqubit
+
+
+@pytest.mark.run(order=TEST_LONG)
+class TestMESolveHessian(IntegratorTester):
+    @pytest.mark.parametrize('method', [Tsit5(), Dopri5(), Dopri8()])
+    def test_hessian(self, method):
+        self._test_hessian(mesolve_hqubit, method, HigherOrder(), rtol=1e-2, atol=1e-2)

--- a/tests/sesolve/test_hessian.py
+++ b/tests/sesolve/test_hessian.py
@@ -1,0 +1,15 @@
+import pytest
+
+from dynamiqs.gradient import HigherOrder
+from dynamiqs.method import Dopri5, Dopri8, Tsit5
+
+from ..integrator_tester import IntegratorTester
+from ..order import TEST_LONG
+from ..systems.hessian import hqubit
+
+
+@pytest.mark.run(order=TEST_LONG)
+class TestSESolveHessian(IntegratorTester):
+    @pytest.mark.parametrize('method', [Tsit5(), Dopri5(), Dopri8()])
+    def test_hessian(self, method):
+        self._test_hessian(hqubit, method, HigherOrder(), rtol=1e-2, atol=1e-2)

--- a/tests/systems/__init__.py
+++ b/tests/systems/__init__.py
@@ -2,3 +2,4 @@ from ._system import System
 from .closed_system import dense_cavity, dia_cavity, tdqubit
 from .floquet_qubit import floquet_qubit
 from .open_system import dense_ocavity, dia_ocavity, otdqubit
+from .hessian_mesolve import mesolve_hqubit

--- a/tests/systems/hessian.py
+++ b/tests/systems/hessian.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+from jaxtyping import PyTree, ScalarLike
+
+import dynamiqs as dq
+from dynamiqs import QArray
+from dynamiqs.gradient import Gradient
+from dynamiqs.method import Method
+from dynamiqs.result import Result
+from dynamiqs.time_qarray import TimeQArray
+
+from ._system import System
+
+
+class HQubit(System):
+    class Params(NamedTuple):
+        w: float
+
+    def __init__(self, *, w: float, tsave: Array):
+        self.n = 2
+        self.w = w
+        self.tsave = tsave
+        self.params_default = self.Params(w)
+
+    def H(self, params: PyTree) -> QArray | TimeQArray:
+        return 0.5 * params.w * dq.sigmax()
+
+    def y0(self, params: PyTree) -> QArray:  # noqa: ARG002
+        return dq.basis(2, 0)
+
+    def Es(self, params: PyTree) -> list[QArray]:  # noqa: ARG002
+        return [dq.sigmaz()]
+
+    def expect(self, t: float) -> Array:
+        return jnp.array([jnp.cos(self.w * t)])
+
+    def loss_expect(self, expect: Array) -> Array:
+        return expect.real
+
+    def grads_expect(self, t: float) -> PyTree:
+        grad_w = -t * jnp.sin(self.w * t)
+        return self.Params([grad_w])
+
+    def hess_expect(self, t: float) -> PyTree:
+        """Exact second derivative of each expectation-value loss wrt parameters."""
+        hess_w = -(t**2) * jnp.cos(self.w * t)
+        return self.Params([hess_w])
+
+    def run(
+        self,
+        method: Method,
+        *,
+        gradient: Gradient | None = None,
+        params: PyTree | None = None,
+        t0: ScalarLike | None = None,
+    ) -> Result:
+        params = self.params_default if params is None else params
+        return dq.sesolve(
+            self.H(params),
+            self.y0(params),
+            self.tsave,
+            exp_ops=self.Es(params),
+            method=method,
+            gradient=gradient,
+            t0=t0,
+        )
+
+
+# t_end chosen away from a node of sin/cos so neither the gradient nor the
+# Hessian is accidentally zero
+tsave = np.linspace(0.0, 1.0, 11)
+hqubit = HQubit(w=1.3, tsave=tsave)

--- a/tests/systems/hessian_mesolve.py
+++ b/tests/systems/hessian_mesolve.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import jax.numpy as jnp
+import numpy as np
+from jax import Array
+from jaxtyping import PyTree
+
+import dynamiqs as dq
+from dynamiqs import QArray
+from dynamiqs.time_qarray import TimeQArray
+
+from .open_system import OpenSystem
+
+
+class MeSolveHQubit(OpenSystem):
+    r"""Closed-system mesolve qubit with an analytically known Hessian."""
+
+    class Params(NamedTuple):
+        w: float
+
+    def __init__(self, *, w: float, tsave: Array):
+        self.n = 2
+        self.w = w
+        self.tsave = tsave
+        self.params_default = self.Params(w)
+
+    def H(self, params: PyTree) -> QArray | TimeQArray:
+        return 0.5 * params.w * dq.sigmax()
+
+    def Ls(self, params: PyTree) -> list[QArray | TimeQArray]:  # noqa: ARG002
+        return []
+
+    def y0(self, params: PyTree) -> QArray:  # noqa: ARG002
+        return dq.basis(2, 0)
+
+    def Es(self, params: PyTree) -> list[QArray]:  # noqa: ARG002
+        return [dq.sigmaz()]
+
+    def expect(self, t: float) -> Array:
+        return jnp.array([jnp.cos(self.w * t)])
+
+    def loss_expect(self, expect: Array) -> Array:
+        return expect.real
+
+    def grads_expect(self, t: float) -> PyTree:
+        grad_w = -t * jnp.sin(self.w * t)
+        return self.Params([grad_w])
+
+    def hess_expect(self, t: float) -> PyTree:
+        hess_w = -(t**2) * jnp.cos(self.w * t)
+        return self.Params([hess_w])
+
+
+tsave = np.linspace(0.0, 1.0, 11)
+mesolve_hqubit = MeSolveHQubit(w=1.3, tsave=tsave)


### PR DESCRIPTION
## What this does
Adds a `HigherOrder` gradient mode so you can compute Hessians through
`dq.sesolve()` and `dq.mesolve()`, e.g. `jax.hessian(f)` where `f` calls
`sesolve(..., gradient=dq.gradient.HigherOrder())`. Closes #1082.

Under the hood it uses `diffrax.DirectAdjoint()` with the solver built using
`scan_kind="bounded"`, the setup Diffrax recommends for higher-order autodiff.

## Changes
- `gradient.py`: new `HigherOrder` gradient class.
- `diffrax_integrator.py`: maps `HigherOrder` to `DirectAdjoint`, and sets
  `scan_kind="bounded"` on the solver (adaptive methods only). Since sesolve and
  mesolve share this integrator core, both get Hessian support from the same change.
- `method.py`: allow `HigherOrder` on Tsit5/Dopri5/Dopri8/Euler
- Tests: a qubit `H(ω)=ω/2·σx` where `⟨σz⟩=cos(ωt)`, so the Hessian is
  `−t²cos(ωt)`. The test checks `jax.hessian` matches this across all three methods, for both `sesolve` and `mesolve` (the mesolve case runs the same system as a closed system with no jump operators, `Ls=[]`, so the analytical Hessian is identical).

## Notes
- Existing gradient behavior is untouched; full sesolve/mesolve suite passes
  (159 tests).