### PR TITLE
Expand type coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dev = [
     "flit",
     "mike",
     "optax",  # for gradient descent tutorials
-    "ty",
+    "ty==0.0.44",
 ]
 
 [tool.ruff]
@@ -123,13 +123,45 @@ ignore-words-list = "ket, braket, SME"
 
 [tool.ty.src]
 exclude = [
-    "dynamiqs/integrators",
-    "dynamiqs/plot",
-    "dynamiqs/qarrays",
-    "dynamiqs/random",
-    "dynamiqs/utils",
+    "dynamiqs/conftest.py",
+    "dynamiqs/integrators/_utils.py",
+    "dynamiqs/integrators/apis/dsmesolve.py",
+    "dynamiqs/integrators/apis/dssesolve.py",
+    "dynamiqs/integrators/apis/floquet.py",
+    "dynamiqs/integrators/apis/jsmesolve.py",
+    "dynamiqs/integrators/apis/jssesolve.py",
+    "dynamiqs/integrators/apis/mepropagator.py",
+    "dynamiqs/integrators/apis/mesolve.py",
+    "dynamiqs/integrators/apis/sepropagator.py",
+    "dynamiqs/integrators/apis/sesolve.py",
+    "dynamiqs/integrators/core/abstract_integrator.py",
+    "dynamiqs/integrators/core/diffrax_integrator.py",
+    "dynamiqs/integrators/core/event_integrator.py",
+    "dynamiqs/integrators/core/expm_integrator.py",
+    "dynamiqs/integrators/core/fixed_step_stochastic_integrator.py",
+    "dynamiqs/integrators/core/floquet_integrator.py",
+    "dynamiqs/integrators/core/low_rank_integrator.py",
+    "dynamiqs/integrators/core/montecarlo_integrator.py",
+    "dynamiqs/integrators/core/rouchon_integrator.py",
+    "dynamiqs/integrators/core/save_mixin.py",
+    "dynamiqs/plot/fock_plots.py",
+    "dynamiqs/plot/hinton_plots.py",
+    "dynamiqs/plot/misc_plots.py",
+    "dynamiqs/plot/qubit_plots.py",
+    "dynamiqs/plot/utils.py",
+    "dynamiqs/plot/wigner_plots.py",
+    "dynamiqs/qarrays/dataarray.py",
+    "dynamiqs/qarrays/dense_dataarray.py",
+    "dynamiqs/qarrays/qarray.py",
+    "dynamiqs/qarrays/sparsedia_dataarray.py",
+    "dynamiqs/qarrays/sparsedia_primitives.py",
+    "dynamiqs/qarrays/utils.py",
     "dynamiqs/time_qarray.py",
-    "dynamiqs/conftest.py"
+    "dynamiqs/utils/general.py",
+    "dynamiqs/utils/operators.py",
+    "dynamiqs/utils/states.py",
+    "dynamiqs/utils/vectorization.py",
+    "dynamiqs/utils/wigner_utils.py"
 ]
 
 [tool.ty.rules]

