### PR TITLE
Expand QArray manipulation utilities

### DIFF
--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -15,6 +15,7 @@ from qutip import Qobj
 
 from .._utils import is_batched_scalar
 from .dataarray import DataArray, IndexType
+from .dense_dataarray import DenseDataArray
 from .layout import Layout
 
 __all__ = ['QArray']
@@ -195,6 +196,9 @@ class QArray(eqx.Module):
     | `x.todm()`                                               | Alias of [`dq.todm(x)`][dynamiqs.todm].                        |
     | `x.proj()`                                               | Alias of [`dq.proj(x)`][dynamiqs.proj].                        |
     | [`x.reshape(*shape)`][dynamiqs.qarrays.qarray.QArray.reshape] | Returns a reshaped copy of a qarray.                           |
+    | [`x.swapaxes(axis1, axis2)`][dynamiqs.qarrays.qarray.QArray.swapaxes] | Interchanges two axes of a qarray.                             |
+    | [`x.moveaxis(source, destination)`][dynamiqs.qarrays.qarray.QArray.moveaxis] | Moves axes of a qarray to new positions.                       |
+    | [`x.expand_dims(axis)`][dynamiqs.qarrays.qarray.QArray.expand_dims] | Expands the shape of a qarray by inserting new axes.           |
     | [`x.broadcast_to(*shape)`][dynamiqs.qarrays.qarray.QArray.broadcast_to] | Broadcasts a qarray to a new shape.                            |
     | [`x.addscalar(y)`][dynamiqs.qarrays.qarray.QArray.addscalar] | Adds a scalar.                                                 |
     | [`x.elmul(y)`][dynamiqs.qarrays.qarray.QArray.elmul]     | Computes the element-wise multiplication.                      |
