### PR TITLE
Pull Request: Add tests for stochastic solvers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
 markers =
     long: mark a test as having a long runtime.
+    run(order): order tests by expected runtime.
 addopts = -p no:doctest

--- a/tests/dsmesolve/test_dsmesolve.py
+++ b/tests/dsmesolve/test_dsmesolve.py
@@ -1,0 +1,104 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+
+from ..order import TEST_LONG
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_against_mesolve_deexcitation(atol=3e-2):
+    ntrajs = 1_000
+    gamma = 0.5
+
+    H = dq.zeros_like(dq.sigmaz())
+    jump_ops = [jnp.sqrt(gamma) * dq.sigmam()]
+    etas = [1.0]
+    rho0 = dq.excited_dm()
+    tsave = jnp.linspace(0.0, 1.0, 11)
+    keys = jax.random.split(jax.random.key(4081), num=ntrajs)
+    exp_ops = [dq.excited_dm(), dq.ground_dm()]
+    method = dq.method.EulerMaruyama(dt=1e-2)
+
+    dsmeresult = dq.dsmesolve(
+        H, jump_ops, etas, rho0, tsave, keys=keys, exp_ops=exp_ops, method=method
+    )
+    meresult = dq.mesolve(
+        H, jump_ops, rho0, tsave, exp_ops=exp_ops, progress_meter=None
+    )
+
+    assert jnp.allclose(dsmeresult.mean_expects(), meresult.expects, atol=atol)
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_no_back_action_protected_subspace(atol=1e-2):
+    # The measured operator acts as the identity on the odd-parity subspace spanned by
+    # |01> and |10>, so the diffusive stochastic terms cancel and preserve the
+    # deterministic Hamiltonian trajectory inside that subspace.
+    ntrajs = 8
+    omega = 1.3
+
+    sx, sy, sz = dq.sigmax(), dq.sigmay(), dq.sigmaz()
+    H = 0.5 * omega * (dq.tensor(sx, sx) + dq.tensor(sy, sy))
+    jump_ops = [-dq.tensor(sz, sz)]
+    etas = [1.0]
+    psi01 = dq.fock((2, 2), (0, 1))
+    psi10 = dq.fock((2, 2), (1, 0))
+    rho0 = psi01.todm()
+    tsave = jnp.linspace(0.0, 1.2, 13)
+    keys = jax.random.split(jax.random.key(4080), num=ntrajs)
+    method = dq.method.Rouchon1(dt=2e-3)
+
+    result = dq.dsmesolve(H, jump_ops, etas, rho0, tsave, keys=keys, method=method)
+
+    exact = (
+        jnp.cos(omega * tsave)[:, None, None] * psi01.to_jax()
+        - 1j * jnp.sin(omega * tsave)[:, None, None] * psi10.to_jax()
+    )
+    exact = dq.asqarray(exact, dims=(2, 2)).todm()
+
+    assert jnp.allclose(result.states.to_jax(), exact.to_jax(), atol=atol)
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_measurement_record_statistics():
+    # For an eigenstate of a Hermitian measurement operator, the state is unchanged and
+    # the saved averaged current satisfies I = sqrt(eta) <L + L†> + ΔW / Δt.
+    ntrajs = 800
+    gamma = 0.7
+    eta = 0.25
+
+    H = dq.zeros_like(dq.sigmaz())
+    jump_ops = [jnp.sqrt(gamma) * dq.sigmaz()]
+    etas = [eta]
+    rho0 = dq.excited_dm()
+    tsave = jnp.linspace(0.0, 1.0, 11)
+    delta_t = tsave[1] - tsave[0]
+    keys = jax.random.split(jax.random.key(4082), num=ntrajs)
+    method = dq.method.EulerMaruyama(dt=1e-2)
+
+    result = dq.dsmesolve(
+        H,
+        jump_ops,
+        etas,
+        rho0,
+        tsave,
+        keys=keys,
+        exp_ops=[dq.excited_dm()],
+        method=method,
+    )
+
+    current = result.measurements[:, 0, :]
+    expected_mean = 2.0 * jnp.sqrt(eta) * jnp.sqrt(gamma)
+    expected_variance = 1.0 / delta_t
+    mean_standard_error = jnp.sqrt(expected_variance / ntrajs)
+    variance_standard_error = expected_variance * jnp.sqrt(2.0 / (ntrajs - 1))
+
+    assert jnp.allclose(result.expects[:, 0, :].real, 1.0, atol=1e-6)
+    assert jnp.allclose(
+        current.mean(axis=0), expected_mean, atol=3.0 * mean_standard_error
+    )
+    assert jnp.allclose(
+        current.var(axis=0), expected_variance, atol=3.0 * variance_standard_error
+    )

