### PR TITLE
Add QArray manipulation utilities

### DIFF
--- a/dynamiqs/qarrays/dataarray.py
+++ b/dynamiqs/qarrays/dataarray.py
@@ -126,15 +126,13 @@ class DataArray(eqx.Module):
         self, source: int | Sequence[int], destination: int | Sequence[int]
     ) -> DataArray:
         """Moves axes to new positions."""
-        source_axes = tuple(
-            _normalize_axis(axis, self.ndim)
-            for axis in ((source,) if isinstance(source, int) else tuple(source))
+        source_axes = (source,) if isinstance(source, int) else tuple(source)
+        source_axes = tuple(_normalize_axis(axis, self.ndim) for axis in source_axes)
+        destination_axes = (
+            (destination,) if isinstance(destination, int) else tuple(destination)
         )
         destination_axes = tuple(
-            _normalize_axis(axis, self.ndim)
-            for axis in (
-                (destination,) if isinstance(destination, int) else tuple(destination)
-            )
+            _normalize_axis(axis, self.ndim) for axis in destination_axes
         )
         _check_axis_tuples(source_axes, destination_axes)
 
@@ -145,9 +143,18 @@ class DataArray(eqx.Module):
             return self
         if axis_order == final_swap_order:
             return self.mT
-        if in_last_two_dims((*source_axes, *destination_axes), self.ndim):
+        if set(axis_order[:-2]) != set(range(self.ndim - 2)):
             _raise_matrix_axis_error('moveaxis')
-        return self._moveaxis_unchecked(source_axes, destination_axes)
+
+        batch_source = tuple(range(self.ndim - 2))
+        batch_destination = tuple(axis_order[:-2].index(axis) for axis in batch_source)
+        if axis_order[-2:] == identity_order[-2:]:
+            return self._moveaxis_unchecked(batch_source, batch_destination)
+        elif axis_order[-2:] == final_swap_order[-2:]:
+            return self.mT._moveaxis_unchecked(batch_source, batch_destination)
+        else:
+            _raise_matrix_axis_error('moveaxis')
+        raise AssertionError('unreachable')
 
     @abstractmethod
     def _moveaxis_unchecked(
@@ -333,9 +340,9 @@ def _normalize_axis(axis: int, ndim: int) -> int:
 def _normalize_insert_axes(axis: int | Sequence[int], ndim: int) -> tuple[int, ...]:
     axes = (axis,) if isinstance(axis, int) else tuple(axis)
     out_ndim = ndim + len(axes)
-    normalized_axes = tuple(_normalize_axis(a, out_ndim) for a in axes)
+    normalized_axes = tuple(_normalize_axis(ax, out_ndim) for ax in axes)
     if len(set(normalized_axes)) != len(normalized_axes):
-        raise ValueError('repeated axis')
+        raise ValueError(f'Repeated axis found in axes to insert. Got `axis={axis}`.')
     return normalized_axes
 
 
@@ -345,9 +352,11 @@ def _check_axis_tuples(source: tuple[int, ...], destination: tuple[int, ...]) ->
             '`source` and `destination` arguments must have the same number of axes.'
         )
     if len(set(source)) != len(source):
-        raise ValueError('repeated axis in `source` argument')
+        raise ValueError(f'Repeated axis found in `source` argument. Got {source}.')
     if len(set(destination)) != len(destination):
-        raise ValueError('repeated axis in `destination` argument')
+        raise ValueError(
+            f'Repeated axis found in `destination` argument. Got {destination}.'
+        )
 
 
 def _moveaxis_order(

--- a/dynamiqs/qarrays/dataarray.py
+++ b/dynamiqs/qarrays/dataarray.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Sequence
 from math import prod
 from types import EllipsisType
 from typing import TYPE_CHECKING, ClassVar, TypeAlias
@@ -100,19 +101,65 @@ class DataArray(eqx.Module):
     def broadcast_to(self, *shape: int) -> DataArray:
         """Broadcasts to a new shape."""
 
-    @abstractmethod
     def swapaxes(self, axis1: int, axis2: int) -> DataArray:
         """Interchanges two axes."""
+        axis1 = _normalize_axis(axis1, self.ndim)
+        axis2 = _normalize_axis(axis2, self.ndim)
+        if axis1 == axis2:
+            return self
+        if {axis1, axis2} == {self.ndim - 2, self.ndim - 1}:
+            return self.mT
+        if in_last_two_dims((axis1, axis2), self.ndim):
+            _raise_matrix_axis_error('swapaxes')
+        return self._swapaxes_unchecked(axis1, axis2)
 
     @abstractmethod
+    def _swapaxes_unchecked(self, axis1: int, axis2: int) -> DataArray:
+        """Does the heavy-lifting for `swapaxes` but skips all checks."""
+
     def moveaxis(
-        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+        self, source: int | Sequence[int], destination: int | Sequence[int]
     ) -> DataArray:
         """Moves axes to new positions."""
+        source_axes = tuple(
+            _normalize_axis(axis, self.ndim)
+            for axis in ((source,) if isinstance(source, int) else tuple(source))
+        )
+        destination_axes = tuple(
+            _normalize_axis(axis, self.ndim)
+            for axis in (
+                (destination,) if isinstance(destination, int) else tuple(destination)
+            )
+        )
+        _check_axis_tuples(source_axes, destination_axes)
+
+        axis_order = _moveaxis_order(source_axes, destination_axes, self.ndim)
+        identity_order = tuple(range(self.ndim))
+        final_swap_order = (*range(self.ndim - 2), self.ndim - 1, self.ndim - 2)
+        if axis_order == identity_order:
+            return self
+        if axis_order == final_swap_order:
+            return self.mT
+        if in_last_two_dims((*source_axes, *destination_axes), self.ndim):
+            _raise_matrix_axis_error('moveaxis')
+        return self._moveaxis_unchecked(source_axes, destination_axes)
 
     @abstractmethod
-    def expand_dims(self, axis: int | tuple[int, ...]) -> DataArray:
+    def _moveaxis_unchecked(
+        self, source: tuple[int, ...], destination: tuple[int, ...]
+    ) -> DataArray:
+        """Does the heavy-lifting for `moveaxis` but skips all checks."""
+
+    def expand_dims(self, axis: int | Sequence[int]) -> DataArray:
         """Expands the shape by inserting new axes."""
+        axes = _normalize_insert_axes(axis, self.ndim)
+        if in_last_two_dims(axes, self.ndim + len(axes)):
+            _raise_matrix_axis_error('expand_dims')
+        return self._expand_dims_unchecked(axes)
+
+    @abstractmethod
+    def _expand_dims_unchecked(self, axis: tuple[int, ...]) -> DataArray:
+        """Does the heavy-lifting for `expand_dims` but skips all checks."""
 
     @abstractmethod
     def powm(self, n: int) -> DataArray:
@@ -267,6 +314,49 @@ def include_last_two_dims(axis: int | tuple[int, ...] | None, ndim: int) -> bool
     axis = (axis,) if isinstance(axis, int) else axis
     return axis is None or (
         ndim - 1 in [a % ndim for a in axis] and ndim - 2 in [a % ndim for a in axis]
+    )
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    if not -ndim <= axis < ndim:
+        raise ValueError(f'axis {axis} is out of bounds for array of dimension {ndim}')
+    return axis % ndim
+
+
+def _normalize_insert_axes(axis: int | Sequence[int], ndim: int) -> tuple[int, ...]:
+    axes = (axis,) if isinstance(axis, int) else tuple(axis)
+    out_ndim = ndim + len(axes)
+    normalized_axes = tuple(_normalize_axis(a, out_ndim) for a in axes)
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError('repeated axis')
+    return normalized_axes
+
+
+def _check_axis_tuples(source: tuple[int, ...], destination: tuple[int, ...]) -> None:
+    if len(source) != len(destination):
+        raise ValueError(
+            '`source` and `destination` arguments must have the same number of axes.'
+        )
+    if len(set(source)) != len(source):
+        raise ValueError('repeated axis in `source` argument')
+    if len(set(destination)) != len(destination):
+        raise ValueError('repeated axis in `destination` argument')
+
+
+def _moveaxis_order(
+    source: tuple[int, ...], destination: tuple[int, ...], ndim: int
+) -> tuple[int, ...]:
+    order = [axis for axis in range(ndim) if axis not in source]
+    for destination_axis, source_axis in sorted(zip(destination, source, strict=True)):
+        order.insert(destination_axis, source_axis)
+    return tuple(order)
+
+
+def _raise_matrix_axis_error(operation: str) -> None:
+    raise ValueError(
+        f'`{operation}` can only manipulate batching dimensions of a data array; the '
+        'final two dimensions are matrix dimensions. Use `swapaxes(-1, -2)` or '
+        '`.mT` to transpose those final dimensions.'
     )
 
 

--- a/dynamiqs/qarrays/dataarray.py
+++ b/dynamiqs/qarrays/dataarray.py
@@ -101,6 +101,20 @@ class DataArray(eqx.Module):
         """Broadcasts to a new shape."""
 
     @abstractmethod
+    def swapaxes(self, axis1: int, axis2: int) -> DataArray:
+        """Interchanges two axes."""
+
+    @abstractmethod
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> DataArray:
+        """Moves axes to new positions."""
+
+    @abstractmethod
+    def expand_dims(self, axis: int | tuple[int, ...]) -> DataArray:
+        """Expands the shape by inserting new axes."""
+
+    @abstractmethod
     def powm(self, n: int) -> DataArray:
         pass
 

--- a/dynamiqs/qarrays/dense_dataarray.py
+++ b/dynamiqs/qarrays/dense_dataarray.py
@@ -58,17 +58,17 @@ class DenseDataArray(DataArray):
 
     def _swapaxes_unchecked(self, axis1: int, axis2: int) -> DataArray:
         data = jnp.swapaxes(self.data, axis1, axis2)
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def _moveaxis_unchecked(
         self, source: tuple[int, ...], destination: tuple[int, ...]
     ) -> DataArray:
         data = jnp.moveaxis(self.data, source, destination)
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def _expand_dims_unchecked(self, axis: tuple[int, ...]) -> DataArray:
         data = jnp.expand_dims(self.data, axis=axis)
-        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return replace(self, data=data)
 
     def powm(self, n: int) -> DataArray:
         data = jnp.linalg.matrix_power(self.data, n)

--- a/dynamiqs/qarrays/dense_dataarray.py
+++ b/dynamiqs/qarrays/dense_dataarray.py
@@ -56,17 +56,17 @@ class DenseDataArray(DataArray):
         data = jnp.broadcast_to(self.data, shape)
         return replace(self, data=data)  # ty: ignore[invalid-argument-type]
 
-    def swapaxes(self, axis1: int, axis2: int) -> DataArray:
+    def _swapaxes_unchecked(self, axis1: int, axis2: int) -> DataArray:
         data = jnp.swapaxes(self.data, axis1, axis2)
         return replace(self, data=data)  # ty: ignore[invalid-argument-type]
 
-    def moveaxis(
-        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    def _moveaxis_unchecked(
+        self, source: tuple[int, ...], destination: tuple[int, ...]
     ) -> DataArray:
         data = jnp.moveaxis(self.data, source, destination)
         return replace(self, data=data)  # ty: ignore[invalid-argument-type]
 
-    def expand_dims(self, axis: int | tuple[int, ...]) -> DataArray:
+    def _expand_dims_unchecked(self, axis: tuple[int, ...]) -> DataArray:
         data = jnp.expand_dims(self.data, axis=axis)
         return replace(self, data=data)  # ty: ignore[invalid-argument-type]
 

--- a/dynamiqs/qarrays/dense_dataarray.py
+++ b/dynamiqs/qarrays/dense_dataarray.py
@@ -56,6 +56,20 @@ class DenseDataArray(DataArray):
         data = jnp.broadcast_to(self.data, shape)
         return replace(self, data=data)  # ty: ignore[invalid-argument-type]
 
+    def swapaxes(self, axis1: int, axis2: int) -> DataArray:
+        data = jnp.swapaxes(self.data, axis1, axis2)
+        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> DataArray:
+        data = jnp.moveaxis(self.data, source, destination)
+        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+
+    def expand_dims(self, axis: int | tuple[int, ...]) -> DataArray:
+        data = jnp.expand_dims(self.data, axis=axis)
+        return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+
     def powm(self, n: int) -> DataArray:
         data = jnp.linalg.matrix_power(self.data, n)
         return replace(self, data=data)  # ty: ignore[invalid-argument-type]

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -105,60 +105,17 @@ class MaterializedQArray(QArray):
 
     def swapaxes(self, axis1: int, axis2: int) -> QArray:
         """Interchange two axes of a qarray."""
-        from .utils import (  # noqa: PLC0415
-            _axes_are_batch_axes,
-            _normalize_axis,
-            _raise_quantum_axis_error,
-        )
-
-        axis1 = _normalize_axis(axis1, self.ndim)
-        axis2 = _normalize_axis(axis2, self.ndim)
-        if axis1 == axis2:
-            return self
-        if {axis1, axis2} == {self.ndim - 2, self.ndim - 1}:
-            return self.mT
-        if not _axes_are_batch_axes((axis1, axis2), self.ndim):
-            _raise_quantum_axis_error('swapaxes')
         return replace(self, data=self.data.swapaxes(axis1, axis2))
 
     def moveaxis(
         self, source: int | Sequence[int], destination: int | Sequence[int]
     ) -> QArray:
         """Move axes of a qarray to new positions."""
-        from .utils import (  # noqa: PLC0415
-            _check_axis_tuples,
-            _moveaxis_order,
-            _normalize_axes,
-            _raise_quantum_axis_error,
-        )
-
-        source_axes = _normalize_axes(source, self.ndim)
-        destination_axes = _normalize_axes(destination, self.ndim)
-        _check_axis_tuples(source_axes, destination_axes)
-
-        axis_order = _moveaxis_order(source_axes, destination_axes, self.ndim)
-        identity_order = tuple(range(self.ndim))
-        final_swap_order = (*range(self.ndim - 2), self.ndim - 1, self.ndim - 2)
-        if axis_order == identity_order:
-            return self
-        if axis_order == final_swap_order:
-            return self.mT
-        if not all(axis < self.ndim - 2 for axis in (*source_axes, *destination_axes)):
-            _raise_quantum_axis_error('moveaxis')
-        return replace(self, data=self.data.moveaxis(source_axes, destination_axes))
+        return replace(self, data=self.data.moveaxis(source, destination))
 
     def expand_dims(self, axis: int | Sequence[int]) -> QArray:
         """Expand the shape of a qarray by inserting new axes."""
-        from .utils import (  # noqa: PLC0415
-            _normalize_insert_axes,
-            _raise_quantum_axis_error,
-        )
-
-        axes = _normalize_insert_axes(axis, self.ndim)
-        out_ndim = self.ndim + len(axes)
-        if not all(axis < out_ndim - 2 for axis in axes):
-            _raise_quantum_axis_error('expand_dims')
-        return replace(self, data=self.data.expand_dims(axes))
+        return replace(self, data=self.data.expand_dims(axis))
 
     def powm(self, n: int) -> QArray:
         return replace(self, data=self.data.powm(n))

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import replace
 from math import prod
 
@@ -101,6 +102,63 @@ class MaterializedQArray(QArray):
             New qarray with the given shape.
         """
         return replace(self, data=self.data.broadcast_to(*shape))
+
+    def swapaxes(self, axis1: int, axis2: int) -> QArray:
+        """Interchange two axes of a qarray."""
+        from .utils import (  # noqa: PLC0415
+            _axes_are_batch_axes,
+            _normalize_axis,
+            _raise_quantum_axis_error,
+        )
+
+        axis1 = _normalize_axis(axis1, self.ndim)
+        axis2 = _normalize_axis(axis2, self.ndim)
+        if axis1 == axis2:
+            return self
+        if {axis1, axis2} == {self.ndim - 2, self.ndim - 1}:
+            return self.mT
+        if not _axes_are_batch_axes((axis1, axis2), self.ndim):
+            _raise_quantum_axis_error('swapaxes')
+        return replace(self, data=self.data.swapaxes(axis1, axis2))
+
+    def moveaxis(
+        self, source: int | Sequence[int], destination: int | Sequence[int]
+    ) -> QArray:
+        """Move axes of a qarray to new positions."""
+        from .utils import (  # noqa: PLC0415
+            _check_axis_tuples,
+            _moveaxis_order,
+            _normalize_axes,
+            _raise_quantum_axis_error,
+        )
+
+        source_axes = _normalize_axes(source, self.ndim)
+        destination_axes = _normalize_axes(destination, self.ndim)
+        _check_axis_tuples(source_axes, destination_axes)
+
+        axis_order = _moveaxis_order(source_axes, destination_axes, self.ndim)
+        identity_order = tuple(range(self.ndim))
+        final_swap_order = (*range(self.ndim - 2), self.ndim - 1, self.ndim - 2)
+        if axis_order == identity_order:
+            return self
+        if axis_order == final_swap_order:
+            return self.mT
+        if not all(axis < self.ndim - 2 for axis in (*source_axes, *destination_axes)):
+            _raise_quantum_axis_error('moveaxis')
+        return replace(self, data=self.data.moveaxis(source_axes, destination_axes))
+
+    def expand_dims(self, axis: int | Sequence[int]) -> QArray:
+        """Expand the shape of a qarray by inserting new axes."""
+        from .utils import (  # noqa: PLC0415
+            _normalize_insert_axes,
+            _raise_quantum_axis_error,
+        )
+
+        axes = _normalize_insert_axes(axis, self.ndim)
+        out_ndim = self.ndim + len(axes)
+        if not all(axis < out_ndim - 2 for axis in axes):
+            _raise_quantum_axis_error('expand_dims')
+        return replace(self, data=self.data.expand_dims(axes))
 
     def powm(self, n: int) -> QArray:
         return replace(self, data=self.data.powm(n))

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -344,6 +344,15 @@ class QArray(eqx.Module):
         """
 
     def where(self, condition: ArrayLike, y: QArrayLike) -> QArray:
+        """Select values from this qarray or another operand depending on a condition.
+
+        Args:
+            condition: Boolean array-like condition.
+            y: Values selected when `condition` is false.
+
+        Returns:
+            Qarray with values chosen from `self` and `y`.
+        """
         from .utils import where  # noqa: PLC0415
 
         return where(condition, self, y)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -195,11 +195,10 @@ class QArray(eqx.Module):
     | `x.proj()`                                               | Alias of [`dq.proj(x)`][dynamiqs.proj].                        |
     | [`x.reshape(*shape)`][dynamiqs.qarrays.qarray.QArray.reshape] | Returns a reshaped copy of a qarray.                           |
     | [`x.broadcast_to(*shape)`][dynamiqs.qarrays.qarray.QArray.broadcast_to] | Broadcasts a qarray to a new shape.                            |
-    | `x.swapaxes(axis1, axis2)`                               | Alias of [`dq.swapaxes(x, axis1, axis2)`][dynamiqs.swapaxes].  |
-    | `x.moveaxis(source, destination)`                        | Alias of [`dq.moveaxis(x, source, destination)`][dynamiqs.moveaxis]. |
-    | `x.expand_dims(axis)`                                    | Alias of [`dq.expand_dims(x, axis)`][dynamiqs.expand_dims].    |
+    | [`x.swapaxes(axis1, axis2)`][dynamiqs.qarrays.qarray.QArray.swapaxes] | Interchanges two axes of a qarray.                            |
+    | [`x.moveaxis(source, destination)`][dynamiqs.qarrays.qarray.QArray.moveaxis] | Moves axes of a qarray to new positions.                      |
+    | [`x.expand_dims(axis)`][dynamiqs.qarrays.qarray.QArray.expand_dims] | Expands the shape of a qarray by inserting new axes.           |
     | `x.where(condition, y)`                                  | Alias of [`dq.where(condition, x, y)`][dynamiqs.where].        |
-    | `x.concatenate(qarrays, axis)`                           | Alias of [`dq.concatenate((x, *qarrays), axis)`][dynamiqs.concatenate]. |
     | [`x.addscalar(y)`][dynamiqs.qarrays.qarray.QArray.addscalar] | Adds a scalar.                                                 |
     | [`x.elmul(y)`][dynamiqs.qarrays.qarray.QArray.elmul]     | Computes the element-wise multiplication.                      |
     | [`x.elpow(power)`][dynamiqs.qarrays.qarray.QArray.elpow] | Computes the element-wise power.                               |
@@ -301,32 +300,47 @@ class QArray(eqx.Module):
             New qarray with the given shape.
         """
 
+    @abstractmethod
     def swapaxes(self, axis1: int, axis2: int) -> QArray:
-        from .utils import swapaxes  # noqa: PLC0415
+        """Interchange two axes of a qarray.
 
-        return swapaxes(self, axis1, axis2)
+        Args:
+            axis1: First axis.
+            axis2: Second axis.
 
+        Returns:
+            Qarray with axes `axis1` and `axis2` interchanged.
+        """
+
+    @abstractmethod
     def moveaxis(
         self, source: int | Sequence[int], destination: int | Sequence[int]
     ) -> QArray:
-        from .utils import moveaxis  # noqa: PLC0415
+        """Move axes of a qarray to new positions.
 
-        return moveaxis(self, source, destination)
+        Args:
+            source: Original positions of the axes to move.
+            destination: Destination positions for each moved axis.
 
+        Returns:
+            Qarray with moved axes.
+        """
+
+    @abstractmethod
     def expand_dims(self, axis: int | Sequence[int]) -> QArray:
-        from .utils import expand_dims  # noqa: PLC0415
+        """Expand the shape of a qarray by inserting new axes.
 
-        return expand_dims(self, axis)
+        Args:
+            axis: Axis or axes where new dimensions are inserted.
+
+        Returns:
+            Qarray with additional dimensions.
+        """
 
     def where(self, condition: ArrayLike, y: QArrayLike) -> QArray:
         from .utils import where  # noqa: PLC0415
 
         return where(condition, self, y)
-
-    def concatenate(self, qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray:
-        from .utils import concatenate  # noqa: PLC0415
-
-        return concatenate((self, *qarrays), axis=axis)
 
     @abstractmethod
     def powm(self, n: int) -> QArray:

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -195,6 +195,11 @@ class QArray(eqx.Module):
     | `x.proj()`                                               | Alias of [`dq.proj(x)`][dynamiqs.proj].                        |
     | [`x.reshape(*shape)`][dynamiqs.qarrays.qarray.QArray.reshape] | Returns a reshaped copy of a qarray.                           |
     | [`x.broadcast_to(*shape)`][dynamiqs.qarrays.qarray.QArray.broadcast_to] | Broadcasts a qarray to a new shape.                            |
+    | `x.swapaxes(axis1, axis2)`                               | Alias of [`dq.swapaxes(x, axis1, axis2)`][dynamiqs.swapaxes].  |
+    | `x.moveaxis(source, destination)`                        | Alias of [`dq.moveaxis(x, source, destination)`][dynamiqs.moveaxis]. |
+    | `x.expand_dims(axis)`                                    | Alias of [`dq.expand_dims(x, axis)`][dynamiqs.expand_dims].    |
+    | `x.where(condition, y)`                                  | Alias of [`dq.where(condition, x, y)`][dynamiqs.where].        |
+    | `x.concatenate(qarrays, axis)`                           | Alias of [`dq.concatenate((x, *qarrays), axis)`][dynamiqs.concatenate]. |
     | [`x.addscalar(y)`][dynamiqs.qarrays.qarray.QArray.addscalar] | Adds a scalar.                                                 |
     | [`x.elmul(y)`][dynamiqs.qarrays.qarray.QArray.elmul]     | Computes the element-wise multiplication.                      |
     | [`x.elpow(power)`][dynamiqs.qarrays.qarray.QArray.elpow] | Computes the element-wise power.                               |
@@ -295,6 +300,33 @@ class QArray(eqx.Module):
         Returns:
             New qarray with the given shape.
         """
+
+    def swapaxes(self, axis1: int, axis2: int) -> QArray:
+        from .utils import swapaxes  # noqa: PLC0415
+
+        return swapaxes(self, axis1, axis2)
+
+    def moveaxis(
+        self, source: int | Sequence[int], destination: int | Sequence[int]
+    ) -> QArray:
+        from .utils import moveaxis  # noqa: PLC0415
+
+        return moveaxis(self, source, destination)
+
+    def expand_dims(self, axis: int | Sequence[int]) -> QArray:
+        from .utils import expand_dims  # noqa: PLC0415
+
+        return expand_dims(self, axis)
+
+    def where(self, condition: ArrayLike, y: QArrayLike) -> QArray:
+        from .utils import where  # noqa: PLC0415
+
+        return where(condition, self, y)
+
+    def concatenate(self, qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray:
+        from .utils import concatenate  # noqa: PLC0415
+
+        return concatenate((self, *qarrays), axis=axis)
 
     @abstractmethod
     def powm(self, n: int) -> QArray:

--- a/dynamiqs/qarrays/sparsedia_dataarray.py
+++ b/dynamiqs/qarrays/sparsedia_dataarray.py
@@ -111,17 +111,17 @@ class SparseDIADataArray(DataArray):
 
     def _swapaxes_unchecked(self, axis1: int, axis2: int) -> DataArray:
         diags = jnp.swapaxes(self.diags, axis1, axis2)
-        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, diags=diags)
 
     def _moveaxis_unchecked(
         self, source: tuple[int, ...], destination: tuple[int, ...]
     ) -> DataArray:
         diags = jnp.moveaxis(self.diags, source, destination)
-        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, diags=diags)
 
     def _expand_dims_unchecked(self, axis: tuple[int, ...]) -> DataArray:
         diags = jnp.expand_dims(self.diags, axis=axis)
-        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+        return replace(self, diags=diags)
 
     def powm(self, n: int) -> DataArray:
         offsets, diags = powm_sparsedia(self.offsets, self.diags, n)

--- a/dynamiqs/qarrays/sparsedia_dataarray.py
+++ b/dynamiqs/qarrays/sparsedia_dataarray.py
@@ -109,17 +109,17 @@ class SparseDIADataArray(DataArray):
         offsets, diags = broadcast_sparsedia(self.offsets, self.diags, shape)
         return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
 
-    def swapaxes(self, axis1: int, axis2: int) -> DataArray:
+    def _swapaxes_unchecked(self, axis1: int, axis2: int) -> DataArray:
         diags = jnp.swapaxes(self.diags, axis1, axis2)
         return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
 
-    def moveaxis(
-        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    def _moveaxis_unchecked(
+        self, source: tuple[int, ...], destination: tuple[int, ...]
     ) -> DataArray:
         diags = jnp.moveaxis(self.diags, source, destination)
         return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
 
-    def expand_dims(self, axis: int | tuple[int, ...]) -> DataArray:
+    def _expand_dims_unchecked(self, axis: tuple[int, ...]) -> DataArray:
         diags = jnp.expand_dims(self.diags, axis=axis)
         return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
 

--- a/dynamiqs/qarrays/sparsedia_dataarray.py
+++ b/dynamiqs/qarrays/sparsedia_dataarray.py
@@ -109,6 +109,20 @@ class SparseDIADataArray(DataArray):
         offsets, diags = broadcast_sparsedia(self.offsets, self.diags, shape)
         return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]
 
+    def swapaxes(self, axis1: int, axis2: int) -> DataArray:
+        diags = jnp.swapaxes(self.diags, axis1, axis2)
+        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> DataArray:
+        diags = jnp.moveaxis(self.diags, source, destination)
+        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+
+    def expand_dims(self, axis: int | tuple[int, ...]) -> DataArray:
+        diags = jnp.expand_dims(self.diags, axis=axis)
+        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+
     def powm(self, n: int) -> DataArray:
         offsets, diags = powm_sparsedia(self.offsets, self.diags, n)
         return replace(self, offsets=offsets, diags=diags)  # ty: ignore[invalid-argument-type]

--- a/dynamiqs/qarrays/sparsedia_primitives.py
+++ b/dynamiqs/qarrays/sparsedia_primitives.py
@@ -334,7 +334,7 @@ def concatenate_sparsedia(
     axis: int,
 ) -> tuple[tuple[int, ...], Array]:
     # compute unique offsets of the output
-    out_offsets = np.asarray(reduce(np.union1d, offsets_sequence))
+    out_offsets = np.asarray(sorted(reduce(set.union, map(set, offsets_sequence))))
     offset_to_index = {offset: idx for idx, offset in enumerate(out_offsets)}
 
     # prepare input diagonals with matching offsets before concatenating

--- a/dynamiqs/qarrays/sparsedia_primitives.py
+++ b/dynamiqs/qarrays/sparsedia_primitives.py
@@ -326,6 +326,30 @@ def stack_sparsedia(
     return _numpy_to_tuple(out_offsets), out_diags
 
 
+def concatenate_sparsedia(
+    offsets_sequence: Sequence[tuple[int, ...]],
+    diags_sequence: Sequence[Array],
+    axis: int,
+) -> tuple[tuple[int, ...], Array]:
+    # compute unique offsets of the output
+    out_offsets = np.asarray(reduce(np.union1d, offsets_sequence))
+    offset_to_index = {offset: idx for idx, offset in enumerate(out_offsets)}
+
+    # prepare input diagonals with matching offsets before concatenating
+    dtype = reduce(jnp.promote_types, [diags.dtype for diags in diags_sequence])
+    expanded_diags = []
+    for offsets, diags in zip(offsets_sequence, diags_sequence, strict=True):
+        out_shape = (*diags.shape[:-2], len(out_offsets), diags.shape[-1])
+        out_diags = jnp.zeros(out_shape, dtype=dtype)
+        for i, offset in enumerate(offsets):
+            idx = offset_to_index[offset]
+            out_diags = out_diags.at[..., idx, :].add(diags[..., i, :])
+        expanded_diags.append(out_diags)
+
+    diags = jnp.concatenate(expanded_diags, axis=axis)
+    return _numpy_to_tuple(out_offsets), diags
+
+
 def autopad_sparsedia_diags(
     offsets: tuple[int, ...], diags: Sequence[Array]
 ) -> tuple[Array]:

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -285,11 +285,15 @@ def where(condition: ArrayLike, x: QArrayLike, y: QArrayLike) -> QArray:
         dims = x.dims
         vectorized = x.vectorized
     elif x_is_qarray:
-        _check_qarraylike_dims(x, y)
+        y_dims = get_dims(y)
+        if y_dims is not None:
+            check_compatible_dims(x.dims, y_dims)
         dims = x.dims
         vectorized = x.vectorized
     else:
-        _check_qarraylike_dims(y, x)
+        x_dims = get_dims(x)
+        if x_dims is not None:
+            check_compatible_dims(y.dims, x_dims)
         dims = y.dims
         vectorized = y.vectorized
 
@@ -316,9 +320,15 @@ def concatenate(qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray:
     qarrays = tuple(asqarray(q) for q in qarrays)
     dims = qarrays[0].dims
     vectorized = qarrays[0].vectorized
-    axis = _normalize_axis(axis, qarrays[0].ndim)
-    if not _axes_are_batch_axes((axis,), qarrays[0].ndim):
-        _raise_quantum_axis_error('concatenate')
+    ndim = qarrays[0].ndim
+    if not -ndim <= axis < ndim:
+        raise ValueError(f'axis {axis} is out of bounds for array of dimension {ndim}')
+    axis = axis % ndim
+    if axis >= ndim - 2:
+        raise ValueError(
+            '`concatenate` can only manipulate batching dimensions of a qarray; the '
+            'final two dimensions are matrix dimensions.'
+        )
 
     if not all(q.dims == dims for q in qarrays):
         raise ValueError(
@@ -465,61 +475,9 @@ def _assert_dims_match_shape(dims: tuple[int, ...], shape: tuple[int, ...]):
         )
 
 
-def _normalize_axis(axis: int, ndim: int) -> int:
-    if not -ndim <= axis < ndim:
-        raise ValueError(f'axis {axis} is out of bounds for array of dimension {ndim}')
-    return axis % ndim
-
-
-def _normalize_axes(axis: int | Sequence[int], ndim: int) -> tuple[int, ...]:
-    axes = (axis,) if isinstance(axis, int) else tuple(axis)
-    return tuple(_normalize_axis(a, ndim) for a in axes)
-
-
-def _normalize_insert_axes(axis: int | Sequence[int], ndim: int) -> tuple[int, ...]:
-    axes = (axis,) if isinstance(axis, int) else tuple(axis)
-    out_ndim = ndim + len(axes)
-    normalized_axes = tuple(_normalize_axis(a, out_ndim) for a in axes)
-    if len(set(normalized_axes)) != len(normalized_axes):
-        raise ValueError('repeated axis')
-    return normalized_axes
-
-
-def _check_axis_tuples(source: tuple[int, ...], destination: tuple[int, ...]) -> None:
-    if len(source) != len(destination):
-        raise ValueError(
-            '`source` and `destination` arguments must have the same number of axes.'
-        )
-    if len(set(source)) != len(source):
-        raise ValueError('repeated axis in `source` argument')
-    if len(set(destination)) != len(destination):
-        raise ValueError('repeated axis in `destination` argument')
-
-
-def _axes_are_batch_axes(axes: tuple[int, ...], ndim: int) -> bool:
-    return all(a < ndim - 2 for a in axes)
-
-
-def _moveaxis_order(
-    source: tuple[int, ...], destination: tuple[int, ...], ndim: int
-) -> tuple[int, ...]:
-    order = [axis for axis in range(ndim) if axis not in source]
-    for destination_axis, source_axis in sorted(zip(destination, source, strict=True)):
-        order.insert(destination_axis, source_axis)
-    return tuple(order)
-
-
 def _contains_sparse_qarray(*xs: QArrayLike) -> bool:
     return any(
         isinstance(x, QArray) and isinstance(x.data, SparseDIADataArray) for x in xs
-    )
-
-
-def _raise_quantum_axis_error(operation: str) -> None:
-    raise ValueError(
-        f'`{operation}` can only manipulate batching dimensions of a qarray; the '
-        'final two dimensions represent the quantum object. Use `swapaxes(-1, -2)` '
-        'or `.mT` to transpose those final dimensions.'
     )
 
 
@@ -535,12 +493,6 @@ def _check_compatible_qarray_metadata(x: QArray, y: QArray) -> None:
             'Qarrays have incompatible `vectorized` attributes. '
             f'Got {x.vectorized} and {y.vectorized}.'
         )
-
-
-def _check_qarraylike_dims(reference: QArray, other: QArrayLike) -> None:
-    other_dims = get_dims(other)
-    if other_dims is not None:
-        check_compatible_dims(reference.dims, other_dims)
 
 
 def _warn_sparse_to_dense(operation: str) -> None:

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -22,8 +22,13 @@ from .sparsedia_primitives import (
 
 __all__ = [
     'asqarray',
+    'concatenate',
+    'expand_dims',
+    'moveaxis',
     'sparsedia_from_dict',
     'stack',
+    'swapaxes',
+    'where',
     'to_jax',
     'to_numpy',
     'to_qutip',
@@ -204,6 +209,191 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
         )
 
 
+def swapaxes(x: QArrayLike, axis1: int, axis2: int) -> QArray:
+    """Interchange two axes of a qarray.
+
+    Args:
+        x: Qarray-like object.
+        axis1: First axis.
+        axis2: Second axis.
+
+    Returns:
+        Qarray with axes `axis1` and `axis2` interchanged.
+    """
+    x = asqarray(x)
+    axis1 = _normalize_axis(axis1, x.ndim)
+    axis2 = _normalize_axis(axis2, x.ndim)
+
+    if axis1 == axis2:
+        return x
+    if not (
+        _axes_are_batch_axes((axis1, axis2), x.ndim)
+        or {axis1, axis2} == {x.ndim - 2, x.ndim - 1}
+    ):
+        _raise_quantum_axis_error('swapaxes')
+
+    if isinstance(x.data, DenseDataArray):
+        data = DenseDataArray(jnp.swapaxes(x.data.data, axis1, axis2))
+    elif _axes_are_batch_axes((axis1, axis2), x.ndim):
+        data = SparseDIADataArray(
+            x.data.offsets, jnp.swapaxes(x.data.diags, axis1, axis2)
+        )
+    else:
+        data = x.data.mT
+
+    return MaterializedQArray(x.dims, x.vectorized, data)
+
+
+def moveaxis(
+    x: QArrayLike, source: int | Sequence[int], destination: int | Sequence[int]
+) -> QArray:
+    """Move axes of a qarray to new positions.
+
+    Args:
+        x: Qarray-like object.
+        source: Original positions of the axes to move.
+        destination: Destination positions for each moved axis.
+
+    Returns:
+        Qarray with moved axes.
+    """
+    x = asqarray(x)
+    source_axes = _normalize_axes(source, x.ndim)
+    destination_axes = _normalize_axes(destination, x.ndim)
+    _check_axis_tuples(source_axes, destination_axes)
+    axis_order = _moveaxis_order(source_axes, destination_axes, x.ndim)
+    if not _preserves_quantum_axes(axis_order, x.ndim):
+        _raise_quantum_axis_error('moveaxis')
+
+    if isinstance(x.data, DenseDataArray):
+        data = DenseDataArray(jnp.moveaxis(x.data.data, source_axes, destination_axes))
+    else:
+        sparse_data = (
+            x.data.mT if axis_order[-2:] == (x.ndim - 1, x.ndim - 2) else x.data
+        )
+        batch_order = axis_order[:-2]
+        diags = jnp.transpose(sparse_data.diags, (*batch_order, x.ndim - 2, x.ndim - 1))
+        data = SparseDIADataArray(sparse_data.offsets, diags)
+
+    return MaterializedQArray(x.dims, x.vectorized, data)
+
+
+def expand_dims(x: QArrayLike, axis: int | Sequence[int]) -> QArray:
+    """Expand the shape of a qarray by inserting new axes.
+
+    Args:
+        x: Qarray-like object.
+        axis: Axis or axes where new dimensions are inserted.
+
+    Returns:
+        Qarray with additional dimensions.
+    """
+    x = asqarray(x)
+    axes = _normalize_insert_axes(axis, x.ndim)
+    out_ndim = x.ndim + len(axes)
+    if not all(a < out_ndim - 2 for a in axes):
+        _raise_quantum_axis_error('expand_dims')
+
+    if isinstance(x.data, DenseDataArray):
+        data = DenseDataArray(jnp.expand_dims(x.data.data, axis=axes))
+    else:
+        data = SparseDIADataArray(
+            x.data.offsets, jnp.expand_dims(x.data.diags, axis=axes)
+        )
+
+    return MaterializedQArray(x.dims, x.vectorized, data)
+
+
+def where(condition: ArrayLike, x: QArrayLike, y: QArrayLike) -> QArray:
+    """Select values from two qarrays depending on a condition.
+
+    Args:
+        condition: Boolean array-like condition.
+        x: Values selected when `condition` is true.
+        y: Values selected when `condition` is false.
+
+    Returns:
+        Qarray with values chosen from `x` and `y`.
+    """
+    x_is_qarray = isinstance(x, QArray)
+    y_is_qarray = isinstance(y, QArray)
+
+    if not x_is_qarray and not y_is_qarray:
+        x = asqarray(x)
+        y = asqarray(y)
+        x_is_qarray = y_is_qarray = True
+
+    if x_is_qarray and y_is_qarray:
+        _check_compatible_qarray_metadata(x, y)
+        dims = x.dims
+        vectorized = x.vectorized
+    elif x_is_qarray:
+        _check_compatible_operand_dims(x, y)
+        dims = x.dims
+        vectorized = x.vectorized
+    else:
+        _check_compatible_operand_dims(y, x)
+        dims = y.dims
+        vectorized = y.vectorized
+
+    if _contains_sparse_qarray(x, y):
+        _warn_sparse_to_dense('where')
+
+    data = jnp.where(condition, to_jax(x), to_jax(y))
+    return MaterializedQArray(dims, vectorized, DenseDataArray(data))
+
+
+def concatenate(qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray:
+    """Join a sequence of qarrays along an existing axis.
+
+    Args:
+        qarrays: Qarrays to concatenate.
+        axis: Axis in the result along which the input qarrays are concatenated.
+
+    Returns:
+        Concatenated qarray.
+    """
+    if len(qarrays) == 0:
+        raise ValueError('Argument `qarrays` must contain at least one element.')
+
+    qarrays = tuple(asqarray(q) for q in qarrays)
+    dims = qarrays[0].dims
+    vectorized = qarrays[0].vectorized
+    axis = _normalize_axis(axis, qarrays[0].ndim)
+    if not _axes_are_batch_axes((axis,), qarrays[0].ndim):
+        _raise_quantum_axis_error('concatenate')
+
+    if not all(q.dims == dims for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with identical `dims` attribute.'
+        )
+    if not all(q.shape[-2:] == qarrays[0].shape[-2:] for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with identical final two '
+            'dimensions.'
+        )
+    if not all(q.vectorized == vectorized for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with identical `vectorized` '
+            'attribute.'
+        )
+
+    if all(isinstance(q.data, DenseDataArray) for q in qarrays):
+        data = DenseDataArray(jnp.concatenate([q.data.data for q in qarrays], axis))
+    elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays) and all(
+        q.data.offsets == qarrays[0].data.offsets for q in qarrays
+    ):
+        data = SparseDIADataArray(
+            qarrays[0].data.offsets,
+            jnp.concatenate([q.data.diags for q in qarrays], axis),
+        )
+    else:
+        _warn_sparse_to_dense('concatenate')
+        data = DenseDataArray(jnp.concatenate([q.to_jax() for q in qarrays], axis))
+
+    return MaterializedQArray(dims, vectorized, data)
+
+
 def to_qutip(x: QArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:
     r"""Convert a qarray-like into a QuTiP Qobj or list of Qobjs.
 
@@ -316,3 +506,112 @@ def _assert_dims_match_shape(dims: tuple[int, ...], shape: tuple[int, ...]):
             f'Argument `dims={dims}` is incompatible with the input shape'
             f' `shape={shape}`.'
         )
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    if not -ndim <= axis < ndim:
+        raise ValueError(f'axis {axis} is out of bounds for array of dimension {ndim}')
+    return axis % ndim
+
+
+def _normalize_axes(axis: int | Sequence[int], ndim: int) -> tuple[int, ...]:
+    axes = (axis,) if isinstance(axis, int) else tuple(axis)
+    return tuple(_normalize_axis(a, ndim) for a in axes)
+
+
+def _normalize_insert_axes(axis: int | Sequence[int], ndim: int) -> tuple[int, ...]:
+    axes = (axis,) if isinstance(axis, int) else tuple(axis)
+    out_ndim = ndim + len(axes)
+    normalized_axes = tuple(_normalize_axis(a, out_ndim) for a in axes)
+    if len(set(normalized_axes)) != len(normalized_axes):
+        raise ValueError('repeated axis')
+    return normalized_axes
+
+
+def _check_axis_tuples(source: tuple[int, ...], destination: tuple[int, ...]) -> None:
+    if len(source) != len(destination):
+        raise ValueError(
+            '`source` and `destination` arguments must have the same number of axes.'
+        )
+    if len(set(source)) != len(source):
+        raise ValueError('repeated axis in `source` argument')
+    if len(set(destination)) != len(destination):
+        raise ValueError('repeated axis in `destination` argument')
+
+
+def _axes_are_batch_axes(axes: tuple[int, ...], ndim: int) -> bool:
+    return all(a < ndim - 2 for a in axes)
+
+
+def _moveaxis_order(
+    source: tuple[int, ...], destination: tuple[int, ...], ndim: int
+) -> tuple[int, ...]:
+    order = [axis for axis in range(ndim) if axis not in source]
+    for destination_axis, source_axis in sorted(zip(destination, source, strict=True)):
+        order.insert(destination_axis, source_axis)
+    return tuple(order)
+
+
+def _preserves_quantum_axes(axis_order: tuple[int, ...], ndim: int) -> bool:
+    return all(axis < ndim - 2 for axis in axis_order[:-2]) and set(
+        axis_order[-2:]
+    ) == {ndim - 2, ndim - 1}
+
+
+def _contains_sparse_qarray(*xs: QArrayLike) -> bool:
+    return any(
+        isinstance(x, QArray) and isinstance(x.data, SparseDIADataArray) for x in xs
+    )
+
+
+def _raise_quantum_axis_error(operation: str) -> None:
+    raise ValueError(
+        f'`{operation}` can only manipulate batching dimensions of a qarray; the '
+        'final two dimensions represent the quantum object. Use `swapaxes(-1, -2)` '
+        'or `.mT` to transpose those final dimensions.'
+    )
+
+
+def _check_compatible_qarray_metadata(x: QArray, y: QArray) -> None:
+    if x.dims != y.dims:
+        raise ValueError(
+            f'Qarrays have incompatible Hilbert space dimensions. '
+            f'Got {x.dims} and {y.dims}.'
+        )
+    if x.shape[-2:] != y.shape[-2:]:
+        raise ValueError(
+            'Qarrays have incompatible final two dimensions. '
+            f'Got {x.shape[-2:]} and {y.shape[-2:]}.'
+        )
+    if x.vectorized != y.vectorized:
+        raise ValueError(
+            'Qarrays have incompatible `vectorized` attributes. '
+            f'Got {x.vectorized} and {y.vectorized}.'
+        )
+
+
+def _check_compatible_operand_dims(reference: QArray, other: QArrayLike) -> None:
+    other_dims = get_dims(other)
+    if other_dims is not None and reference.dims != other_dims:
+        raise ValueError(
+            f'Qarrays have incompatible Hilbert space dimensions. '
+            f'Got {reference.dims} and {other_dims}.'
+        )
+    other_shape = to_jax(other).shape
+    if (
+        len(other_shape) >= 2
+        and other_shape[-2:] != (1, 1)
+        and other_shape[-2:] != reference.shape[-2:]
+    ):
+        raise ValueError(
+            'Qarrays have incompatible final two dimensions. '
+            f'Got {reference.shape[-2:]} and {other_shape[-2:]}.'
+        )
+
+
+def _warn_sparse_to_dense(operation: str) -> None:
+    warnings.warn(
+        'A sparse qarray has been converted to dense layout while applying '
+        f'`{operation}`.',
+        stacklevel=2,
+    )

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -24,6 +24,7 @@ from .sparsedia_dataarray import SparseDIADataArray
 from .sparsedia_primitives import (
     array_to_sparsedia,
     autopad_sparsedia_diags,
+    concatenate_sparsedia,
     shape_sparsedia,
     stack_sparsedia,
 )
@@ -304,20 +305,16 @@ def where(condition: ArrayLike, x: QArrayLike, y: QArrayLike) -> QArray:
     return MaterializedQArray(dims, vectorized, DenseDataArray(data))
 
 
-def concatenate(qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray:
-    """Join a sequence of qarrays along an existing axis.
-
-    Args:
-        qarrays: Qarrays to concatenate.
-        axis: Axis in the result along which the input qarrays are concatenated.
-
-    Returns:
-        Concatenated qarray.
-    """
+def _check_concatenate_input(
+    qarrays: Sequence[QArray], axis: int
+) -> tuple[tuple[int, ...], bool, int]:
     if len(qarrays) == 0:
         raise ValueError('Argument `qarrays` must contain at least one element.')
+    if not all(isinstance(q, QArray) for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain only elements of type `QArray`.'
+        )
 
-    qarrays = tuple(asqarray(q) for q in qarrays)
     dims = qarrays[0].dims
     vectorized = qarrays[0].vectorized
     ndim = qarrays[0].ndim
@@ -334,6 +331,11 @@ def concatenate(qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray:
         raise ValueError(
             'Argument `qarrays` must contain elements with identical `dims` attribute.'
         )
+    if not all(q.ndim == ndim for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with the same number of '
+            'batching dimensions.'
+        )
     if not all(q.shape[-2:] == qarrays[0].shape[-2:] for q in qarrays):
         raise ValueError(
             'Argument `qarrays` must contain elements with identical final two '
@@ -345,15 +347,30 @@ def concatenate(qarrays: Sequence[QArrayLike], axis: int = 0) -> QArray:
             'attribute.'
         )
 
+    return dims, vectorized, axis
+
+
+def concatenate(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
+    """Join a sequence of qarrays along an existing axis.
+
+    Args:
+        qarrays: Qarrays to concatenate.
+        axis: Axis in the result along which the input qarrays are concatenated.
+
+    Returns:
+        Concatenated qarray.
+    """
+    dims, vectorized, axis = _check_concatenate_input(qarrays, axis)
+
     if all(isinstance(q.data, DenseDataArray) for q in qarrays):
         data = DenseDataArray(jnp.concatenate([q.data.data for q in qarrays], axis))
-    elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays) and all(
-        q.data.offsets == qarrays[0].data.offsets for q in qarrays
-    ):
-        data = SparseDIADataArray(
-            qarrays[0].data.offsets,
-            jnp.concatenate([q.data.diags for q in qarrays], axis),
+    elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays):
+        offsets, diags = concatenate_sparsedia(
+            [q.data.offsets for q in qarrays],
+            [q.data.diags for q in qarrays],
+            axis=axis,
         )
+        data = SparseDIADataArray(offsets, diags)
     else:
         _warn_sparse_to_dense('concatenate')
         data = DenseDataArray(jnp.concatenate([q.to_jax() for q in qarrays], axis))

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -11,7 +11,15 @@ from qutip import Qobj
 from .dense_dataarray import DenseDataArray, array_to_qobj_list
 from .layout import Layout, dense
 from .materialized_qarray import MaterializedQArray
-from .qarray import QArray, QArrayLike, get_dims, isqarraylike, to_jax, to_numpy
+from .qarray import (
+    QArray,
+    QArrayLike,
+    check_compatible_dims,
+    get_dims,
+    isqarraylike,
+    to_jax,
+    to_numpy,
+)
 from .sparsedia_dataarray import SparseDIADataArray
 from .sparsedia_primitives import (
     array_to_sparsedia,
@@ -220,28 +228,7 @@ def swapaxes(x: QArrayLike, axis1: int, axis2: int) -> QArray:
     Returns:
         Qarray with axes `axis1` and `axis2` interchanged.
     """
-    x = asqarray(x)
-    axis1 = _normalize_axis(axis1, x.ndim)
-    axis2 = _normalize_axis(axis2, x.ndim)
-
-    if axis1 == axis2:
-        return x
-    if not (
-        _axes_are_batch_axes((axis1, axis2), x.ndim)
-        or {axis1, axis2} == {x.ndim - 2, x.ndim - 1}
-    ):
-        _raise_quantum_axis_error('swapaxes')
-
-    if isinstance(x.data, DenseDataArray):
-        data = DenseDataArray(jnp.swapaxes(x.data.data, axis1, axis2))
-    elif _axes_are_batch_axes((axis1, axis2), x.ndim):
-        data = SparseDIADataArray(
-            x.data.offsets, jnp.swapaxes(x.data.diags, axis1, axis2)
-        )
-    else:
-        data = x.data.mT
-
-    return MaterializedQArray(x.dims, x.vectorized, data)
+    return asqarray(x).swapaxes(axis1, axis2)
 
 
 def moveaxis(
@@ -257,25 +244,7 @@ def moveaxis(
     Returns:
         Qarray with moved axes.
     """
-    x = asqarray(x)
-    source_axes = _normalize_axes(source, x.ndim)
-    destination_axes = _normalize_axes(destination, x.ndim)
-    _check_axis_tuples(source_axes, destination_axes)
-    axis_order = _moveaxis_order(source_axes, destination_axes, x.ndim)
-    if not _preserves_quantum_axes(axis_order, x.ndim):
-        _raise_quantum_axis_error('moveaxis')
-
-    if isinstance(x.data, DenseDataArray):
-        data = DenseDataArray(jnp.moveaxis(x.data.data, source_axes, destination_axes))
-    else:
-        sparse_data = (
-            x.data.mT if axis_order[-2:] == (x.ndim - 1, x.ndim - 2) else x.data
-        )
-        batch_order = axis_order[:-2]
-        diags = jnp.transpose(sparse_data.diags, (*batch_order, x.ndim - 2, x.ndim - 1))
-        data = SparseDIADataArray(sparse_data.offsets, diags)
-
-    return MaterializedQArray(x.dims, x.vectorized, data)
+    return asqarray(x).moveaxis(source, destination)
 
 
 def expand_dims(x: QArrayLike, axis: int | Sequence[int]) -> QArray:
@@ -288,20 +257,7 @@ def expand_dims(x: QArrayLike, axis: int | Sequence[int]) -> QArray:
     Returns:
         Qarray with additional dimensions.
     """
-    x = asqarray(x)
-    axes = _normalize_insert_axes(axis, x.ndim)
-    out_ndim = x.ndim + len(axes)
-    if not all(a < out_ndim - 2 for a in axes):
-        _raise_quantum_axis_error('expand_dims')
-
-    if isinstance(x.data, DenseDataArray):
-        data = DenseDataArray(jnp.expand_dims(x.data.data, axis=axes))
-    else:
-        data = SparseDIADataArray(
-            x.data.offsets, jnp.expand_dims(x.data.diags, axis=axes)
-        )
-
-    return MaterializedQArray(x.dims, x.vectorized, data)
+    return asqarray(x).expand_dims(axis)
 
 
 def where(condition: ArrayLike, x: QArrayLike, y: QArrayLike) -> QArray:
@@ -319,20 +275,21 @@ def where(condition: ArrayLike, x: QArrayLike, y: QArrayLike) -> QArray:
     y_is_qarray = isinstance(y, QArray)
 
     if not x_is_qarray and not y_is_qarray:
-        x = asqarray(x)
-        y = asqarray(y)
-        x_is_qarray = y_is_qarray = True
+        raise TypeError(
+            'At least one of `x` or `y` must be a QArray. For non-qarray operands, '
+            'use `jax.numpy.where` directly.'
+        )
 
     if x_is_qarray and y_is_qarray:
         _check_compatible_qarray_metadata(x, y)
         dims = x.dims
         vectorized = x.vectorized
     elif x_is_qarray:
-        _check_compatible_operand_dims(x, y)
+        _check_qarraylike_dims(x, y)
         dims = x.dims
         vectorized = x.vectorized
     else:
-        _check_compatible_operand_dims(y, x)
+        _check_qarraylike_dims(y, x)
         dims = y.dims
         vectorized = y.vectorized
 
@@ -552,12 +509,6 @@ def _moveaxis_order(
     return tuple(order)
 
 
-def _preserves_quantum_axes(axis_order: tuple[int, ...], ndim: int) -> bool:
-    return all(axis < ndim - 2 for axis in axis_order[:-2]) and set(
-        axis_order[-2:]
-    ) == {ndim - 2, ndim - 1}
-
-
 def _contains_sparse_qarray(*xs: QArrayLike) -> bool:
     return any(
         isinstance(x, QArray) and isinstance(x.data, SparseDIADataArray) for x in xs
@@ -573,11 +524,7 @@ def _raise_quantum_axis_error(operation: str) -> None:
 
 
 def _check_compatible_qarray_metadata(x: QArray, y: QArray) -> None:
-    if x.dims != y.dims:
-        raise ValueError(
-            f'Qarrays have incompatible Hilbert space dimensions. '
-            f'Got {x.dims} and {y.dims}.'
-        )
+    check_compatible_dims(x.dims, y.dims)
     if x.shape[-2:] != y.shape[-2:]:
         raise ValueError(
             'Qarrays have incompatible final two dimensions. '
@@ -590,23 +537,10 @@ def _check_compatible_qarray_metadata(x: QArray, y: QArray) -> None:
         )
 
 
-def _check_compatible_operand_dims(reference: QArray, other: QArrayLike) -> None:
+def _check_qarraylike_dims(reference: QArray, other: QArrayLike) -> None:
     other_dims = get_dims(other)
-    if other_dims is not None and reference.dims != other_dims:
-        raise ValueError(
-            f'Qarrays have incompatible Hilbert space dimensions. '
-            f'Got {reference.dims} and {other_dims}.'
-        )
-    other_shape = to_jax(other).shape
-    if (
-        len(other_shape) >= 2
-        and other_shape[-2:] != (1, 1)
-        and other_shape[-2:] != reference.shape[-2:]
-    ):
-        raise ValueError(
-            'Qarrays have incompatible final two dimensions. '
-            f'Got {reference.shape[-2:]} and {other_shape[-2:]}.'
-        )
+    if other_dims is not None:
+        check_compatible_dims(reference.dims, other_dims)
 
 
 def _warn_sparse_to_dense(operation: str) -> None:

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -293,73 +293,33 @@ def where(condition: ArrayLike, x: QArrayLike, y: QArrayLike) -> QArray:
             'use `jax.numpy.where` directly.'
         )
 
-    if x_is_qarray and y_is_qarray:
+    if isinstance(x, MaterializedQArray) and isinstance(y, MaterializedQArray):
         _check_compatible_qarray_metadata(x, y)
         dims = x.dims
         vectorized = x.vectorized
-    elif x_is_qarray:
+    elif isinstance(x, MaterializedQArray):
         y_dims = get_dims(y)
         if y_dims is not None:
             check_compatible_dims(x.dims, y_dims)
         dims = x.dims
         vectorized = x.vectorized
-    else:
+    elif isinstance(y, MaterializedQArray):
         x_dims = get_dims(x)
         if x_dims is not None:
             check_compatible_dims(y.dims, x_dims)
         dims = y.dims
         vectorized = y.vectorized
+    else:
+        raise NotImplementedError(
+            '`where` is only implemented for materialized qarrays.'
+        )
 
     if _contains_sparse_qarray(x, y):
+        # TODO: Generalize implementation of `dq.where` to sparse dia layout.
         _warn_sparse_to_dense('where')
 
     data = jnp.where(condition, to_jax(x), to_jax(y))
     return MaterializedQArray(dims, vectorized, DenseDataArray(data))
-
-
-def _check_concatenate_input(
-    qarrays: Sequence[QArray], axis: int
-) -> tuple[tuple[int, ...], bool, int]:
-    if len(qarrays) == 0:
-        raise ValueError('Argument `qarrays` must contain at least one element.')
-    if not all(isinstance(q, QArray) for q in qarrays):
-        raise ValueError(
-            'Argument `qarrays` must contain only elements of type `QArray`.'
-        )
-
-    dims = qarrays[0].dims
-    vectorized = qarrays[0].vectorized
-    ndim = qarrays[0].ndim
-    if not -ndim <= axis < ndim:
-        raise ValueError(f'axis {axis} is out of bounds for array of dimension {ndim}')
-    axis = axis % ndim
-    if axis >= ndim - 2:
-        raise ValueError(
-            '`concatenate` can only manipulate batching dimensions of a qarray; the '
-            'final two dimensions are matrix dimensions.'
-        )
-
-    if not all(q.dims == dims for q in qarrays):
-        raise ValueError(
-            'Argument `qarrays` must contain elements with identical `dims` attribute.'
-        )
-    if not all(q.ndim == ndim for q in qarrays):
-        raise ValueError(
-            'Argument `qarrays` must contain elements with the same number of '
-            'batching dimensions.'
-        )
-    if not all(q.shape[-2:] == qarrays[0].shape[-2:] for q in qarrays):
-        raise ValueError(
-            'Argument `qarrays` must contain elements with identical final two '
-            'dimensions.'
-        )
-    if not all(q.vectorized == vectorized for q in qarrays):
-        raise ValueError(
-            'Argument `qarrays` must contain elements with identical `vectorized` '
-            'attribute.'
-        )
-
-    return dims, vectorized, axis
 
 
 def concatenate(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
@@ -372,14 +332,16 @@ def concatenate(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
     Returns:
         Concatenated qarray.
     """
-    dims, vectorized, axis = _check_concatenate_input(qarrays, axis)
+    qarrays, dims, vectorized, axis = _check_concatenate_input(qarrays, axis)
 
     if all(isinstance(q.data, DenseDataArray) for q in qarrays):
-        data = DenseDataArray(jnp.concatenate([q.data.data for q in qarrays], axis))
+        data = DenseDataArray(
+            jnp.concatenate([cast(DenseDataArray, q.data).data for q in qarrays], axis)
+        )
     elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays):
         offsets, diags = concatenate_sparsedia(
-            [q.data.offsets for q in qarrays],
-            [q.data.diags for q in qarrays],
+            [cast(SparseDIADataArray, q.data).offsets for q in qarrays],
+            [cast(SparseDIADataArray, q.data).diags for q in qarrays],
             axis=axis,
         )
         data = SparseDIADataArray(offsets, diags)
@@ -388,6 +350,52 @@ def concatenate(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
         data = DenseDataArray(jnp.concatenate([q.to_jax() for q in qarrays], axis))
 
     return MaterializedQArray(dims, vectorized, data)
+
+
+def _check_concatenate_input(
+    qarrays: Sequence[QArray], axis: int
+) -> tuple[list[MaterializedQArray], tuple[int, ...], bool, int]:
+    if len(qarrays) == 0:
+        raise ValueError('Argument `qarrays` must contain at least one element.')
+    if not all(isinstance(q, MaterializedQArray) for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain only elements of type `QArray`.'
+        )
+
+    materialized_qarrays = cast(list[MaterializedQArray], qarrays)
+    dims = materialized_qarrays[0].dims
+    vectorized = materialized_qarrays[0].vectorized
+    ndim = materialized_qarrays[0].ndim
+    if not -ndim <= axis < ndim:
+        raise ValueError(f'axis {axis} is out of bounds for array of dimension {ndim}')
+    axis = axis % ndim
+    if axis >= ndim - 2:
+        raise ValueError(
+            '`concatenate` can only manipulate batching dimensions of a qarray; the '
+            'final two dimensions are matrix dimensions.'
+        )
+
+    if not all(q.dims == dims for q in materialized_qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with identical `dims` attribute.'
+        )
+    if not all(q.ndim == ndim for q in materialized_qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with the same number of '
+            'batching dimensions.'
+        )
+    if not all(q.shape[-2:] == materialized_qarrays[0].shape[-2:] for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with identical final two '
+            'dimensions.'
+        )
+    if not all(q.vectorized == vectorized for q in materialized_qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with identical `vectorized` '
+            'attribute.'
+        )
+
+    return materialized_qarrays, dims, vectorized, axis
 
 
 def to_qutip(x: QArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:
@@ -506,11 +514,14 @@ def _assert_dims_match_shape(dims: tuple[int, ...], shape: tuple[int, ...]):
 
 def _contains_sparse_qarray(*xs: QArrayLike) -> bool:
     return any(
-        isinstance(x, QArray) and isinstance(x.data, SparseDIADataArray) for x in xs
+        isinstance(x, MaterializedQArray) and isinstance(x.data, SparseDIADataArray)
+        for x in xs
     )
 
 
-def _check_compatible_qarray_metadata(x: QArray, y: QArray) -> None:
+def _check_compatible_qarray_metadata(
+    x: MaterializedQArray, y: MaterializedQArray
+) -> None:
     check_compatible_dims(x.dims, y.dims)
     if x.shape[-2:] != y.shape[-2:]:
         raise ValueError(

--- a/tests/qarrays/test_qarray_manipulation.py
+++ b/tests/qarrays/test_qarray_manipulation.py
@@ -45,6 +45,19 @@ def test_moveaxis_dense_matches_jax(batched_data, batched_qarray):
 
 
 @pytest.mark.run(order=TEST_INSTANT)
+def test_moveaxis_dense_multi_axis_matches_jax():
+    data = jnp.arange(2 * 3 * 5 * 4 * 4, dtype=jnp.float32).reshape(2, 3, 5, 4, 4)
+    qarray = dq.asqarray(data, dims=(2, 2))
+
+    result = qarray.moveaxis((0, 1), (2, 0))
+
+    assert result.shape == (3, 5, 2, 4, 4)
+    assert result.dims == (2, 2)
+    assert result.layout == dq.dense
+    assert jnp.array_equal(result.to_jax(), jnp.moveaxis(data, (0, 1), (2, 0)))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
 def test_expand_dims_dense_matches_jax(batched_data, batched_qarray):
     result = dq.expand_dims(batched_qarray, axis=(0, 2))
 
@@ -161,7 +174,7 @@ def test_where_sparse_converts_to_dense_with_warning():
     ],
 )
 def test_quantum_axis_manipulation_raises(batched_qarray, operation, args):
-    match = 'final two dimensions represent the quantum object'
+    match = 'final two dimensions'
 
     with pytest.raises(ValueError, match=match):
         _apply_quantum_axis_operation(batched_qarray, operation, args)

--- a/tests/qarrays/test_qarray_manipulation.py
+++ b/tests/qarrays/test_qarray_manipulation.py
@@ -248,6 +248,18 @@ def test_sparse_moveaxis_final_axes_preserves_sparse_layout():
 
 
 @pytest.mark.run(order=TEST_INSTANT)
+def test_moveaxis_can_swap_final_axes_while_moving_batch_axes():
+    qarray = dq.eye(4).broadcast_to(1, 1, 4, 4)
+
+    result = qarray.moveaxis((0, -1, -2), (1, -2, -1))
+
+    assert result.layout == dq.dia
+    assert jnp.array_equal(
+        result.to_jax(), jnp.moveaxis(qarray.to_jax(), (0, -1, -2), (1, -2, -1))
+    )
+
+
+@pytest.mark.run(order=TEST_INSTANT)
 def test_where_sparse_converts_to_dense_with_warning():
     x_data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
     y_data = -x_data

--- a/tests/qarrays/test_qarray_manipulation.py
+++ b/tests/qarrays/test_qarray_manipulation.py
@@ -90,9 +90,6 @@ def test_concatenate_dense_matches_jax():
     assert result.layout == dq.dense
     assert jnp.array_equal(result.to_jax(), jnp.concatenate([x_data, y_data], axis=0))
 
-    method_result = x.concatenate([y], axis=0)
-    assert jnp.array_equal(method_result.to_jax(), result.to_jax())
-
 
 @pytest.mark.run(order=TEST_INSTANT)
 @pytest.mark.parametrize('operation', ['swapaxes', 'moveaxis', 'expand_dims'])
@@ -177,6 +174,12 @@ def test_where_rejects_incompatible_quantum_shapes():
 
     with pytest.raises(ValueError, match='final two dimensions'):
         dq.where(True, operator, ket)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_requires_qarray_operand():
+    with pytest.raises(TypeError, match=r'jax\.numpy\.where'):
+        dq.where(True, 1.0, 2.0)
 
 
 @pytest.mark.run(order=TEST_INSTANT)

--- a/tests/qarrays/test_qarray_manipulation.py
+++ b/tests/qarrays/test_qarray_manipulation.py
@@ -1,0 +1,199 @@
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+
+from ..order import TEST_INSTANT
+
+
+@pytest.fixture
+def batched_data():
+    return jnp.arange(2 * 3 * 4 * 4, dtype=jnp.float32).reshape(2, 3, 4, 4)
+
+
+@pytest.fixture
+def batched_qarray(batched_data):
+    return dq.asqarray(batched_data, dims=(2, 2))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_swapaxes_dense_matches_jax(batched_data, batched_qarray):
+    result = dq.swapaxes(batched_qarray, 0, 1)
+
+    assert result.shape == (3, 2, 4, 4)
+    assert result.dims == (2, 2)
+    assert result.dtype == batched_qarray.dtype
+    assert result.layout == dq.dense
+    assert jnp.array_equal(result.to_jax(), jnp.swapaxes(batched_data, 0, 1))
+
+    mt = batched_qarray.swapaxes(-1, -2)
+    assert jnp.array_equal(mt.to_jax(), jnp.swapaxes(batched_data, -1, -2))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_moveaxis_dense_matches_jax(batched_data, batched_qarray):
+    result = batched_qarray.moveaxis(0, 1)
+
+    assert result.shape == (3, 2, 4, 4)
+    assert result.dims == (2, 2)
+    assert result.dtype == batched_qarray.dtype
+    assert result.layout == dq.dense
+    assert jnp.array_equal(result.to_jax(), jnp.moveaxis(batched_data, 0, 1))
+
+    mt = dq.moveaxis(batched_qarray, -1, -2)
+    assert jnp.array_equal(mt.to_jax(), jnp.moveaxis(batched_data, -1, -2))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_expand_dims_dense_matches_jax(batched_data, batched_qarray):
+    result = dq.expand_dims(batched_qarray, axis=(0, 2))
+
+    assert result.shape == (1, 2, 1, 3, 4, 4)
+    assert result.dims == (2, 2)
+    assert result.dtype == batched_qarray.dtype
+    assert result.layout == dq.dense
+    assert jnp.array_equal(result.to_jax(), jnp.expand_dims(batched_data, axis=(0, 2)))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_matches_jax_and_accepts_scalars():
+    x_data = jnp.arange(2 * 3 * 3, dtype=jnp.float32).reshape(2, 3, 3)
+    y_data = -x_data
+    condition = jnp.asarray([True, False])[:, None, None]
+    x = dq.asqarray(x_data)
+    y = dq.asqarray(y_data)
+
+    result = dq.where(condition, x, y)
+
+    assert result.shape == (2, 3, 3)
+    assert result.dims == (3,)
+    assert result.dtype == x.dtype
+    assert result.layout == dq.dense
+    assert jnp.array_equal(result.to_jax(), jnp.where(condition, x_data, y_data))
+
+    scalar_result = x.where(condition, 0.0)
+    assert jnp.array_equal(scalar_result.to_jax(), jnp.where(condition, x_data, 0.0))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_concatenate_dense_matches_jax():
+    x_data = jnp.arange(2 * 3 * 3, dtype=jnp.float32).reshape(2, 3, 3)
+    y_data = -x_data
+    x = dq.asqarray(x_data)
+    y = dq.asqarray(y_data)
+
+    result = dq.concatenate([x, y], axis=0)
+
+    assert result.shape == (4, 3, 3)
+    assert result.dims == (3,)
+    assert result.dtype == x.dtype
+    assert result.layout == dq.dense
+    assert jnp.array_equal(result.to_jax(), jnp.concatenate([x_data, y_data], axis=0))
+
+    method_result = x.concatenate([y], axis=0)
+    assert jnp.array_equal(method_result.to_jax(), result.to_jax())
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize('operation', ['swapaxes', 'moveaxis', 'expand_dims'])
+def test_sparse_batch_axis_manipulation_preserves_sparse_layout(operation):
+    data = jnp.arange(2 * 3 * 4 * 4, dtype=jnp.float32).reshape(2, 3, 4, 4)
+    qarray = dq.asqarray(data, dims=(4,), layout=dq.dia)
+
+    if operation == 'swapaxes':
+        result = dq.swapaxes(qarray, 0, 1)
+        expected = jnp.swapaxes(data, 0, 1)
+    elif operation == 'moveaxis':
+        result = dq.moveaxis(qarray, 0, 1)
+        expected = jnp.moveaxis(data, 0, 1)
+    else:
+        result = dq.expand_dims(qarray, 0)
+        expected = jnp.expand_dims(data, 0)
+
+    assert result.layout == dq.dia
+    assert jnp.array_equal(result.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_sparse_concatenate_batch_axis_preserves_sparse_layout():
+    x_data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    y_data = -x_data
+    x = dq.asqarray(x_data, layout=dq.dia)
+    y = dq.asqarray(y_data, layout=dq.dia)
+
+    result = dq.concatenate([x, y], axis=0)
+
+    assert result.layout == dq.dia
+    assert jnp.array_equal(result.to_jax(), jnp.concatenate([x_data, y_data], axis=0))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_sparse_moveaxis_final_axes_preserves_sparse_layout():
+    data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    qarray = dq.asqarray(data, layout=dq.dia)
+
+    result = dq.moveaxis(qarray, -1, -2)
+
+    assert result.layout == dq.dia
+    assert jnp.array_equal(result.to_jax(), jnp.moveaxis(data, -1, -2))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_sparse_converts_to_dense_with_warning():
+    x_data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    y_data = -x_data
+    condition = jnp.asarray([True, False])[:, None, None]
+    x = dq.asqarray(x_data, layout=dq.dia)
+    y = dq.asqarray(y_data, layout=dq.dia)
+
+    with pytest.warns(UserWarning, match='converted to dense layout'):
+        result = dq.where(condition, x, y)
+
+    assert result.layout == dq.dense
+    assert jnp.array_equal(result.to_jax(), jnp.where(condition, x_data, y_data))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize(
+    ('operation', 'args'),
+    [
+        ('swapaxes', (0, -1)),
+        ('moveaxis', (0, -1)),
+        ('expand_dims', (-1,)),
+        ('concatenate', (-1,)),
+    ],
+)
+def test_quantum_axis_manipulation_raises(batched_qarray, operation, args):
+    match = 'final two dimensions represent the quantum object'
+
+    with pytest.raises(ValueError, match=match):
+        _apply_quantum_axis_operation(batched_qarray, operation, args)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_rejects_incompatible_quantum_shapes():
+    operator = dq.eye(3)
+    ket = dq.fock(3, 0)
+
+    with pytest.raises(ValueError, match='final two dimensions'):
+        dq.where(True, operator, ket)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_concatenate_rejects_incompatible_dims():
+    x = dq.eye(2)
+    y = dq.eye(3)
+
+    with pytest.raises(ValueError, match='identical `dims`'):
+        dq.concatenate([dq.stack([x]), dq.stack([y])], axis=0)
+
+
+def _apply_quantum_axis_operation(qarray, operation, args):
+    if operation == 'swapaxes':
+        return dq.swapaxes(qarray, *args)
+    elif operation == 'moveaxis':
+        return dq.moveaxis(qarray, *args)
+    elif operation == 'expand_dims':
+        return dq.expand_dims(qarray, *args)
+    else:
+        return dq.concatenate([qarray, qarray], axis=args[0])

--- a/tests/qarrays/test_qarray_manipulation.py
+++ b/tests/qarrays/test_qarray_manipulation.py
@@ -138,6 +138,20 @@ def test_sparse_concatenate_batch_axis_preserves_sparse_layout():
 
 
 @pytest.mark.run(order=TEST_INSTANT)
+def test_sparse_concatenate_merges_different_offsets():
+    x = dq.sparsedia_from_dict({0: jnp.ones((2, 4))})
+    y = dq.sparsedia_from_dict({1: jnp.ones((3, 3))})
+
+    result = dq.concatenate([x, y], axis=0)
+
+    assert result.layout == dq.dia
+    assert result.data.offsets == (0, 1)
+    assert jnp.array_equal(
+        result.to_jax(), jnp.concatenate([x.to_jax(), y.to_jax()], axis=0)
+    )
+
+
+@pytest.mark.run(order=TEST_INSTANT)
 def test_sparse_moveaxis_final_axes_preserves_sparse_layout():
     data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
     qarray = dq.asqarray(data, layout=dq.dia)
@@ -202,6 +216,21 @@ def test_concatenate_rejects_incompatible_dims():
 
     with pytest.raises(ValueError, match='identical `dims`'):
         dq.concatenate([dq.stack([x]), dq.stack([y])], axis=0)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_concatenate_rejects_non_qarray_input():
+    with pytest.raises(ValueError, match='type `QArray`'):
+        dq.concatenate([jnp.ones((2, 2)), jnp.ones((2, 2))], axis=0)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_concatenate_rejects_incompatible_batch_ndim():
+    x = dq.stack([dq.eye(2)])
+    y = dq.stack([dq.stack([dq.eye(2)])])
+
+    with pytest.raises(ValueError, match='batching dimensions'):
+        dq.concatenate([x, y], axis=0)
 
 
 def _apply_quantum_axis_operation(qarray, operation, args):

--- a/tests/qarrays/test_qarray_manipulation.py
+++ b/tests/qarrays/test_qarray_manipulation.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import jax.numpy as jnp
 import pytest
 
@@ -106,6 +108,56 @@ def test_concatenate_dense_matches_jax():
 
 @pytest.mark.run(order=TEST_INSTANT)
 @pytest.mark.parametrize('operation', ['swapaxes', 'moveaxis', 'expand_dims'])
+def test_vectorized_axis_manipulation_preserves_vectorized(operation):
+    data = jnp.arange(2 * 3 * 4 * 4, dtype=jnp.float32).reshape(2, 3, 4, 4)
+    qarray = dq.vectorize(dq.asqarray(data, dims=(2, 2)))
+
+    if operation == 'swapaxes':
+        result = qarray.swapaxes(0, 1)
+        expected = jnp.swapaxes(qarray.to_jax(), 0, 1)
+    elif operation == 'moveaxis':
+        result = qarray.moveaxis(0, 1)
+        expected = jnp.moveaxis(qarray.to_jax(), 0, 1)
+    else:
+        result = qarray.expand_dims(0)
+        expected = jnp.expand_dims(qarray.to_jax(), 0)
+
+    assert result.vectorized
+    assert result.shape == expected.shape
+    assert jnp.array_equal(result.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_vectorized_concatenate_preserves_vectorized():
+    x_data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    y_data = -x_data
+    x = dq.vectorize(dq.asqarray(x_data, dims=(2, 2)))
+    y = dq.vectorize(dq.asqarray(y_data, dims=(2, 2)))
+
+    result = dq.concatenate([x, y], axis=0)
+
+    assert result.vectorized
+    assert jnp.array_equal(result.to_jax(), jnp.concatenate([x.to_jax(), y.to_jax()]))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_vectorized_where_preserves_vectorized():
+    x_data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    y_data = -x_data
+    condition = jnp.asarray([True, False])[:, None, None]
+    x = dq.vectorize(dq.asqarray(x_data, dims=(2, 2)))
+    y = dq.vectorize(dq.asqarray(y_data, dims=(2, 2)))
+
+    result = dq.where(condition, x, y)
+
+    assert result.vectorized
+    assert jnp.array_equal(
+        result.to_jax(), jnp.where(condition, x.to_jax(), y.to_jax())
+    )
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize('operation', ['swapaxes', 'moveaxis', 'expand_dims'])
 def test_sparse_batch_axis_manipulation_preserves_sparse_layout(operation):
     data = jnp.arange(2 * 3 * 4 * 4, dtype=jnp.float32).reshape(2, 3, 4, 4)
     qarray = dq.asqarray(data, dims=(4,), layout=dq.dia)
@@ -122,6 +174,39 @@ def test_sparse_batch_axis_manipulation_preserves_sparse_layout(operation):
 
     assert result.layout == dq.dia
     assert jnp.array_equal(result.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_sparse_swapaxes_final_axes_preserves_sparse_layout():
+    data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    qarray = dq.asqarray(data, layout=dq.dia)
+
+    result = dq.swapaxes(qarray, -1, -2)
+
+    assert result.layout == dq.dia
+    assert jnp.array_equal(result.to_jax(), jnp.swapaxes(data, -1, -2))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_sparse_moveaxis_multi_axis_matches_jax():
+    data = jnp.arange(2 * 3 * 5 * 4 * 4, dtype=jnp.float32).reshape(2, 3, 5, 4, 4)
+    qarray = dq.asqarray(data, dims=(4,), layout=dq.dia)
+
+    result = qarray.moveaxis((0, 1), (2, 0))
+
+    assert result.layout == dq.dia
+    assert jnp.array_equal(result.to_jax(), jnp.moveaxis(data, (0, 1), (2, 0)))
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_sparse_expand_dims_tuple_axis_matches_jax():
+    data = jnp.arange(2 * 3 * 4 * 4, dtype=jnp.float32).reshape(2, 3, 4, 4)
+    qarray = dq.asqarray(data, dims=(4,), layout=dq.dia)
+
+    result = qarray.expand_dims(axis=(0, 2))
+
+    assert result.layout == dq.dia
+    assert jnp.array_equal(result.to_jax(), jnp.expand_dims(data, axis=(0, 2)))
 
 
 @pytest.mark.run(order=TEST_INSTANT)
@@ -210,6 +295,16 @@ def test_where_requires_qarray_operand():
 
 
 @pytest.mark.run(order=TEST_INSTANT)
+def test_where_rejects_mismatched_vectorized_metadata():
+    x_data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    x = dq.vectorize(dq.asqarray(x_data, dims=(2, 2)))
+    y = replace(x, vectorized=False)
+
+    with pytest.raises(ValueError, match='incompatible `vectorized`'):
+        dq.where(True, x, y)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
 def test_concatenate_rejects_incompatible_dims():
     x = dq.eye(2)
     y = dq.eye(3)
@@ -230,6 +325,16 @@ def test_concatenate_rejects_incompatible_batch_ndim():
     y = dq.stack([dq.stack([dq.eye(2)])])
 
     with pytest.raises(ValueError, match='batching dimensions'):
+        dq.concatenate([x, y], axis=0)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_concatenate_rejects_mismatched_vectorized_metadata():
+    x_data = jnp.arange(2 * 4 * 4, dtype=jnp.float32).reshape(2, 4, 4)
+    x = dq.vectorize(dq.asqarray(x_data, dims=(2, 2)))
+    y = replace(x, vectorized=False)
+
+    with pytest.raises(ValueError, match='identical `vectorized`'):
         dq.concatenate([x, y], axis=0)
 
 


### PR DESCRIPTION
Fixes #1080.

## Summary

- add `swapaxes`, `moveaxis`, `expand_dims`, `where`, and `concatenate` qarray utilities
- expose matching `QArray` convenience methods
- preserve qarray metadata and sparse DIA layout for supported batch-axis operations
- protect the final two quantum-object dimensions from accidental batch-axis manipulation
- add dense, sparse, scalar, shape, and error-path tests against equivalent JAX behavior

## Tests

- `.venv/bin/ruff check dynamiqs/qarrays/qarray.py dynamiqs/qarrays/utils.py tests/qarrays/test_qarray_manipulation.py`
- `.venv/bin/python -m pytest tests/qarrays/test_qarray_manipulation.py`
- `.venv/bin/python -m pytest tests/qarrays`

The full qarray test run passed with 82 tests and 3 existing sparse scalar-add warnings.

## AI assistance disclosure

I used AI assistance to inspect the existing qarray structure, draft parts of this patch, and prepare tests. I reviewed the implementation, adjusted it to maintainer feedback, and ran the validation commands listed above.