--- a/type_coverage_example/type_coverage_utilities.ipynb
+++ b/type_coverage_example/type_coverage_utilities.ipynb
@@ -1,0 +1,206 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# Dynamiqs type coverage utilities example\n",
+    "\n",
+    "This notebook is a small and executable guide for writing typed Dynamiqs helper code. It distills the contributor guidance into a concrete example:\n",
+    "\n",
+    "- accept broad user-facing inputs with `QArrayLike` and `ArrayLike`;\n",
+    "- normalize them immediately with `dq.asqarray()` and `jnp.asarray()`;\n",
+    "- return precise `QArray` and `jax.Array` values;\n",
+    "- use `typing.assert_type()` as a lightweight type-coverage assertion next to examples.\n",
+    "\n",
+    "The example uses `dq.random`, qarray conversion utilities, and expectation-value utilities together.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "source": [
+    "## 1. Imports and public type aliases\n",
+    "\n",
+    "Dynamiqs exports the qarray API from `dynamiqs.qarrays`, while JAX provides `Array` and `ArrayLike` for numerical values. `PRNGKeyArray` from jaxtyping documents random-key expectations.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "from collections.abc import Iterable\n",
+    "from dataclasses import dataclass\n",
+    "from typing import assert_type\n",
+    "\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "from IPython.display import display as ipy_display\n",
+    "from jax import Array\n",
+    "from jax.typing import ArrayLike\n",
+    "from jaxtyping import PRNGKeyArray\n",
+    "\n",
+    "import dynamiqs as dq\n",
+    "from dynamiqs.qarrays import QArray, QArrayLike"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "source": [
+    "## 2. Typed wrappers around Dynamiqs conversion utilities\n",
+    "\n",
+    "These wrappers mirror the style used in Dynamiqs public functions: keep the call signature permissive, then convert once at the boundary. This improves static coverage without making user code less ergonomic.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def normalized_state(state: QArrayLike) -> QArray:\n",
+    "    \"\"\"Convert a qarray-like state to a normalized Dynamiqs QArray.\"\"\"\n",
+    "    qstate = dq.asqarray(state)\n",
+    "    return qstate.unit()\n",
+    "\n",
+    "\n",
+    "def centered_grid(points: ArrayLike) -> Array:\n",
+    "    \"\"\"Convert array-like points to a centered JAX array.\"\"\"\n",
+    "    values = jnp.asarray(points)\n",
+    "    return values - values.mean()\n",
+    "\n",
+    "\n",
+    "def random_density_matrix(key: PRNGKeyArray, dims: int | tuple[int, ...]) -> QArray:\n",
+    "    \"\"\"Return a random normalized density matrix with a precise type.\"\"\"\n",
+    "    return dq.random.dm(key, dims)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    "## 3. A typed observable utility\n",
+    "\n",
+    "The helper below accepts any iterable of qarray-like observables. It converts each observable through `dq.asqarray()` and returns one stacked `jax.Array` of real expectation values. The `assert_type()` calls are executable no-ops, but static checkers can use them to verify the intended type contract.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def real_expectations(observables: Iterable[QArrayLike], state: QArrayLike) -> Array:\n",
+    "    \"\"\"Compute real expectation values for typed Dynamiqs inputs.\"\"\"\n",
+    "    qstate = normalized_state(state)\n",
+    "    values = [\n",
+    "        dq.expect(dq.asqarray(observable), qstate).real for observable in observables\n",
+    "    ]\n",
+    "    return jnp.stack(values)\n",
+    "\n",
+    "\n",
+    "psi = normalized_state(dq.fock(4, 0) + dq.fock(4, 1))\n",
+    "observables = [dq.number(4), dq.position(4), dq.momentum(4)]\n",
+    "expectations = real_expectations(observables, psi)\n",
+    "\n",
+    "assert_type(psi, QArray)\n",
+    "assert_type(expectations, Array)\n",
+    "ipy_display(expectations)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "## 4. A small typed experiment object\n",
+    "\n",
+    "Dataclasses are useful when notebook experiments grow into library code. The fields below document the experiment boundary, and the methods keep Dynamiqs-specific return types explicit.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dataclass(frozen=True)\n",
+    "class RandomStateExperiment:\n",
+    "    dims: int | tuple[int, ...]\n",
+    "    sample_points: ArrayLike\n",
+    "\n",
+    "    def state(self, key: PRNGKeyArray) -> QArray:\n",
+    "        return dq.random.ket(key, self.dims)\n",
+    "\n",
+    "    def density_matrix(self, key: PRNGKeyArray) -> QArray:\n",
+    "        return random_density_matrix(key, self.dims)\n",
+    "\n",
+    "    def centered_points(self) -> Array:\n",
+    "        return centered_grid(self.sample_points)\n",
+    "\n",
+    "\n",
+    "key = jax.random.PRNGKey(7)\n",
+    "experiment = RandomStateExperiment(dims=4, sample_points=jnp.linspace(-2.0, 2.0, 9))\n",
+    "random_psi = experiment.state(key)\n",
+    "random_rho = experiment.density_matrix(key)\n",
+    "points = experiment.centered_points()\n",
+    "\n",
+    "assert_type(random_psi, QArray)\n",
+    "assert_type(random_rho, QArray)\n",
+    "assert_type(points, Array)\n",
+    "ipy_display((random_psi.shape, random_rho.shape, points.shape))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "source": [
+    "## 5. Tips for using the above type-covered show-functions\n",
+    "\n",
+    "Say if you want to move them into `dynamiqs/`,\n",
+    "\n",
+    "1. keep the public function annotated,\n",
+    "2. use `QArrayLike`/`ArrayLike` for inputs that should accept Python, NumPy, JAX, or Dynamiqs values,\n",
+    "3. convert at the top of the function with `dq.asqarray()` or `jnp.asarray()`,\n",
+    "4. return `QArray` or `Array` rather than an untyped object,\n",
+    "5. run `task type`.\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/type_coverage_example/type_coverage_utilities.ipynb
+++ b/type_coverage_example/type_coverage_utilities.ipynb
@@ -177,8 +177,19 @@
     "2. use `QArrayLike`/`ArrayLike` for inputs that should accept Python, NumPy, JAX, or Dynamiqs values,\n",
     "3. convert at the top of the function with `dq.asqarray()` or `jnp.asarray()`,\n",
     "4. return `QArray` or `Array` rather than an untyped object,\n",
-    "5. run `task type`.\n",
+    "5. run `task type`. See Below:\n",
     "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef0516c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ty --version\n",
+    "!task type"
    ]
   }
  ],