@@ -309,6 +313,89 @@ class QArray(eqx.Module):
             New qarray with the given shape.
         """
         return replace(self, data=self.data.broadcast_to(*shape))
+
+    def _wrap_jax_result(
+        self, data: Array, *, quantum_axes_preserved: bool = True
+    ) -> QArray | Array:
+        if not quantum_axes_preserved:
+            return data
+        try:
+            return replace(self, data=DenseDataArray(data))
+        except ValueError:
+            return data
+
+    def swapaxes(self, axis1: int, axis2: int) -> QArray | Array:
+        """Interchange two axes of a qarray.
+
+        Args:
+            axis1: First axis.
+            axis2: Second axis.
+
+        Returns:
+            A qarray when the resulting shape is compatible with the original Hilbert
+            space dimensions, otherwise a JAX array.
+        """
+        permutation = list(range(self.ndim))
+        axis1 %= self.ndim
+        axis2 %= self.ndim
+        permutation[axis1], permutation[axis2] = permutation[axis2], permutation[axis1]
+        quantum_axes_preserved = set(permutation[-2:]) == {self.ndim - 2, self.ndim - 1}
+        return self._wrap_jax_result(
+            jnp.swapaxes(self.to_jax(), axis1, axis2),
+            quantum_axes_preserved=quantum_axes_preserved,
+        )
+
+    def moveaxis(
+        self, source: int | Sequence[int], destination: int | Sequence[int]
+    ) -> QArray | Array:
+        """Move axes of a qarray to new positions.
+
+        Args:
+            source: Original positions of the axes to move.
+            destination: Destination positions for each original axis.
+
+        Returns:
+            A qarray when the resulting shape is compatible with the original Hilbert
+            space dimensions, otherwise a JAX array.
+        """
+        source_axes = (source,) if isinstance(source, int) else tuple(source)
+        destination_axes = (
+            (destination,) if isinstance(destination, int) else tuple(destination)
+        )
+        source_axes = tuple(axis % self.ndim for axis in source_axes)
+        destination_axes = tuple(axis % self.ndim for axis in destination_axes)
+        permutation = [axis for axis in range(self.ndim) if axis not in source_axes]
+        for destination_axis, source_axis in sorted(
+            zip(destination_axes, source_axes, strict=True)
+        ):
+            permutation.insert(destination_axis, source_axis)
+        quantum_axes_preserved = set(permutation[-2:]) == {self.ndim - 2, self.ndim - 1}
+        return self._wrap_jax_result(
+            jnp.moveaxis(self.to_jax(), source, destination),
+            quantum_axes_preserved=quantum_axes_preserved,
+        )
+
+    def expand_dims(self, axis: int | Sequence[int]) -> QArray | Array:
+        """Expand the shape of a qarray by inserting new axes.
+
+        Args:
+            axis: Position or positions where new axes are inserted.
+
+        Returns:
+            A qarray when the resulting shape is compatible with the original Hilbert
+            space dimensions, otherwise a JAX array.
+        """
+        result_ndim = self.ndim + (1 if isinstance(axis, int) else len(tuple(axis)))
+        axes = (axis,) if isinstance(axis, int) else tuple(axis)
+        axes = tuple(a if a >= 0 else a + result_ndim for a in axes)
+        labels: list[int | None] = list(range(self.ndim))
+        for insert_axis in sorted(axes):
+            labels.insert(insert_axis, None)
+        quantum_axes_preserved = set(labels[-2:]) == {self.ndim - 2, self.ndim - 1}
+        return self._wrap_jax_result(
+            jnp.expand_dims(self.to_jax(), axis),
+            quantum_axes_preserved=quantum_axes_preserved,
+        )
 
     def powm(self, n: int) -> QArray:
         return replace(self, data=self.data.powm(n))

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -23,6 +23,11 @@ __all__ = [
     'asqarray',
     'sparsedia_from_dict',
     'stack',
+    'swapaxes',
+    'moveaxis',
+    'expand_dims',
+    'where',
+    'concatenate',
     'to_jax',
     'to_numpy',
     'to_qutip',
@@ -143,6 +148,142 @@ def init_dims(
     _assert_dims_match_shape(dims, shape)
 
     return dims
+
+
+def _first_qarray(*xs: object) -> QArray | None:
+    for x in xs:
+        if isinstance(x, QArray):
+            return x
+        if isinstance(x, Sequence) and not isinstance(x, str | bytes):
+            qarray = _first_qarray(*x)
+            if qarray is not None:
+                return qarray
+    return None
+
+
+def _wrap_like(
+    reference: QArray | None, data: jnp.ndarray, *, quantum_axes_preserved: bool = True
+) -> QArray | jnp.ndarray:
+    if reference is None or not quantum_axes_preserved:
+        return data
+    try:
+        return QArray(reference.dims, reference.vectorized, DenseDataArray(data))
+    except ValueError:
+        return data
+
+
+def swapaxes(x: QArrayLike, axis1: int, axis2: int) -> QArray | jnp.ndarray:
+    """Interchange two axes of a qarray-like object.
+
+    Args:
+        x: Qarray-like object.
+        axis1: First axis.
+        axis2: Second axis.
+
+    Returns:
+        A qarray when the result is compatible with the input Hilbert space dimensions,
+        otherwise a JAX array.
+    """
+    if isinstance(x, QArray):
+        return x.swapaxes(axis1, axis2)
+    return jnp.swapaxes(to_jax(x), axis1, axis2)
+
+
+def moveaxis(
+    x: QArrayLike, source: int | Sequence[int], destination: int | Sequence[int]
+) -> QArray | jnp.ndarray:
+    """Move axes of a qarray-like object to new positions.
+
+    Args:
+        x: Qarray-like object.
+        source: Original positions of the axes to move.
+        destination: Destination positions for each original axis.
+
+    Returns:
+        A qarray when the result is compatible with the input Hilbert space dimensions,
+        otherwise a JAX array.
+    """
+    if isinstance(x, QArray):
+        return x.moveaxis(source, destination)
+    return jnp.moveaxis(to_jax(x), source, destination)
+
+
+def expand_dims(x: QArrayLike, axis: int | Sequence[int]) -> QArray | jnp.ndarray:
+    """Expand the shape of a qarray-like object by inserting new axes.
+
+    Args:
+        x: Qarray-like object.
+        axis: Position or positions where new axes are inserted.
+
+    Returns:
+        A qarray when the result is compatible with the input Hilbert space dimensions,
+        otherwise a JAX array.
+    """
+    if isinstance(x, QArray):
+        return x.expand_dims(axis)
+    return jnp.expand_dims(to_jax(x), axis)
+
+
+def where(
+    condition: ArrayLike, x: QArrayLike | None = None, y: QArrayLike | None = None
+) -> QArray | jnp.ndarray | tuple[jnp.ndarray, ...]:
+    """Select elements from qarray-like inputs according to a condition.
+
+    Args:
+        condition: Condition selecting values from ``x`` or ``y``.
+        x: Values selected where ``condition`` is true. If omitted together with ``y``,
+            returns condition indices like ``jax.numpy.where``.
+        y: Values selected where ``condition`` is false.
+
+    Returns:
+        A qarray when ``x`` or ``y`` is a qarray and the result is compatible with its
+        Hilbert space dimensions, otherwise the corresponding JAX result.
+    """
+    if x is None and y is None:
+        return jnp.where(condition)
+    if x is None or y is None:
+        raise TypeError('Either both or neither of `x` and `y` should be given.')
+
+    if isinstance(x, QArray) and isinstance(y, QArray) and x.dims != y.dims:
+        raise ValueError(
+            f'Qarrays have incompatible Hilbert space dimensions. Got {x.dims} and '
+            f'{y.dims}.'
+        )
+
+    reference = _first_qarray(x, y)
+    data = jnp.where(condition, to_jax(x), to_jax(y))
+    return _wrap_like(reference, data)
+
+
+def concatenate(qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray | jnp.ndarray:
+    """Join qarray-like objects along an existing axis.
+
+    Args:
+        qarrays: Qarray-like objects to concatenate.
+        axis: Axis along which the inputs are joined.
+
+    Returns:
+        A qarray when the result is compatible with the input Hilbert space dimensions,
+        otherwise a JAX array.
+    """
+    if len(qarrays) == 0:
+        raise ValueError('Argument `qarrays` must contain at least one element.')
+
+    reference = _first_qarray(qarrays)
+    if reference is not None:
+        for qarray in qarrays:
+            if isinstance(qarray, QArray) and qarray.dims != reference.dims:
+                raise ValueError(
+                    'Argument `qarrays` must contain qarrays with identical `dims` '
+                    'attributes.'
+                )
+
+    data = jnp.concatenate([to_jax(qarray) for qarray in qarrays], axis=axis)
+    quantum_axes_preserved = True
+    if reference is not None:
+        normalized_axis = axis % reference.ndim
+        quantum_axes_preserved = normalized_axis < reference.ndim - 2
+    return _wrap_like(reference, data, quantum_axes_preserved=quantum_axes_preserved)
 
 
 def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:

--- a/qarray_example/qarray_manipulation_utilities.ipynb
+++ b/qarray_example/qarray_manipulation_utilities.ipynb
@@ -1,0 +1,304 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# QArray manipulation utilities in a batched Dynamiqs workflow\n",
+    "\n",
+    "This notebook demonstrates how the QArray manipulation utilities (`swapaxes`, `moveaxis`, `expand_dims`, `where`, and `concatenate`) fit into a realistic Dynamiqs workflow.\n",
+    "\n",
+    "The example is a small batched Rabi-oscillation sweep for a qubit. We solve many combinations of detuning, drive strength, and initial state, then reorganize and post-process the resulting `QArray` directly—without converting to raw `jax.Array` objects."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "source": [
+    "## Research notes from the Dynamiqs API\n",
+    "\n",
+    "Dynamiqs represents quantum objects as `QArray` instances:\n",
+    "\n",
+    "- the last two axes are the quantum object axes, such as `(n, 1)` for kets and `(n, n)` for operators or density matrices,\n",
+    "- all axes before the last two are batch axes,\n",
+    "- batched solvers return `QArray` results, for example `sesolve(...).states` has shape `(...H, ...psi0, ntsave, n, 1)` with Cartesian batching enabled,\n",
+    "- preserving the last two quantum axes means array manipulations can usually preserve the `QArray` abstraction.\n",
+    "\n",
+    "That makes the new utilities especially useful after simulations: batch axes can be reordered, extra scenario axes can be inserted, filtered state banks can be built, and compatible collections can be concatenated while keeping `QArray` semantics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mport jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "import dynamiqs as dq\n",
+    "\n",
+    "# Keep notebook output compact.\n",
+    "dq.set_progress_meter(False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "source": [
+    "## 1. Build a batched qubit problem\n",
+    "\n",
+    "We create a simple ZX Hamiltonian sweep:\n",
+    "\n",
+    "$$\n",
+    "H(\\Delta, \\Omega) = \\Delta\\,\\sigma_z + \\Omega\\,\\sigma_x.\n",
+    "$$\n",
+    "\n",
+    "The Hamiltonian batch axes are `(detuning, drive)`. We also prepare four initial states, giving an additional initial-state batch axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "detunings = jnp.linspace(-1.0, 1.0, 3)  # detuning batch axis\n",
+    "drives = jnp.linspace(0.5, 1.5, 4)  # drive-strength batch axis\n",
+    "\n",
+    "H = (\n",
+    "    detunings[:, None, None, None] * dq.sigmaz()\n",
+    "    + drives[None, :, None, None] * dq.sigmax()\n",
+    ")\n",
+    "\n",
+    "g = dq.ground()\n",
+    "e = dq.excited()\n",
+    "plus = (g + e).unit()\n",
+    "minus = (g - e).unit()\n",
+    "psi0 = dq.stack([g, e, plus, minus])\n",
+    "\n",
+    "print(f'H shape:    {H.shape}    # (detuning, drive, n, n)')\n",
+    "print(f'psi0 shape: {psi0.shape}       # (initial_state, n, 1)')\n",
+    "print(f'H dims: {H.dims}, psi0 dims: {psi0.dims}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## 2. Solve all combinations in one batched call\n",
+    "\n",
+    "With the default Cartesian batching, the result combines all Hamiltonian batches with the initial-state batch:\n",
+    "\n",
+    "`(detuning, drive, initial_state, time, n, 1)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tsave = jnp.linspace(0.0, 2.0, 21)\n",
+    "result = dq.sesolve(H, psi0, tsave, exp_ops=[dq.sigmaz()], progress_meter=False)\n",
+    "states = result.states\n",
+    "\n",
+    "print(f'states type:  {type(states).__name__}')\n",
+    "print(f'states shape: {states.shape}')\n",
+    "print('axis meaning: (detuning, drive, initial_state, time, n, 1)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "## 3. Reorder batch axes with `moveaxis` and `swapaxes`\n",
+    "\n",
+    "Here we put `initial_state` first, then produce a drive-first view.\n",
+    "\n",
+    "Because the quantum axes remain the last two dimensions, both manipulations return `QArray` objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Move initial_state from axis 2 to axis 0:\n",
+    "# (detuning, drive, initial_state, time, n, 1)\n",
+    "# -> (initial_state, detuning, drive, time, n, 1)\n",
+    "states_by_initial = dq.moveaxis(states, 2, 0)\n",
+    "\n",
+    "# Swap detuning and drive axes:\n",
+    "# -> (initial_state, drive, detuning, time, n, 1)\n",
+    "states_drive_first = dq.swapaxes(states_by_initial, 1, 2)\n",
+    "\n",
+    "print(\n",
+    "    f'states_by_initial: type={type(states_by_initial).__name__}, '\n",
+    "    f'shape={states_by_initial.shape}'\n",
+    ")\n",
+    "print(\n",
+    "    f'states_drive_first: type={type(states_drive_first).__name__}, '\n",
+    "    f'shape={states_drive_first.shape}'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": [
+    "## 4. Add scenario axes with `expand_dims`\n",
+    "\n",
+    "`expand_dims` is useful when building higher-level result banks. Here we add a leading `scenario` axis while preserving the qarray quantum axes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scenario_states = dq.expand_dims(states_by_initial, 0)\n",
+    "\n",
+    "print(f'scenario_states type:  {type(scenario_states).__name__}')\n",
+    "print(f'scenario_states shape: {scenario_states.shape}')\n",
+    "print('axis meaning: (scenario, initial_state, detuning, drive, time, n, 1)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "source": [
+    "## 5. Filter states with `where`\n",
+    "\n",
+    "At the final time, let us compute the excited-state population. We then keep the final state only when the excited population is above a threshold. Otherwise we replace it with the ground state.\n",
+    "\n",
+    "The condition is a regular JAX boolean array, while `x` and `y` are `QArray` objects. The result remains a `QArray` because the selected values have compatible Hilbert-space dimensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_states = states_by_initial[..., -1, :, :]\n",
+    "excited_projector = dq.excited().proj()\n",
+    "final_excited_pop = dq.expect(excited_projector, final_states).real\n",
+    "\n",
+    "# Broadcast |g> to the same batch shape as final_states.\n",
+    "ground_like = dq.expand_dims(dq.ground(), (0, 1, 2)).broadcast_to(*final_states.shape)\n",
+    "\n",
+    "selected_final_states = dq.where(\n",
+    "    final_excited_pop[..., None, None] > 0.5, final_states, ground_like\n",
+    ")\n",
+    "\n",
+    "print(f'final_states shape:          {final_states.shape}')\n",
+    "print(f'final_excited_pop shape:     {final_excited_pop.shape}')\n",
+    "print(f'selected_final_states type:  {type(selected_final_states).__name__}')\n",
+    "print(f'selected_final_states shape: {selected_final_states.shape}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "## 6. Combine compatible QArray collections with `concatenate`\n",
+    "\n",
+    "Finally, build a two-scenario bank: the raw final states and the threshold-filtered final states. Because we concatenate along a batch axis and keep the last two quantum axes intact, the output is still a `QArray`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "final_state_bank = dq.concatenate(\n",
+    "    [dq.expand_dims(final_states, 0), dq.expand_dims(selected_final_states, 0)], axis=0\n",
+    ")\n",
+    "\n",
+    "print(f'final_state_bank type:  {type(final_state_bank).__name__}')\n",
+    "print(f'final_state_bank shape: {final_state_bank.shape}')\n",
+    "print('axis meaning: (scenario, initial_state, detuning, drive, n, 1)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8a65eabff63a45729fe45fb5ade58bdc",
+   "metadata": {},
+   "source": [
+    "## 7. A quick visualization\n",
+    "\n",
+    "The manipulation utilities let us organize data before plotting. Below we plot the final excited-state population for the `|g>` initial state, with detuning on rows and drive strength on columns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3933fab20d04ec698c2621248eb3be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ground_initial_index = 0\n",
+    "heatmap = final_excited_pop[ground_initial_index]\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(5, 3))\n",
+    "im = ax.imshow(heatmap, origin='lower', aspect='auto')\n",
+    "ax.set_xticks(range(len(drives)), [f'{x:.2f}' for x in drives])\n",
+    "ax.set_yticks(range(len(detunings)), [f'{x:.2f}' for x in detunings])\n",
+    "ax.set_xlabel('Drive strength Ω')\n",
+    "ax.set_ylabel('Detuning Δ')\n",
+    "ax.set_title('Final excited-state population from |g>')\n",
+    "fig.colorbar(im, ax=ax, label='Population')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4dd4641cc4064e0191573fe9c69df29b",
+   "metadata": {},
+   "source": [
+    "## Takeaway\n",
+    "\n",
+    "For normal Dynamiqs users' workflows, these utilities are most useful on **batch axes**:\n",
+    "\n",
+    "- `moveaxis` and `swapaxes` reorganize simulation outputs for analysis;\n",
+    "- `expand_dims` adds scenario or ensemble axes;\n",
+    "- `where` builds filtered or conditionally selected state collections;\n",
+    "- `concatenate` combines compatible batches.\n",
+    "\n",
+    "When the last two quantum axes remain valid, outputs preserve the `QArray` abstraction and can be passed directly into other Dynamiqs utilities such as `dq.expect`, `dq.to_qutip`, or other additional simulations."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/qarray_example/qarray_manipulation_utilities.ipynb
+++ b/qarray_example/qarray_manipulation_utilities.ipynb
@@ -55,7 +55,7 @@
     "We create a simple ZX Hamiltonian sweep:\n",
     "\n",
     "$$\n",
-    "H(\\Delta, \\Omega) = \\Delta\\,\\sigma_z + \\Omega\\,\\sigma_x.\n",
+    "H(\\Delta, \\Omega) = \\Delta\\sigma_z + \\Omega\\sigma_x.\n",
     "$$\n",
     "\n",
     "The Hamiltonian batch axes are `(detuning, drive)`. We also prepare four initial states, giving an additional initial-state batch axis."

--- a/tests/qarrays/test_manipulation.py
+++ b/tests/qarrays/test_manipulation.py
@@ -1,0 +1,143 @@
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+
+from ..order import TEST_INSTANT
+
+
+@pytest.fixture(params=[dq.dense, dq.dia])
+def batched_qarray(request):
+    data = (jnp.arange(24, dtype=jnp.float32).reshape(2, 3, 2, 2) + 1j).astype(
+        jnp.complex64
+    )
+    return data, dq.asqarray(data, dims=(2,), layout=request.param)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_swapaxes_matches_jax_and_preserves_qarray(batched_qarray):
+    data, qarray = batched_qarray
+
+    result = dq.swapaxes(qarray, 0, 1)
+    expected = jnp.swapaxes(data, 0, 1)
+
+    assert isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert result.dims == qarray.dims
+    assert jnp.array_equal(result.to_jax(), expected)
+    assert jnp.array_equal(qarray.swapaxes(0, 1).to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_swapaxes_quantum_axes_matches_jax(batched_qarray):
+    data, qarray = batched_qarray
+
+    result = dq.swapaxes(qarray, -1, -2)
+    expected = jnp.swapaxes(data, -1, -2)
+
+    assert isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert result.dims == qarray.dims
+    assert jnp.array_equal(result.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_moveaxis_matches_jax_and_preserves_qarray(batched_qarray):
+    data, qarray = batched_qarray
+
+    result = dq.moveaxis(qarray, 0, 1)
+    expected = jnp.moveaxis(data, 0, 1)
+
+    assert isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert result.dims == qarray.dims
+    assert jnp.array_equal(result.to_jax(), expected)
+    assert jnp.array_equal(qarray.moveaxis(0, 1).to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_moveaxis_returns_array_when_quantum_shape_is_not_preserved(batched_qarray):
+    data, qarray = batched_qarray
+
+    result = dq.moveaxis(qarray, -1, 0)
+    expected = jnp.moveaxis(data, -1, 0)
+
+    assert not isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert jnp.array_equal(result, expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_expand_dims_matches_jax_and_preserves_qarray(batched_qarray):
+    data, qarray = batched_qarray
+
+    result = dq.expand_dims(qarray, 1)
+    expected = jnp.expand_dims(data, 1)
+
+    assert isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert result.dims == qarray.dims
+    assert jnp.array_equal(result.to_jax(), expected)
+    assert jnp.array_equal(qarray.expand_dims(1).to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_matches_jax_and_preserves_qarray(batched_qarray):
+    data, qarray = batched_qarray
+    other = dq.asqarray(data + 100, dims=qarray.dims)
+    condition = (data.real % 2) == 0
+
+    result = dq.where(condition, qarray, other)
+    expected = jnp.where(condition, data, data + 100)
+
+    assert isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert result.dims == qarray.dims
+    assert jnp.array_equal(result.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_mixed_qarray_and_scalar_matches_jax(batched_qarray):
+    data, qarray = batched_qarray
+    condition = (data.real % 2) == 0
+
+    result = dq.where(condition, qarray, 0.0)
+    expected = jnp.where(condition, data, 0.0)
+
+    assert isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert result.dims == qarray.dims
+    assert jnp.array_equal(result.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_concatenate_matches_jax_and_preserves_qarray(batched_qarray):
+    data, qarray = batched_qarray
+    other = dq.asqarray(data + 100, dims=qarray.dims)
+
+    result = dq.concatenate([qarray, other], axis=0)
+    expected = jnp.concatenate([data, data + 100], axis=0)
+
+    assert isinstance(result, dq.QArray)
+    assert result.shape == expected.shape
+    assert result.dtype == expected.dtype
+    assert result.dims == qarray.dims
+    assert jnp.array_equal(result.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_concatenate_raw_arrays_matches_jax():
+    data = jnp.arange(12).reshape(3, 2, 2)
+
+    result = dq.concatenate([data, data + 100], axis=0)
+    expected = jnp.concatenate([data, data + 100], axis=0)
+
+    assert not isinstance(result, dq.QArray)
+    assert jnp.array_equal(result, expected)


### PR DESCRIPTION
<!-- Place the PR description below, stating which issues it resolves. -->

## Pull Request: Expand QArray manipulation utilities

Closes https://github.com/dynamiqs/dynamiqs/issues/1080

## What changed

This pull request aims to close an ergonomics gap in the `QArray` API by adding NumPy/JAX-style manipulation primitives, specifically the need for `swapaxes`, `moveaxis`, `expand_dims`, `where`, and `concatenate`. The expansion works on `QArray` inputs, respects batching dimensions, preserves `QArray` outputs when appropriate, and avoids forcing users to manually convert to `jax.Array`.

Before these additions, a user who had a batched qarray with shape

$$
(*B, n, m)
$$

would often need to do something like:

```python
raw = dq.to_jax(x)
raw = jnp.moveaxis(raw, source, destination)
x = dq.asqarray(raw, dims=x.dims)
```

That workflow is technically possible, but it is noisy and easy to be wrong. It also leaks internal representation details into user code. The new utilities let users stay in the `QArray` world:

```python
y = dq.moveaxis(x, source, destination)
```

That is a big win in usability. The user can focus themselevs on quantum objects and batch axes. For Dynamiqs, the last two axes carry quantum-object meaning. A typical ket, operator, or density matrix has shape

$$
(*B, n, 1), \qquad (*B, n, n), \qquad \text{or more generally} \qquad (*B, n, m),
$$

where $B$ denotes zero or more batch dimensions and $(n, m)$ are the quantum axes. The implementation respects this convention.

### Implemented core utilities

The following core additions were added and implemented:

| Utility | Status | Notes |
| --- | --- | --- |
| `swapaxes` | Implemented | Available as a functional API and as `QArray.swapaxes(...)`. |
| `moveaxis` | Implemented | Available as a functional API and as `QArray.moveaxis(...)`. |
| `expand_dims` | Implemented | Available as a functional API and as `QArray.expand_dims(...)`. |
| `where` | Implemented | Available as a functional API supporting `QArray` operands. |
| `concatenate` | Implemented | Available as a functional API for qarray-like sequences. |

### Implementation summary by utility

#### `swapaxes`

The `swapaxes` utility follows the JAX/NumPy-style signature:

$$
\text{swapaxes}(x, axis_1, axis_2)
$$

where $x$ is qarray-like and $axis_1$, $axis_2$ are the two axes to exchange.

The implementation supports:

```python
dq.swapaxes(x, axis1, axis2)
x.swapaxes(axis1, axis2)
```

This is especially useful for reordering batch axes. For example, if a simulation result has shape

$$
(N_\Delta, N_\Omega, N_\psi, N_t, n, 1),
$$

then swapping two batch axes can produce

$$
(N_\Omega, N_\Delta, N_\psi, N_t, n, 1)
$$

while preserving the `QArray` abstraction because the quantum axes $(n, 1)$ remain last.

#### `moveaxis`

The `moveaxis` utility follows:

$$
\text{moveaxis}(x, source, destination)
$$

where $source$ and $destination$ may be integers or sequences of integers.

The implementation supports:

```python
dq.moveaxis(x, source, destination)
x.moveaxis(source, destination)
```

A common Dynamiqs use case is moving an initial-state batch axis to the front. If `sesolve` returns states with Cartesian batching:

$$
(N_H, N_{\psi_0}, N_t, n, 1),
$$

or, for a Hamiltonian sweep,

$$
(N_\Delta, N_\Omega, N_{\psi_0}, N_t, n, 1),
$$

then users can write:

```python
states_by_initial = dq.moveaxis(states, 2, 0)
```

and obtain

$$
(N_{\psi_0}, N_\Delta, N_\Omega, N_t, n, 1).
$$

That is a very natural analysis layout. The implementation preserves `QArray` when the move affects batch axes only.

#### `expand_dims`

The `expand_dims` utility follows:

```
expand_dims(x, axis)
```

where $axis$ may be a single integer or a sequence of integers.

The implementation supports:

```python
dq.expand_dims(x, axis)
x.expand_dims(axis)
```

This is useful for adding scenario, ensemble, or sweep axes. For a qarray with shape

$$
(*B, n, m),
$$

adding a leading scenario axis gives

$$
(1, *B, n, m).
$$

Users can prepare values for broadcasting, stacking, etc, without dropping into raw JAX.

#### `where`

The `where` utility follows the three-argument selection pattern:

$$
\text{where}(condition, x, y),
$$

where $condition$ is a boolean array and $x$, $y$ are qarray-like values.

In elementwise form, it implements:

$$
z_i =
\begin{cases}
 x_i, & \text{if } condition_i, \\
 y_i, & \text{otherwise}.
\end{cases}
$$

The implementation supports use cases such as:

```python
selected = dq.where(mask[..., None, None], states, fallback_states)
```

where $mask$ has batch shape $B$, and `states` and `fallback_states` have shape

$$
(*B, n, m).
$$

For example, one can keep a final state only when an excited-state population exceeds a threshold:

$$
P_e > p_{\mathrm{threshold}},
$$

and replace it with a fallback state otherwise.

The implementation also checks that when both $x$ and $y$ are `QArray` objects, their Hilbert-space dimensions agree:

$$
\mathrm{dims}(x) = \mathrm{dims}(y).
$$

This catches subtle any future physics-shape mistakes.

#### `concatenate`

The `concatenate` utility follows:

$$
\text{concatenate}([x_0, x_1, \ldots, x_{k-1}], axis=a).
$$

For compatible qarrays with shapes

$$
(B_0, \ldots, B_a^{(i)}, \ldots, B_r, n, m),
$$

concatenating along a batch axis $a$ produces a shape whose $a$-th batch dimension is

$$
\sum_{i=0}^{k-1} B_a^{(i)}.
$$

The utility preserves `QArray` when the concatenation axis is a batch axis and the quantum axes remain valid.

It also enforces that qarray inputs have matching Hilbert-space dimensions:

$$
\mathrm{dims}(x_0) = \mathrm{dims}(x_1) = \cdots = \mathrm{dims}(x_{k-1}).
$$

That makes the operation both ergonomic and safe.

### QArray preservation semantics

The most important design choice is the output type rule:

$$
\text{output} =
\begin{cases}
\texttt{QArray}, & \text{if the result remains a valid quantum object}, \\
\texttt{jax.Array}, & \text{otherwise}.
\end{cases}
$$

This is a good compromise between convenience and correctness.

If a user manipulates only batch axes, the output remains a qarray:

$$
(*B, n, m) \longrightarrow (*B', n, m).
$$

If a user moves a quantum axis into the batch region, the result may no longer satisfy Dynamiqs' qarray conventions:

$$
(*B, n, m) \longrightarrow (m, *B, n),
$$

so returning a raw JAX array is clearer.

### Tests added

The new tests compare each core utility against the equivalent JAX operation. They cover:

- output shape;
- output values;
- dtype preservation;
- batched `QArray` inputs;
- dense layout;
- sparse DIA layout;
- preservation of `QArray` outputs when appropriate;
- fallback to raw JAX arrays when quantum axes are not preserved;
- mixed qarray/raw-array scenarios for selection and concatenation.

This lines up closely with the issue's requested test coverage.

Overall, these utilities make batched workflows feel more like NumPy/JAX while still honoring Dynamiqs' quantum-object conventions. That is a genuinely nice boost for usability and readability.

### Example notebook added

An example notebook was added under:

```text
qarray_example/qarray_manipulation_utilities.ipynb
```

It demonstrates a batched qubit/Rabi workflow with Hamiltonians of the form

$$
H(\Delta, \Omega) = \Delta \sigma_z + \Omega \sigma_x,
$$

where $\Delta$ is the detuning and $\Omega$ is the drive strength.

It then shows how to use the new qarray manipulation utilities to reorganize solver outputs.

Demo:

https://github.com/user-attachments/assets/a1fe3320-1d33-48f8-8fcb-67c38ec23cf2



<!-- Please fill in the disclosure below: -->

### Generative AI/LLM disclosure


Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [x] The code and logic architecture/design are partially performed by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **99%** performed by the author(s)
- [ ] The code and logic architecture/design are fully performed by generative AI/LLM


Code content:

- [ ] The code contains no generative AI/LLM work
- [x] The code is partially written by generative AI/L
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **70%** performed by the author(s)
- [ ] The code is fully written by generative AI/LLM


Code review:

- [x] The code review contains no generative AI/LLM
- [ ] The code review is partially done by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code review is fully done by generative AI/LLM


Code tests:

- [x] The code tests contain no generative AI/LLM
- [ ] The code tests are partially written by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code tests are fully written by generative AI/LLM