--- a/tests/dssesolve/test_dssesolve.py
+++ b/tests/dssesolve/test_dssesolve.py
@@ -1,0 +1,92 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+
+from ..order import TEST_LONG
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_against_mesolve_deexcitation(atol=4e-2):
+    ntrajs = 1000
+    gamma = 0.5
+    H = dq.zeros_like(dq.sigmaz())
+    jump_ops = [jnp.sqrt(gamma) * dq.sigmam()]
+    psi0 = dq.excited()
+    tsave = jnp.linspace(0.0, 1.0, 11)
+    keys = jax.random.split(jax.random.key(2081), num=ntrajs)
+    exp_ops = [dq.excited_dm(), dq.ground_dm()]
+    method = dq.method.EulerMaruyama(dt=1e-2)
+
+    dsseresult = dq.dssesolve(
+        H, jump_ops, psi0, tsave, keys=keys, exp_ops=exp_ops, method=method
+    )
+    meresult = dq.mesolve(
+        H, jump_ops, psi0, tsave, exp_ops=exp_ops, progress_meter=None
+    )
+
+    assert jnp.allclose(dsseresult.mean_expects(), meresult.expects, atol=atol)
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_no_back_action_protected_subspace(atol=1e-3):
+    # The measurement operator is the identity on the odd-parity subspace spanned by
+    # |01> and |10>, so the diffusive stochastic terms cancel trajectory by trajectory.
+    ntrajs = 8
+    omega = 1.3
+
+    sx, sy, sz = dq.sigmax(), dq.sigmay(), dq.sigmaz()
+    H = 0.5 * omega * (dq.tensor(sx, sx) + dq.tensor(sy, sy))
+    jump_ops = [-dq.tensor(sz, sz)]
+    psi01 = dq.fock((2, 2), (0, 1))
+    psi10 = dq.fock((2, 2), (1, 0))
+    tsave = jnp.linspace(0.0, 1.2, 13)
+    keys = jax.random.split(jax.random.key(2079), num=ntrajs)
+    method = dq.method.Rouchon1(dt=1e-2)
+
+    result = dq.dssesolve(H, jump_ops, psi01, tsave, keys=keys, method=method)
+
+    exact = (
+        jnp.cos(omega * tsave)[:, None, None] * psi01.to_jax()
+        - 1j * jnp.sin(omega * tsave)[:, None, None] * psi10.to_jax()
+    )
+    exact = dq.asqarray(exact, dims=(2, 2))
+
+    infidelity = 1.0 - dq.overlap(exact, result.states)
+    assert jnp.allclose(infidelity, 0.0, atol=atol)
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_measurement_record_statistics():
+    # For an eigenstate of a Hermitian measurement operator, the state is unchanged and
+    # the saved averaged current satisfies I = <L + L†> + ΔW / Δt. Thus its mean and
+    # variance are known analytically over each saved interval.
+    ntrajs = 800
+    gamma = 0.7
+
+    H = dq.zeros_like(dq.sigmaz())
+    jump_ops = [jnp.sqrt(gamma) * dq.sigmaz()]
+    psi0 = dq.excited()
+    tsave = jnp.linspace(0.0, 1.0, 11)
+    delta_t = tsave[1] - tsave[0]
+    keys = jax.random.split(jax.random.key(2080), num=ntrajs)
+    method = dq.method.EulerMaruyama(dt=1e-2)
+
+    result = dq.dssesolve(
+        H, jump_ops, psi0, tsave, keys=keys, exp_ops=[dq.excited_dm()], method=method
+    )
+
+    current = result.measurements[:, 0, :]
+    expected_mean = 2 * jnp.sqrt(gamma)
+    expected_variance = 1.0 / delta_t
+    mean_standard_error = jnp.sqrt(expected_variance / ntrajs)
+    variance_standard_error = expected_variance * jnp.sqrt(2.0 / (ntrajs - 1))
+
+    assert jnp.allclose(result.expects[:, 0, :].real, 1.0, atol=1e-6)
+    assert jnp.allclose(
+        current.mean(axis=0), expected_mean, atol=3.0 * mean_standard_error
+    )
+    assert jnp.allclose(
+        current.var(axis=0), expected_variance, atol=3.0 * variance_standard_error
+    )

