### PR TITLE
Type the `plot` module and remove it from the ty exclusion list

### DIFF
--- a/dynamiqs/plot/fock_plots.py
+++ b/dynamiqs/plot/fock_plots.py
@@ -4,7 +4,7 @@ import jax.numpy as jnp
 from jax import Array
 from jax.typing import ArrayLike
 from matplotlib.axes import Axes
-from matplotlib.colors import ListedColormap, LogNorm, Normalize
+from matplotlib.colors import Colormap, ListedColormap, LogNorm, Normalize
 
 from .._checks import check_shape, check_times
 from ..qarrays.qarray import QArrayLike
@@ -70,6 +70,9 @@ def fock(
 
         ![plot_fock_coherent](../../figs_code/plot_fock_coherent.png){.fig}
     """
+    # `ax` is always set by the `@optional_ax` decorator
+    assert ax is not None
+
     state = to_jax(state)
     check_shape(state, 'state', '(n, 1)', '(n, n)')
 
@@ -127,6 +130,9 @@ def fock_evolution(
 
         ![plot_fock_evolution_log](../../figs_code/plot_fock_evolution_log.png){.fig}
     """
+    # `ax` is always set by the `@optional_ax` decorator
+    assert ax is not None
+
     states = to_jax(states)
     times = jnp.asarray(times) if times is not None else None
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')
@@ -139,17 +145,19 @@ def fock_evolution(
     z = _populations(states).T
 
     # set norm and colormap
+    colormap: str | Colormap
     if logscale:
         norm = LogNorm(vmin=logvmin, vmax=1.0, clip=True)
         # stepped cmap
-        ncolors = jnp.round(jnp.log10(1 / logvmin)).astype(int)
+        ncolors = int(jnp.round(jnp.log10(1 / logvmin)))
         clist = sample_cmap(cmap, ncolors + 2)[1:-1]  # remove extremal colors
-        cmap = ListedColormap(clist)
+        colormap = ListedColormap(clist)
     else:
         norm = Normalize(vmin=0.0, vmax=1.0)
+        colormap = cmap
 
     # plot
-    ax.pcolormesh(x, y, z, cmap=cmap, norm=norm)
+    ax.pcolormesh(x, y, z, cmap=colormap, norm=norm)
     ax.grid(False)
 
     # set y ticks
@@ -157,4 +165,4 @@ def fock_evolution(
     ket_ticks(ax.yaxis)
 
     if colorbar:
-        add_colorbar(ax, cmap, norm, size=0.02, pad=0.02)
+        add_colorbar(ax, colormap, norm, size=0.02, pad=0.02)

--- a/dynamiqs/plot/hinton_plots.py
+++ b/dynamiqs/plot/hinton_plots.py
@@ -86,6 +86,9 @@ def _plot_hinton(
 ):
     # areas: 2D array (n, n) with real values in [0, 1]
     # colors: 2D array (n, n) with real values in [0, 1]
+    # `ax` is always set by the `@optional_ax` decorator
+    assert ax is not None
+
     areas = jnp.asarray(areas)
     colors = jnp.asarray(colors)
 
@@ -109,14 +112,15 @@ def _plot_hinton(
     # squares areas
     areas = areas.T.flatten()
     # squares colors
-    cmap = mpl.colormaps[cmap]
-    colors = cmap(colors.T).reshape(-1, 4)
+    colormap = mpl.colormaps[cmap]
+    # `colormap` returns an RGBA array since `colors.T` is an array (not a scalar)
+    colors = np.asarray(colormap(colors.T)).reshape(-1, 4)
     _plot_squares(ax, areas, colors, offsets, ecolor=ecolor, ewidth=ewidth)
 
     # === colorbar
     if colorbar:
         norm = Normalize(colors_vmin, colors_vmax)
-        cax = add_colorbar(ax, cmap, norm, size=0.04, pad=0.04)
+        cax = add_colorbar(ax, colormap, norm, size=0.04, pad=0.04)
         if colors_vmin == -jnp.pi and colors_vmax == jnp.pi:
             cax.set_yticks([-jnp.pi, 0.0, jnp.pi], labels=[r'$-\pi$', r'$0$', r'$\pi$'])
 
@@ -193,6 +197,9 @@ def hinton(
 
         ![plot_hinton_large](../../figs_code/plot_hinton_large.png){.fig}
     """
+    # `ax` is always set by the `@optional_ax` decorator
+    assert ax is not None
+
     x = to_jax(x)
     check_shape(x, 'x', '(n, n)')
 
@@ -205,10 +212,8 @@ def hinton(
         if cmap is None:
             # sequential colormap for positive data, diverging colormap otherwise
             cmap = 'Blues' if all_positive else 'dq'
-        if vmin is None:
-            vmin = 0.0 if all_positive else jnp.min(x)
-
-        vmax = jnp.max(x) if vmax is None else vmax
+        vmin = (0.0 if all_positive else float(jnp.min(x))) if vmin is None else vmin
+        vmax = float(jnp.max(x)) if vmax is None else vmax
 
         # areas: absolute value of x
         area_max = max(abs(vmin), abs(vmax))
@@ -225,13 +230,15 @@ def hinton(
 
         # areas: magnitude of x
         magnitude = jnp.abs(x)
-        areas_max = jnp.max(magnitude) if vmax is None else vmax
+        areas_max = float(jnp.max(magnitude)) if vmax is None else vmax
         areas = _normalize(magnitude, 0.0, areas_max)
 
         # colors: phase of x
         phase = jnp.angle(x)
-        colors = _normalize(phase, -jnp.pi, jnp.pi)
-        colors_vmin, colors_vmax = -jnp.pi, jnp.pi
+        colors = _normalize(phase, -float(jnp.pi), float(jnp.pi))
+        colors_vmin, colors_vmax = -float(jnp.pi), float(jnp.pi)
+    else:
+        raise TypeError('Argument `x` must be a real or complex matrix.')
 
     if clear:
         colorbar = False

--- a/dynamiqs/plot/misc_plots.py
+++ b/dynamiqs/plot/misc_plots.py
@@ -15,7 +15,7 @@ def pwc_pulse(
     times: ArrayLike,
     values: ArrayLike,
     *,
-    ax: Axes = None,
+    ax: Axes | None = None,
     ycenter: bool = True,
     real_color: str = colors['blue'],
     imag_color: str = colors['purple'],
@@ -35,6 +35,9 @@ def pwc_pulse(
 
         ![plot_pwc_pulse](../../figs_code/plot_pwc_pulse.png){.fig}
     """
+    # `ax` is always set by the `@optional_ax` decorator
+    assert ax is not None
+
     times = jnp.asarray(times)  # (n + 1)
     values = jnp.asarray(values)  # (n)
     times = check_times(times, 'times')

--- a/dynamiqs/plot/qubit_plots.py
+++ b/dynamiqs/plot/qubit_plots.py
@@ -39,6 +39,9 @@ def xyz(
 
         ![plot_xyz](../../figs_code/plot_xyz.png){.fig}
     """
+    # `ax` is always set by the `@optional_ax` decorator
+    assert ax is not None
+
     states = to_jax(states)
     times = jnp.asarray(times) if times is not None else None
     check_shape(states, 'states', '(N, n, 1)', '(N, n, n)')

--- a/dynamiqs/plot/utils.py
+++ b/dynamiqs/plot/utils.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterable, Sequence
 from functools import wraps
 from io import BytesIO
 from math import ceil
-from typing import TypeVar
+from typing import Any, Concatenate, TypeVar
 
 import matplotlib
 import matplotlib as mpl
@@ -14,7 +14,7 @@ from IPython.display import Image
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.axis import Axis
-from matplotlib.colors import Normalize
+from matplotlib.colors import Colormap, Normalize
 from matplotlib.figure import Figure
 from matplotlib.ticker import FixedLocator, MaxNLocator, MultipleLocator, NullLocator
 from PIL import Image as PILImage
@@ -48,7 +48,7 @@ def figax(w: float = 7.0, h: float | None = None, **kwargs) -> tuple[Figure, Axe
     return plt.subplots(1, 1, figsize=(w, h), constrained_layout=True, **kwargs)
 
 
-def optional_ax(func: callable) -> callable:
+def optional_ax(func: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator to build an `Axes` object to pass as an argument to a plot
     function if it wasn't passed by the user.
 
@@ -262,7 +262,7 @@ def integer_ticks(axis: Axis, n: int, all: bool = True):  # noqa: A002
 
 def ket_ticks(axis: Axis):
     # fix ticks location
-    axis.set_major_locator(FixedLocator(axis.get_ticklocs()))
+    axis.set_major_locator(FixedLocator(axis.get_ticklocs().tolist()))
 
     # format ticks as ket
     new_labels = [rf'$| {label.get_text()} \rangle$' for label in axis.get_ticklabels()]
@@ -271,7 +271,7 @@ def ket_ticks(axis: Axis):
 
 def bra_ticks(axis: Axis):
     # fix ticks location
-    axis.set_major_locator(FixedLocator(axis.get_ticklocs()))
+    axis.set_major_locator(FixedLocator(axis.get_ticklocs().tolist()))
 
     # format ticks as ket
     new_labels = [rf'$\langle {label.get_text()} |$' for label in axis.get_ticklabels()]
@@ -289,10 +289,15 @@ def minorticks_off(axis: Axis):
 
 
 def add_colorbar(
-    ax: Axes, cmap: str, norm: Normalize, *, size: float = 0.05, pad: float = 0.05
+    ax: Axes,
+    cmap: str | Colormap,
+    norm: Normalize,
+    *,
+    size: float = 0.05,
+    pad: float = 0.05,
 ) -> Axes:
     # insert a new axes on the right with the same height
-    cax = ax.inset_axes([1 + size, 0, pad, 1])
+    cax = ax.inset_axes((1 + size, 0, pad, 1))
     mappable = mpl.cm.ScalarMappable(norm=norm, cmap=cmap)
     plt.colorbar(mappable=mappable, cax=cax)
     cax.grid(False)
@@ -311,8 +316,8 @@ def gif_indices(nitems: int, nframes: int) -> np.ndarray:
 
 
 def gifit(
-    plot_function: Callable[[T, ...], None],
-) -> Callable[[Sequence[T], ...], Image]:
+    plot_function: Callable[Concatenate[T, ...], None],
+) -> Callable[Concatenate[Sequence[T], ...], Image]:
     """Transform a plot function into a new function that returns an animated GIF.
 
     This function takes a plot function that normally operates on a single input and
@@ -379,7 +384,9 @@ def gifit(
             plot_function(items[idx], *args, **kwargs)  # plot frame
             canvas = plt.gcf().canvas
             canvas.draw()  # ensure the figure is drawn
-            frame = np.array(canvas.buffer_rgba())  # capture the RGBA buffer
+            # `buffer_rgba` is defined on the Agg-based canvas used at runtime but not
+            # on the `FigureCanvasBase` type exposed by `Figure.canvas`
+            frame = np.array(canvas.buffer_rgba())  # ty: ignore[unresolved-attribute]
             frames.append(frame)
 
         plt.close()

--- a/dynamiqs/plot/wigner_plots.py
+++ b/dynamiqs/plot/wigner_plots.py
@@ -44,6 +44,9 @@ def wigner_data(
         - [`dq.plot.wigner()`][dynamiqs.plot.wigner]: plot the Wigner function of a
             state.
     """
+    # `ax` is always set by the `@optional_ax` decorator
+    assert ax is not None
+
     w = to_jax(wigner)
     check_shape(w, 'wigner', '(n, n)')
     if w.dtype not in (jnp.float32, jnp.float64):
@@ -67,7 +70,7 @@ def wigner_data(
         origin='lower',
         aspect='equal',
         interpolation=interpolation,
-        extent=[-xmax, xmax, -ymax, ymax],
+        extent=(-xmax, xmax, -ymax, ymax),
     )
 
     # remove grid by default
@@ -242,7 +245,10 @@ def wigner_mosaic(
 
     ymax = xmax if ymax is None else ymax
     selected_indexes = np.linspace(0, nstates, n, dtype=int)
-    _, _, wig = compute_wigner(states[selected_indexes], xmax, ymax, npixels, hbar=hbar)
+    # `QArray` supports array (fancy) indexing at runtime; its `__getitem__` type hint
+    # is conservative and does not advertise it
+    selected_states = states[selected_indexes]  # ty: ignore[invalid-argument-type]
+    _, _, wig = compute_wigner(selected_states, xmax, ymax, npixels, hbar=hbar)
 
     # plot individual wigner
     for i, ax in enumerate(axs):
@@ -317,10 +323,13 @@ def wigner_gif(
     ymax = xmax if ymax is None else ymax
     nframes = int(gif_duration * fps)
     indices = gif_indices(len(states), nframes)
-    _, _, wig = compute_wigner(states[indices], xmax, ymax, npixels, hbar=hbar)
+    # `QArray` supports array (fancy) indexing at runtime; its `__getitem__` type hint
+    # is conservative and does not advertise it
+    selected_states = states[indices]  # ty: ignore[invalid-argument-type]
+    _, _, wig = compute_wigner(selected_states, xmax, ymax, npixels, hbar=hbar)
 
     return gifit(wigner_data)(
-        wig,
+        wig,  # ty: ignore[invalid-argument-type]
         w=w,
         h=ymax / xmax * w,
         xmax=xmax,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,6 @@ ignore-words-list = "ket, braket, SME"
 [tool.ty.src]
 exclude = [
     "dynamiqs/integrators",
-    "dynamiqs/plot",
     "dynamiqs/qarrays",
     "dynamiqs/random",
     "dynamiqs/utils",


### PR DESCRIPTION
## Summary

Part of #1081 (expanding `ty` type coverage across Dynamiqs).

This PR types the entire `dynamiqs/plot` package and removes it from the
`[tool.ty.src]` exclusion list, so the module is now checked by `task type`.

All diagnostics are fixed with real annotations or code changes. The only
suppressions are a handful of narrowly-scoped, individually-justified
`# ty: ignore[...]` comments where a third-party stub is more conservative
than the runtime behaviour.

Closes #1081

## What changed

- **`optional_ax` decorator** (`plot/utils.py`): annotated with
  `Callable[..., Any]` instead of the invalid builtin `callable`. The
  decorator always injects a real `Axes`, so each decorated plotting
  function now narrows `ax` with `assert ax is not None` at the top of its
  body. This removes the large group of `unresolved-attribute` errors of the
  form *"Attribute `…` is not defined on `None`"* without changing any public
  signature (`ax` stays `Axes | None`, which is what callers may pass).
- **`gifit`** (`plot/utils.py`): the signature used `Callable[[T, ...], …]`,
  which is not a valid type form. Replaced with
  `Callable[Concatenate[T, ...], …]`, which is valid and also lets
  `wigner_gif` type-check at the call site.
- **Colormaps** (`plot/fock_plots.py`, `plot/hinton_plots.py`,
  `plot/utils.py`): the local colormap is now stored in a dedicated
  `str | Colormap` variable instead of reassigning the `cmap: str` parameter,
  and `add_colorbar` accepts `str | Colormap`. The Hinton colormap call is
  wrapped in `np.asarray(...)` to reflect that it returns an RGBA array for
  array input.
- **`hinton`** (`plot/hinton_plots.py`): the `if isrealobj / elif iscomplexobj`
  block now has an explicit `else: raise TypeError`, mirroring the existing
  `_populations` helper. This removes the `possibly-unresolved-reference`
  errors and makes the contract explicit. `vmin`/`vmax` are coerced to
  `float` where they feed `_normalize`.
- **matplotlib geometry args**: `inset_axes` and `imshow(extent=...)` now
  receive tuples (the stubs require tuples; behaviour is unchanged), and
  `FixedLocator` receives a list via `.tolist()`.
- **pyproject.toml**: removed `"dynamiqs/plot"` from `[tool.ty.src].exclude`.

### Justified suppressions

These are the only `# ty: ignore` comments added, each with an inline reason:

- `QArray.__getitem__` advertises a conservative `IndexType` and does not
  include array (fancy) indexing, which it supports at runtime — used in
  `wigner_mosaic`/`wigner_gif` (`states[indices]`).
- `FigureCanvasBase` (the type exposed by `Figure.canvas`) has no
  `buffer_rgba`; the Agg canvas used at runtime does.

The repository's `unused-ignore-comment = "error"` rule confirms each
suppression is actually required.

## Verification

Run with Python 3.11 and `ty 0.0.46`:

- `ty check dynamiqs` (i.e. `task type`) -> `All checks passed!`
- `ruff check` -> `All checks passed!`
- `ruff format --check` -> all files already formatted
- `codespell tests dynamiqs` -> clean
- `pytest tests/plot` -> `6 passed`
- `pytest dynamiqs` (doctests, after `python docs/remove_figs.py docs/figs_code`)
  -> `475 passed` (138 of which are in `dynamiqs/plot`)

No public API changes: signatures are unchanged except for widening
`add_colorbar`'s `cmap` parameter and correcting `pwc_pulse`'s `ax`
annotation from `Axes` to `Axes | None` (it already accepted `None` via the
decorator). The remaining excluded modules (`integrators`, `qarrays`,
`random`, `utils`, `time_qarray.py`) are intentionally left for follow-up.