### PR DESCRIPTION
<!-- Place the PR description below, stating which issues it resolves. -->

## Pull Request: Expand type coverage across Dynamiqs

Closes https://github.com/dynamiqs/dynamiqs/issues/1081

## What changed

The pull request pins the type checker, removes a real public module from the exclusion list, and narrows broad exclusions into concrete file-level follow-up work. The current changes move the project in the following direction:

$$
\begin{aligned}
&\text{less excluded code} \\
&+\text{more precise annotations} \\
&+\text{passing } \texttt{task type}\\
 &=\text{safer refactors and better developer experience}.
\end{aligned}
$$

With this pull request, instead of facing a few large directory-level exclusions, Dynamiqs' users now have a file-level map.

### 1. `ty` is pinned to a concrete supported version

The development dependency now uses a concrete `ty` version:

$$
\text{VER}_{\mathrm{ty}} = 0.0.44.
$$

That is great for reproducibility. Everyone running the development workflow is
pointed at the same type checker version rather than floating across whatever
`ty` release happens to be latest on a given day.

In practical terms, this changes the toolchain contract from

$$
\texttt{ty} \to \texttt{ty} = 0.0.44.
$$

### 2. `dynamiqs/random` is now included in type checks

The broad problem called out this excluded module set:

$$
E_{\mathrm{original}} = \{\texttt{integrators}, \texttt{plot},\texttt{qarrays}, \texttt{random}, \texttt{utils},
\texttt{time\\_qarray.py}\}.
$$

The current work removes `dynamiqs/random` from that excluded set:

$$
\texttt{dynamiqs/random} \notin E_{\mathrm{current}}.
$$

Equivalently, the newly covered public module includes

$$
\Delta E_{\mathrm{random}} = \{\texttt{dynamiqs/random}\}.
$$

This can be a win because `dynamiqs/random` is a user-facing utility
surface. It exposes typed random constructors for objects such as real arrays,
complex arrays, Hermitian operators, positive semidefinite matrices, density
matrices, operators, and kets.

The most relevant parameter families are

$$
\texttt{key}:\ \texttt{PRNGKeyArray},
\qquad
\texttt{shape}:\ \texttt{int}\ |\ \texttt{tuple[int, ...]},
$$

and, for Hilbert-space aware constructors,