--- a/tests/jsmesolve/test_batching.py
+++ b/tests/jsmesolve/test_batching.py
@@ -8,7 +8,6 @@ from ..order import TEST_SHORT
 
 # ── key batching test ────────────────────────────────────────────────────────
 
-
 @pytest.mark.run(order=TEST_SHORT)
 @pytest.mark.parametrize('cartesian_batching', [True, False])
 @pytest.mark.parametrize(

--- a/tests/jsmesolve/test_jsmesolve.py
+++ b/tests/jsmesolve/test_jsmesolve.py
@@ -1,0 +1,128 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+
+from ..order import TEST_LONG
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_no_back_action_protected_subspace(atol=1e-2):
+    # The jump operator is the identity on the odd-parity subspace spanned by
+    # |01> and |10>, so stochastic clicks must not perturb the deterministic
+    # Hamiltonian trajectory inside that subspace.
+    ntrajs = 8
+    omega = 1.3
+
+    sx, sy, sz = dq.sigmax(), dq.sigmay(), dq.sigmaz()
+    H = 0.5 * omega * (dq.tensor(sx, sx) + dq.tensor(sy, sy))
+    jump_ops = [-dq.tensor(sz, sz)]
+    thetas = [0.0]
+    etas = [1.0]
+    psi01 = dq.fock((2, 2), (0, 1))
+    psi10 = dq.fock((2, 2), (1, 0))
+    rho0 = psi01.todm()
+    tsave = jnp.linspace(0.0, 1.2, 13)
+    keys = jax.random.split(jax.random.key(3080), num=ntrajs)
+    method = dq.method.EulerJump(dt=2e-3)
+
+    result = dq.jsmesolve(
+        H, jump_ops, thetas, etas, rho0, tsave, keys=keys, method=method, nmaxclick=16
+    )
+
+    exact = (
+        jnp.cos(omega * tsave)[:, None, None] * psi01.to_jax()
+        - 1j * jnp.sin(omega * tsave)[:, None, None] * psi10.to_jax()
+    )
+    exact = dq.asqarray(exact, dims=(2, 2)).todm()
+
+    assert jnp.allclose(result.states.to_jax(), exact.to_jax(), atol=atol)
+    assert jnp.any(result.nclicks > 0)
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_deexcitation_bernoulli_statistics(atol=5e-2):
+    # For an ideal detector monitoring L=sqrt(gamma) sigma_-, each trajectory is either
+    # still excited or has emitted one jump. With the fixed-step jump method, the exact
+    # no-click probability at saved times is (1 - gamma * dt) ** nsteps.
+    ntrajs = 800
+    gamma = 0.8
+    dt = 1e-2
+
+    H = dq.zeros_like(dq.sigmaz())
+    jump_ops = [jnp.sqrt(gamma) * dq.sigmam()]
+    thetas = [0.0]
+    etas = [1.0]
+    rho0 = dq.excited_dm()
+    tsave = jnp.linspace(0.0, 2.0, 21)
+    keys = jax.random.split(jax.random.key(3081), num=ntrajs)
+    method = dq.method.EulerJump(dt=dt)
+
+    result = dq.jsmesolve(
+        H,
+        jump_ops,
+        thetas,
+        etas,
+        rho0,
+        tsave,
+        keys=keys,
+        exp_ops=[dq.excited_dm()],
+        method=method,
+        nmaxclick=2,
+    )
+
+    excited_population = result.expects[:, 0, :].real
+    expected_mean = (1.0 - gamma * dt) ** jnp.rint(tsave / dt)
+    expected_variance = expected_mean * (1.0 - expected_mean)
+
+    assert jnp.allclose(excited_population * (1.0 - excited_population), 0.0, atol=1e-6)
+    assert jnp.allclose(excited_population.mean(axis=0), expected_mean, atol=atol)
+    assert jnp.allclose(excited_population.var(axis=0), expected_variance, atol=atol)
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_dark_count_statistics():
+    # With a zero jump operator and nonzero dark-count rate, clicks are independent of
+    # the quantum state. The number of clicks over the integration is binomial over the
+    # fixed time steps with probability theta * dt per step.
+    ntrajs = 1_000
+    theta = 0.4
+    dt = 1e-2
+    t1 = 1.0
+
+    H = dq.zeros_like(dq.sigmaz())
+    jump_ops = [dq.zeros_like(dq.sigmaz())]
+    thetas = [theta]
+    etas = [1.0]
+    rho0 = dq.excited_dm()
+    tsave = jnp.linspace(0.0, t1, 11)
+    keys = jax.random.split(jax.random.key(3082), num=ntrajs)
+    method = dq.method.EulerJump(dt=dt)
+
+    result = dq.jsmesolve(
+        H,
+        jump_ops,
+        thetas,
+        etas,
+        rho0,
+        tsave,
+        keys=keys,
+        exp_ops=[dq.excited_dm()],
+        method=method,
+        nmaxclick=8,
+    )
+
+    nsteps = round(t1 / dt)
+    click_probability = theta * dt
+    expected_mean = nsteps * click_probability
+    expected_variance = nsteps * click_probability * (1.0 - click_probability)
+    mean_standard_error = jnp.sqrt(expected_variance / ntrajs)
+    variance_standard_error = expected_variance * jnp.sqrt(2.0 / (ntrajs - 1))
+    nclicks = result.nclicks[:, 0]
+
+    assert jnp.allclose(result.expects[:, 0, :].real, 1.0, atol=1e-6)
+    assert jnp.allclose(nclicks.mean(), expected_mean, atol=3.0 * mean_standard_error)
+    assert jnp.allclose(
+        nclicks.var(), expected_variance, atol=3.0 * variance_standard_error
+    )

--- a/tests/jssesolve/test_jssesolve.py
+++ b/tests/jssesolve/test_jssesolve.py
@@ -8,7 +8,6 @@ import dynamiqs as dq
 
 from ..order import TEST_LONG
 
-
 @pytest.mark.run(order=TEST_LONG)
 @pytest.mark.parametrize('smart_sampling', [True, False])
 def test_against_mesolve_oscillator(smart_sampling, atol=1e-2):
@@ -76,3 +75,64 @@ def test_against_mesolve_qubit(smart_sampling, atol=1e-2):
     assert jnp.allclose(
         meresult.states.to_jax(), jsseresult.mean_states().to_jax(), atol=atol
     )
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_no_back_action_protected_subspace(atol=1e-5):
+    # The jump operator is the identity on the odd-parity subspace spanned by
+    # |01> and |10>, so stochastic clicks must not perturb the trajectory.
+    ntrajs = 16
+    omega = 1.3
+
+    sx, sy, sz = dq.sigmax(), dq.sigmay(), dq.sigmaz()
+    H = 0.5 * omega * (dq.tensor(sx, sx) + dq.tensor(sy, sy))
+    jump_ops = [-dq.tensor(sz, sz)]
+    psi01 = dq.fock((2, 2), (0, 1))
+    psi10 = dq.fock((2, 2), (1, 0))
+    tsave = jnp.linspace(0.0, 1.2, 13)
+    keys = jax.random.split(jax.random.key(1079), num=ntrajs)
+    method = dq.method.Event(dtmax=1e-2)
+
+    result = dq.jssesolve(
+        H, jump_ops, psi01, tsave, keys=keys, method=method, nmaxclick=32
+    )
+
+    exact = (
+        jnp.cos(omega * tsave)[:, None, None] * psi01.to_jax()
+        - 1j * jnp.sin(omega * tsave)[:, None, None] * psi10.to_jax()
+    )
+    exact = dq.asqarray(exact, dims=(2, 2))
+
+    infidelity = 1.0 - dq.overlap(exact, result.states)
+    assert jnp.allclose(infidelity, 0.0, atol=atol)
+
+
+@pytest.mark.run(order=TEST_LONG)
+def test_deexcitation_bernoulli_statistics(atol=5e-2):
+    # For H=0, L=sqrt(gamma) sigma_-, and psi0=|e>, each trajectory is either
+    # excited or has emitted one jump, with P_e(t) ~ Bernoulli(exp(-gamma t)).
+    ntrajs = 800
+    gamma = 0.8
+    tsave = jnp.linspace(0.0, 2.0, 21)
+    keys = jax.random.split(jax.random.key(1080), num=ntrajs)
+    exp_ops = [dq.excited_dm()]
+    method = dq.method.Event(dtmax=2e-2)
+
+    result = dq.jssesolve(
+        dq.zeros_like(dq.sigmaz()),
+        [jnp.sqrt(gamma) * dq.sigmam()],
+        dq.excited(),
+        tsave,
+        keys=keys,
+        exp_ops=exp_ops,
+        method=method,
+        nmaxclick=2,
+    )
+
+    excited_population = result.expects[:, 0, :].real
+    expected_mean = jnp.exp(-gamma * tsave)
+    expected_variance = expected_mean * (1.0 - expected_mean)
+
+    assert jnp.allclose(excited_population * (1.0 - excited_population), 0.0, atol=1e-5)
+    assert jnp.allclose(excited_population.mean(axis=0), expected_mean, atol=atol)
+    assert jnp.allclose(excited_population.var(axis=0), expected_variance, atol=atol)


### PR DESCRIPTION
<!-- Place the PR description below, stating which issues it resolves. -->

## Pull Request: Add tests for stochastic solvers 

Closes https://github.com/dynamiqs/dynamiqs/issues/1079

## What changed

In this pull request, the four stochastic solvers

- `dq.jssesolve()` — jump stochastic Schrödinger equation solver,
- `dq.dssesolve()` — diffusive stochastic Schrödinger equation solver,
- `dq.jsmesolve()` — jump stochastic master equation solver,
- `dq.dsmesolve()` — diffusive stochastic master equation solver,

 are now accompanied by their testers in the `tests/` directory.

These new tests check the two things that matter most for stochastic integrators:

1. **trajectory-level physics**: when the stochastic measurement back-action should cancel, every trajectory follows the same deterministic analytical solution
2. **ensemble-level physics**: when the stochastic process has known first- and second-order statistics, the simulated mean and variance match those formulas within the expected Monte Carlo accuracy.

That combination is valuable, since they can catch both future update bugs and subtle random-process regressions to converge to the right physics.

### Test 1 — no-back-action protected-subspace trajectory

The shared protected-subspace setup is for testing regression coverage. The measurement operator acts like the identity on the odd-parity subspace

$$
\mathcal{H}_{\mathrm{odd}} = \text{span}\{\lvert 01 \rangle, \lvert 10 \rangle\},
$$

so stochastic clicks or diffusive measurement noise should not create any physical back-action inside that subspace.

The chosen Hamiltonian and Lindblad jump operator are

$$
H = \frac{\omega}{2}\left(\sigma_x \otimes \sigma_x + \sigma_y \otimes \sigma_y\right),
\qquad
L = -\sigma_z \otimes \sigma_z,
$$

with coupling and initial state as

$$
\omega = 1.3,
\qquad
\lvert \psi_0 \rangle = \lvert 01 \rangle.
$$

The analytical state trajectory is in this analytical form:

$$
\lvert \psi(t) \rangle
= \cos(\omega t)\lvert 01 \rangle - i\sin(\omega t)\lvert 10 \rangle.
$$

For density-matrix solvers, the expected density matrix evolves as:

$$
\rho(t) = \lvert \psi(t) \rangle\langle \psi(t) \rvert.
$$

Fix random seed is used in the test.

#### `jssesolve`: jump SSE

File: `tests/jssesolve/test_jssesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 16$,
- $\omega = 1.3$,
- $t \in [0, 1.2]$ with `13` saved points,
- method: `dq.method.Event(dtmax=1e-2)`,
- `nmaxclick = 32`,
- absolute tolerance: $10^{-5}$ on infidelity.

The test computes the error

$$
1 - \left|\langle \psi_{\mathrm{exact}}(t) \mid \psi_{\mathrm{traj}}(t) \rangle\right|^2
$$

for every trajectory and saved time, and asserts it stays at zero within tolerance. This directly verifies that stochastic jump events do not perturb the protected deterministic motion.

Another fix random seed is used in the test.

#### `dssesolve`: diffusive SSE

File: `tests/dssesolve/test_dssesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 8$,
- $\omega = 1.3$,
- $t \in [0, 1.2]$ with `13` saved points,
- method: `dq.method.Rouchon1(dt=1e-2)`,
- tolerance: $10^{-3}$ on infidelity.

The test uses the same protected-subspace analytical ket trajectory as `jssesolve`. The diffusive stochastic term should cancel trajectory by trajectory, so all trajectories remain locked to the exact deterministic state.

#### `jsmesolve`: jump SME

File: `tests/jsmesolve/test_jsmesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 8$,
- $\omega = 1.3$,
- $t \in [0, 1.2]$ with `13` saved points,
- measured channel parameters: $\theta = 0$, $\eta = 1$,
- method: `dq.method.EulerJump(dt=2e-3)`,
- `nmaxclick = 16`,
- absolute tolerance: $10^{-2}$ on density-matrix entries.

The expected object is the density matrix

$$
\rho_{\mathrm{exact}}(t)
= \lvert \psi_{\mathrm{exact}}(t) \rangle
  \langle \psi_{\mathrm{exact}}(t) \rvert.
$$

The test compares every stochastic SME trajectory against $\rho_{\mathrm{exact}}(t)$ and also confirms that clicks actually occur in the run. That last check is a sanity check: the test is not passing because the stochastic part is dormant. It is passing because the stochastic back-action is physically harmless in this protected subspace.

Another fix random seed is used in the test.

#### `dsmesolve`: diffusive SME

File: `tests/dsmesolve/test_dsmesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 8$,
- $\omega = 1.3$,
- $t \in [0, 1.2]$ with `13` saved points,
- measurement efficiency: $\eta = 1$,
- method: `dq.method.Rouchon1(dt=2e-3)`,
- tolerance: $10^{-2}$ on density-matrix entries.

Like `jsmesolve`, this test checks

$$
\rho_{\mathrm{traj}}(t) \approx \rho_{\mathrm{exact}}(t)
$$

for every trajectory. This completes the same protected-subspace physics across all four stochastic APIs.

(Another fix random seed is used in the test.)

### Test 2 — statistical ensemble tests

The second family of tests checks that the random processes have the correct 1st and 2nd-order statistics. The exact quantity differs naturally between jump and diffusive unravelings, they should be basically the same. To do that, we check the following statistical ensembling properties:

#### Jump statistics: Bernoulli de-excitation

The jump solvers use a two-level de-excitation problem with no Hamiltonina:

$$
H = 0,
\qquad
L = \sqrt{\gamma}\sigma_-,
\qquad
\lvert \psi_0 \rangle = \lvert e \rangle.
$$

Each trajectory is either still excited or has emitted a jump, so the excited-state population is Bernoulli-valued.

#### `jssesolve`: event-based Bernoulli statistics

File: `tests/jssesolve/test_jssesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 800$,
- $\gamma = 0.8$,
- $t \in [0, 2]$ with `21` saved points,
- method: `dq.method.Event(dtmax=2e-2)`,
- `nmaxclick = 2`,
- absolute tolerance: $5\times 10^{-2}$.

The analytical survival probability is

$$
p_e(t) = e^{-\gamma t},
$$

and the Bernoulli variance is

$$
\text{Var}[n_e(t)] = p_e(t)\left(1 - p_e(t)\right).
$$

The test verifies that trajectory populations are binary and that both the sample mean and sample variance match these formulas.

#### `jsmesolve`: fixed-step Bernoulli statistics

File: `tests/jsmesolve/test_jsmesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 800$,
- $\gamma = 0.8$,
- $\Delta t = 10^{-2}$,
- $t \in [0, 2]$ with `21` saved points,
- $\theta = 0$,
- $\eta = 1$,
- method: `dq.method.EulerJump(dt=1e-2)`,
- `nmaxclick = 2`,
- absolute tolerance: $5\times 10^{-2}$.

Because this is the fixed-step jump method, the tested survival probability is

$$
p_e(t) = \left(1 - \gamma\Delta t\right)^{\text{round}(t / \Delta t)},
$$

with variance

$$
\text{Var}[n_e(t)] = p_e(t)\left(1 - p_e(t)\right).
$$

This gives `jsmesolve` a direct 1st- and 2nd-order check of its jump statistics.

#### `jsmesolve`: dark-count binomial statistics

File: `tests/jsmesolve/test_jsmesolve.py`

The jump SME also gets an extra dark-count test, which is a great addition because it exercises the SME-only parameter $\theta$.

Key parameters:

- $n_{\mathrm{trajs}} = 1000$,
- $\theta = 0.4$,
- $\Delta t = 10^{-2}$,
- $t_1 = 1.0$,
- zero jump operator: $L = 0$,
- $\eta = 1$,
- method: `dq.method.EulerJump(dt=1e-2)`,
- `nmaxclick = 8`.

The number of dark counts is binomial with

$$
N_{\mathrm{steps}} = \frac{t_1}{\Delta t},
\qquad
p = \theta\Delta t.
$$

The expected mean and variance are

$$
\mathbb{E}[N] = N_{\mathrm{steps}}p,
\qquad
\text{Var}[N] = N_{\mathrm{steps}}p(1-p).
$$

The tolerance is scaled using the sampling uncertainty over $n_{\mathrm{trajs}}$ trajectories.

### Diffusive statistics: measurement-current mean and variance

The diffusive solvers use a Hermitian measurement problem where the state is an eigenstate and the measurement record has an analytical mean and variance.

#### `dssesolve`: ideal diffusive current statistics

File: `tests/dssesolve/test_dssesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 800$,
- $\gamma = 0.7$,
- $H = 0$,
- $L = \sqrt{\gamma}\sigma_z$,
- $\lvert \psi_0 \rangle = \lvert e \rangle$,
- $t \in [0, 1]$ with `11` saved points,
- $\Delta T = t_{k+1} - t_k$,
- method: `dq.method.EulerMaruyama(dt=1e-2)`.

The saved averaged current satisfies

$$
I = \langle L + L^\dagger \rangle + \frac{\Delta W}{\Delta T},
$$

so the analytical mean and variance are

$$
\mathbb{E}[I] = 2\sqrt{\gamma},
\qquad
\text{Var}[I] = \frac{1}{\Delta T}.
$$

The test uses standard-error-scaled tolerances,

$$
\sigma_{\bar I} = \sqrt{\frac{\text{Var}[I]}{n_{\mathrm{trajs}}}},
\qquad
\sigma_{s^2} = \text{Var}[I]\sqrt{\frac{2}{n_{\mathrm{trajs}}-1}},
$$

and checks both mean and variance within $3\sigma$.

#### `dsmesolve`: inefficient diffusive current statistics

File: `tests/dsmesolve/test_dsmesolve.py`

Key parameters:

- $n_{\mathrm{trajs}} = 800$,
- $\gamma = 0.7$,
- $\eta = 0.25$,
- $H = 0$,
- $L = \sqrt{\gamma}\sigma_z$,
- $\rho_0 = \lvert e \rangle\langle e \rvert$,
- $t \in [0, 1]$ with `11` saved points,
- $\Delta T = t_{k+1} - t_k$,
- method: `dq.method.EulerMaruyama(dt=1e-2)`.

The SME measurement current includes the detection efficiency:

$$
I = \sqrt{\eta}\langle L + L^\dagger \rangle + \frac{\Delta W}{\Delta T}.
$$

Therefore

$$
\mathbb{E}[I] = 2\sqrt{\eta}\sqrt{\gamma},
\qquad
\text{Var}[I] = \frac{1}{\Delta T}.
$$

This serves as aregression test because it checks both stochastic-current normalization and the efficiency factor $\sqrt{\eta}$.

### Deterministic-average checks

The diffusive solvers also include direct ensemble comparisons to master equation solver `dq.mesolve()` for de-excitation:

$$
H = 0,
\qquad
L = \sqrt{\gamma}\sigma_-,
\qquad
\gamma = 0.5.
$$

- `dssesolve`: $n_{\mathrm{trajs}} = 1000$, method `dq.method.EulerMaruyama(dt=1e-2)`, tolerance $4\times 10^{-2}$.
- `dsmesolve`: $n_{\mathrm{trajs}} = 1000$, method `dq.method.EulerMaruyama(dt=1e-2)`, tolerance $3\times 10^{-2}$.

These tests are not a substitute for the variance checks, but they are bsaic guardrails for future updatings. (The unravellings must average back to the master equation solution.)

###### Note: Pytest marker cleanup

The existing test suite uses

```python
@pytest.mark.run(order=...)
```

to order tests by expected runtime. The marker is now registered in `pytest.ini` as

```ini
run(order): order tests by expected runtime.
```

This removes `PytestUnknownMarkWarning` while preserving the existing test style.

### Summary of the Four Stochastic Solver Testers


| Testing for/ | No-back-action trajectory | Statistical ensemble check | Extra coverage |
| --- | --- | --- | --- |
| `jssesolve` | protected two-qubit ket trajectory | Bernoulli de-excitation mean/variance | event-method click handling |
| `dssesolve` | protected two-qubit ket trajectory | diffusive current mean/variance | `mesolve` ensemble-average comparison |
| `jsmesolve` | protected two-qubit density-matrix trajectory | Bernoulli de-excitation mean/variance | dark-count binomial statistics |
| `dsmesolve` | protected two-qubit density-matrix trajectory | inefficient diffusive current mean/variance | `mesolve` ensemble-average comparison |


## Expected Result

https://github.com/user-attachments/assets/be403fc4-5f42-4bad-b893-2f17d5afea12



-----------------------------------------------------

<!-- Please fill in the disclosure below: -->

### Generative AI/LLM disclosure


Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [x] The code and logic architecture/design are partially performed by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **99%** performed by the author(s)
- [ ] The code and logic architecture/design are fully performed by generative AI/LLM


Code content:

- [ ] The code contains no generative AI/LLM work
- [x] The code is partially written by generative AI/L
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **70%** performed by the author(s)
- [ ] The code is fully written by generative AI/LLM


Code review:

- [x] The code review contains no generative AI/LLM
- [ ] The code review is partially done by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code review is fully done by generative AI/LLM


Code tests:

- [x] The code tests contain no generative AI/LLM
- [ ] The code tests are partially written by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code tests are fully written by generative AI/LLM



