$$
\texttt{dims}:\ \texttt{int}\ |\ \texttt{tuple[int, ...]},
\qquad
\texttt{batch}:\ \texttt{int}\ |\ \texttt{tuple[int, ...]}.
$$

For composite dimensions $\texttt{dims} = (d_1, \ldots, d_m)$, the Hilbert-space size is of direct rpoduct:

$$
d = \prod_{k=1}^{m} d_k.
$$

That makes the public random-state shape contracts clearer:

$$
\text{ket}(\texttt{key}, \texttt{dims}, \texttt{batch})
\to \texttt{QArray}\ \text{with shape}\ (*\texttt{batch}, d, 1),
$$

$$
\text{dm}(\texttt{key}, \texttt{dims}, \texttt{batch})
\to \texttt{QArray}\ \text{with shape}\ (*\texttt{batch}, d, d).
$$

### 3. Broad exclusions are narrowed to file-level exclusions

Broad directory exclusions can feel like a black box. File-level exclusions are much easier to understand and review.

Before this change, whole directories were excluded:

$$
E_{\mathrm{broad}} = \{\texttt{integrators},\texttt{plot},\texttt{qarrays},\texttt{utils}\}.
$$

After this change, the remaining exclusions are explicit files:

$$
E_{\mathrm{current}} = \{f_1, f_2, \ldots, f_n\},
\qquad f_i = \text{one known file-level typing task}.
$$

This is a NICE migration shape because it increases real coverage without
pretending the remaining work is done. It also gives future users a much
clearer checklist:

$$
\text{pick } f_i
\quad \to \quad
\text{fix annotations or code}
\quad \to \quad
\text{remove } f_i \text{ from } E_{\mathrm{current}}.
$$

Newly visible package entry points and helper files include examples like

`dynamiqs/plot/colormaps.py`
`dynamiqs/qarrays/layout.py`
`dynamiqs/utils/global_settings.py`
`dynamiqs/utils/optimal_control.py`

The pull request changes the type coverage map from broad silencing to actionable work.

### Type coverage utilities notebook

The notebook `type_coverage_example/type_coverage_utilities.ipynb` is a user-friendly
example of how to write typed Dynamiqs utilities. 

The central pattern is

$$
\text{broad public input}
\xrightarrow{\ \text{convert once at the boundary}\ }
\text{stable internal type}
\xrightarrow{\ \text{return explicitly}\ }
\texttt{QArray}\ \text{or}\ \texttt{Array}.
$$

Concretely:

- use `QArrayLike` for quantum objects accepted from users;
- use `ArrayLike` for numerical arrays accepted from users;
- convert with `dq.asqarray()` or `jnp.asarray()`;
- return `QArray` or `jax.Array`;
- use `typing.assert_type()` to document and check the intended static contract.
- verify `ty --version` and run `task type`

### Implemented notebook utilities and extracted parameters

#### `normalized_state(state)`

This utility accepts a friendly qarray-like input and returns a normalized
Dynamiqs `QArray`.

Relevant parameter:

$$
\texttt{state}:\ \texttt{QArrayLike}.
$$

Conversion and return contract:

$$
\texttt{QArrayLike}
\xrightarrow{\ \texttt{dq.asqarray}\ }
\texttt{QArray}
\xrightarrow{\ \texttt{unit}\ }
\texttt{QArray}.
$$

Function type:

$$
\text{normalized\\_state}:
\texttt{QArrayLike} \to \texttt{QArray}.
$$

It preserves Dynamiqs ergonomics at the call site while giving the implementation a precise internal type.

#### `centered_grid(points)`

This utility accepts Python, NumPy, or JAX-style numerical input and returns a
JAX `Array`.

Relevant parameter:

$$
\texttt{points}:\ \texttt{ArrayLike}.
$$

For input values $x_1, \ldots, x_N$, it computes

$$
\bar{x} = \frac{1}{N}\sum_{j=1}^{N} x_j,
\qquad
\tilde{x}_i = x_i - \bar{x}.
$$

Function type:

$$
\text{centered\\_grid}:
\texttt{ArrayLike} \to \texttt{Array}.
$$

It demonstrates the array-side mirror of the qarray boundary conversion pattern, using `jnp.asarray()` as the normalization step.

#### `random_density_matrix(key, dims)`

This utility wraps `dq.random.dm()` with a precise return annotation.

Relevant parameters:

$$
\texttt{key}:\ \texttt{PRNGKeyArray},
\qquad
\texttt{dims}:\ \texttt{int}\ |\ \texttt{tuple[int, ...]}.
$$

For $\texttt{dims} = (d_1, \ldots, d_m)$,

$$
d = \prod_{k=1}^{m} d_k,
\qquad
\rho \in \mathbb{C}^{d \times d}.
$$

Function type:

$$
\text{random\\_density\\_matrix}:
(\texttt{PRNGKeyArray},\ \texttt{int}\ |\ \texttt{tuple[int, ...]})
\to \texttt{QArray}.
$$

It connects the newly covered `dynamiqs/random` module directly to user-facing typed helper code.

#### `real_expectations(observables, state)`

This utility accepts qarray-like observables and a qarray-like state, then
returns real expectation values as a JAX `Array`.

Relevant parameters:

$$
\texttt{observables}:\ \texttt{Iterable[QArrayLike]},
\qquad
\texttt{state}:\ \texttt{QArrayLike}.
$$

For each observable $O_k$, the expectation value is

$$
\langle O_k \rangle =
\begin{cases}
\langle \psi | O_k | \psi \rangle, & \text{if the state is a ket } \psi,\\
\text{Tr}(O_k\rho), & \text{if the state is a density matrix } \rho.
\end{cases}
$$

The utility returns the real component:

$$
y_k = \text{Re}\langle O_k \rangle.
$$

Function type:

$$
\text{real\\_expectations}:
(\texttt{Iterable[QArrayLike]},\ \texttt{QArrayLike})
\to \texttt{Array}.
$$

It essentially turns a common scientific pattern into a statically clear helper without taking flexibility away from users.

#### `RandomStateExperiment`

This dataclass shows how a notebook experiment can grow into structured typed
code.

Relevant fields:

$$
\texttt{dims}:\ \texttt{int}\ |\ \texttt{tuple[int, ...]},
\qquad
\texttt{sample\\_points}:\ \texttt{ArrayLike}.
$$

Relevant methods:

$$
\text{state}(\texttt{key}:\ \texttt{PRNGKeyArray})
\to \texttt{QArray},
$$

$$
\text{density\\_matrix}(\texttt{key}:\ \texttt{PRNGKeyArray})
\to \texttt{QArray},
$$

$$
\text{centered\\_points}() \to \texttt{Array}.
$$

It gives users a realistic pattern for carrying type clarity from exploratory code into reusable helpers.

####  Verify `ty --version` and run `task type`

Should output `ty 0.0.44` and 
```
>>> ty check dynamiqs All checks passed!
```

### Demo


https://github.com/user-attachments/assets/1bbf0b23-f497-4159-9c96-e1f4fb9a178f





<!-- Please fill in the disclosure below: -->

### Generative AI/LLM disclosure


Code and Logic Architecture/Design:

- [ ] The code and logic architecture/design contain no generative AI/LLM
- [x] The code and logic architecture/design are partially performed by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **99%** performed by the author(s)
- [ ] The code and logic architecture/design are fully performed by generative AI/LLM


Code content:

- [ ] The code contains no generative AI/LLM work
- [x] The code is partially written by generative AI/L
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **69%** performed by the author(s)
- [ ] The code is fully written by generative AI/LLM


Code review:

- [x] The code review contains no generative AI/LLM
- [ ] The code review is partially done by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code review is fully done by generative AI/LLM


Code tests:

- [x] The code tests contain no generative AI/LLM
- [ ] The code tests are partially written by generative AI/LLM
  <!-- If the above field is selected, please place the percentage it was done by you below: -->
  - **X%** performed by the author(s)
- [ ] The code tests are fully written by generative AI/LLM