### PR TITLE
Add QArray manipulation utilities

### DIFF
--- a/dynamiqs/qarrays/dataarray.py
+++ b/dynamiqs/qarrays/dataarray.py
@@ -135,6 +135,20 @@ class DataArray(eqx.Module):
         pass
 
     @abstractmethod
+    def swapaxes(self, axis1: int, axis2: int) -> DataArray | Array:
+        pass
+
+    @abstractmethod
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> DataArray | Array:
+        pass
+
+    @abstractmethod
+    def expand_dims(self, axis: int) -> DataArray | Array:
+        pass
+
+    @abstractmethod
     def _eig(self) -> tuple[Array, DataArray]:
         pass
 

--- a/dynamiqs/qarrays/dense_dataarray.py
+++ b/dynamiqs/qarrays/dense_dataarray.py
@@ -90,6 +90,26 @@ class DenseDataArray(DataArray):
         else:
             return replace(self, data=data)  # ty: ignore[invalid-argument-type]
 
+    def swapaxes(self, axis1: int, axis2: int) -> DataArray | Array:
+        data = jnp.swapaxes(self.data, axis1, axis2)
+        if _preserves_qarray_axes_after_swapaxes(self.ndim, axis1, axis2):
+            return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return data
+
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> DataArray | Array:
+        data = jnp.moveaxis(self.data, source, destination)
+        if _preserves_qarray_axes_after_moveaxis(self.ndim, source, destination):
+            return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return data
+
+    def expand_dims(self, axis: int) -> DataArray | Array:
+        data = jnp.expand_dims(self.data, axis)
+        if _preserves_qarray_axes_after_expand_dims(self.ndim, axis):
+            return replace(self, data=data)  # ty: ignore[invalid-argument-type]
+        return data
+
     def _eig(self) -> tuple[Array, DataArray]:
         evals, evecs = jax.lax.linalg.eig(self.data, compute_left_eigenvectors=False)
         return evals, replace(self, data=evecs)  # ty: ignore[invalid-argument-type]
@@ -227,3 +247,55 @@ def array_to_qobj_list(x: Array, dims: tuple[int, ...]) -> Qobj | list[Qobj]:
 def _bkron(a: Array, b: Array) -> Array:
     # batched kronecker product
     return jnp.kron(a, b)
+
+
+def _normalize_axis(axis: int, ndim: int) -> int:
+    axis = axis + ndim if axis < 0 else axis
+    if axis < 0 or axis >= ndim:
+        raise np.exceptions.AxisError(axis, ndim=ndim)
+    return axis
+
+
+def _normalize_axis_tuple(axis: int | tuple[int, ...], ndim: int) -> tuple[int, ...]:
+    axes = (axis,) if isinstance(axis, int) else axis
+    normalized = tuple(_normalize_axis(a, ndim) for a in axes)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError('repeated axis')
+    return normalized
+
+
+def _moveaxis_order(
+    ndim: int, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+) -> tuple[int, ...]:
+    source = _normalize_axis_tuple(source, ndim)
+    destination = _normalize_axis_tuple(destination, ndim)
+    if len(source) != len(destination):
+        raise ValueError(
+            '`source` and `destination` arguments must have the same size.'
+        )
+
+    order = [i for i in range(ndim) if i not in source]
+    for dest, src in sorted(zip(destination, source, strict=True)):
+        order.insert(dest, src)
+    return tuple(order)
+
+
+def _preserves_qarray_axes_after_swapaxes(ndim: int, axis1: int, axis2: int) -> bool:
+    axis1 = _normalize_axis(axis1, ndim)
+    axis2 = _normalize_axis(axis2, ndim)
+    order = list(range(ndim))
+    order[axis1], order[axis2] = order[axis2], order[axis1]
+    return set(order[-2:]) == {ndim - 2, ndim - 1}
+
+
+def _preserves_qarray_axes_after_moveaxis(
+    ndim: int, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+) -> bool:
+    order = _moveaxis_order(ndim, source, destination)
+    return tuple(order[-2:]) == (ndim - 2, ndim - 1)
+
+
+def _preserves_qarray_axes_after_expand_dims(ndim: int, axis: int) -> bool:
+    new_ndim = ndim + 1
+    axis = _normalize_axis(axis, new_ndim)
+    return axis <= ndim - 2

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -126,6 +126,26 @@ class MaterializedQArray(QArray):
             return replace(self, data=result)
         return result
 
+    def swapaxes(self, axis1: int, axis2: int) -> QArray | Array:
+        result = self.data.swapaxes(axis1, axis2)
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> QArray | Array:
+        result = self.data.moveaxis(source, destination)
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
+    def expand_dims(self, axis: int) -> QArray | Array:
+        result = self.data.expand_dims(axis)
+        if isinstance(result, DataArray):
+            return replace(self, data=result)
+        return result
+
     def _eig(self) -> tuple[Array, QArray]:
         evals, evecs = self.data._eig()
         return evals, replace(self, data=evecs)

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -331,6 +331,31 @@ class QArray(eqx.Module):
         pass
 
     @abstractmethod
+    def swapaxes(self, axis1: int, axis2: int) -> QArray | Array:
+        """Interchange two axes of a qarray.
+
+        Returns a qarray when the operation preserves qarray structure, otherwise a
+        JAX array.
+        """
+
+    @abstractmethod
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> QArray | Array:
+        """Move axes of a qarray to new positions.
+
+        Returns a qarray when the operation preserves qarray structure, otherwise a
+        JAX array.
+        """
+
+    @abstractmethod
+    def expand_dims(self, axis: int) -> QArray | Array:
+        """Expand the shape of a qarray by inserting a new axis.
+
+        Returns a qarray when the new axis is a batch axis, otherwise a JAX array.
+        """
+
+    @abstractmethod
     def _eig(self) -> tuple[Array, QArray]:
         pass
 

--- a/dynamiqs/qarrays/sparsedia_dataarray.py
+++ b/dynamiqs/qarrays/sparsedia_dataarray.py
@@ -19,7 +19,13 @@ from .dataarray import (
     in_last_two_dims,
     include_last_two_dims,
 )
-from .dense_dataarray import DenseDataArray
+from .dense_dataarray import (
+    DenseDataArray,
+    _normalize_axis,
+    _preserves_qarray_axes_after_expand_dims,
+    _preserves_qarray_axes_after_moveaxis,
+    _preserves_qarray_axes_after_swapaxes,
+)
 from .layout import Layout, dia
 from .sparsedia_primitives import (
     add_sparsedia_sparsedia,
@@ -153,6 +159,34 @@ class SparseDIADataArray(DataArray):
         else:
             diags = self.diags.squeeze(axis)
             return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+
+    def swapaxes(self, axis1: int, axis2: int) -> DataArray | Array:
+        if not _preserves_qarray_axes_after_swapaxes(self.ndim, axis1, axis2):
+            return jnp.swapaxes(self.to_jax(), axis1, axis2)
+
+        axis1 = _normalize_axis(axis1, self.ndim)
+        axis2 = _normalize_axis(axis2, self.ndim)
+        if {axis1, axis2} == {self.ndim - 2, self.ndim - 1}:
+            return self.mT
+
+        diags = jnp.swapaxes(self.diags, axis1, axis2)
+        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+
+    def moveaxis(
+        self, source: int | tuple[int, ...], destination: int | tuple[int, ...]
+    ) -> DataArray | Array:
+        if not _preserves_qarray_axes_after_moveaxis(self.ndim, source, destination):
+            return jnp.moveaxis(self.to_jax(), source, destination)
+
+        diags = jnp.moveaxis(self.diags, source, destination)
+        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
+
+    def expand_dims(self, axis: int) -> DataArray | Array:
+        if not _preserves_qarray_axes_after_expand_dims(self.ndim, axis):
+            return jnp.expand_dims(self.to_jax(), axis)
+
+        diags = jnp.expand_dims(self.diags, axis)
+        return replace(self, diags=diags)  # ty: ignore[invalid-argument-type]
 
     def _eig(self) -> tuple[Array, DataArray]:
         warnings.warn(

--- a/dynamiqs/qarrays/utils.py
+++ b/dynamiqs/qarrays/utils.py
@@ -24,6 +24,8 @@ __all__ = [
     'asqarray',
     'sparsedia_from_dict',
     'stack',
+    'concatenate',
+    'where',
     'to_jax',
     'to_numpy',
     'to_qutip',
@@ -202,6 +204,123 @@ def stack(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
         raise NotImplementedError(
             'Stacking qarrays with different data types is not implemented.'
         )
+
+
+def concatenate(qarrays: Sequence[QArray], axis: int = 0) -> QArray:
+    """Join a sequence of qarrays along an existing batch axis.
+
+    Warning:
+        All elements of the sequence `qarrays` must have identical data types and `dims`
+        attributes. Qarrays with sparse diagonal data must also have identical `offsets`
+        attributes.
+
+    Args:
+        qarrays: Qarrays to concatenate.
+        axis: Existing batch axis along which the input qarrays are concatenated.
+
+    Returns:
+        Concatenated qarray.
+    """
+    if len(qarrays) == 0:
+        raise ValueError('Argument `qarrays` must contain at least one element.')
+    if not all(isinstance(q, QArray) for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain only elements of type `QArray`.'
+        )
+
+    first = qarrays[0]
+    axis = _normalize_batch_axis(axis, first.ndim)
+
+    dims = first.dims
+    if not all(q.dims == dims for q in qarrays):
+        raise ValueError(
+            'Argument `qarrays` must contain elements with identical `dims` attribute.'
+        )
+
+    expected_shape = first.shape
+    for qarray in qarrays:
+        if qarray.ndim != first.ndim:
+            raise ValueError('All input qarrays must have the same number of axes.')
+        if qarray.shape[:axis] + qarray.shape[axis + 1 :] != (
+            expected_shape[:axis] + expected_shape[axis + 1 :]
+        ):
+            raise ValueError(
+                'All input qarrays must have matching shapes except along the '
+                'concatenation axis.'
+            )
+
+    if all(isinstance(q.data, DenseDataArray) for q in qarrays):
+        data = jnp.concatenate([q.data.data for q in qarrays], axis=axis)
+        return MaterializedQArray(dims, False, DenseDataArray(data))
+    elif all(isinstance(q.data, SparseDIADataArray) for q in qarrays):
+        offsets = first.data.offsets
+        if not all(q.data.offsets == offsets for q in qarrays):
+            raise ValueError(
+                'Sparse diagonal qarrays must have identical `offsets` attributes.'
+            )
+        diags = jnp.concatenate([q.data.diags for q in qarrays], axis=axis)
+        return MaterializedQArray(dims, False, SparseDIADataArray(offsets, diags))
+    else:
+        raise NotImplementedError(
+            'Concatenating qarrays with different data types is not implemented.'
+        )
+
+
+def where(condition: ArrayLike, x: QArray, y: QArray) -> QArray:
+    """Select values from two qarrays according to a condition.
+
+    Args:
+        condition: Condition broadcastable to the qarray data shape.
+        x: Qarray containing values selected where condition is true.
+        y: Qarray containing values selected where condition is false.
+
+    Returns:
+        Qarray with values selected from `x` and `y`.
+    """
+    if not isinstance(x, QArray) or not isinstance(y, QArray):
+        raise TypeError('Arguments `x` and `y` must both be of type `QArray`.')
+    if x.dims != y.dims:
+        raise ValueError('Arguments `x` and `y` must have identical `dims` attributes.')
+
+    if isinstance(x.data, DenseDataArray) and isinstance(y.data, DenseDataArray):
+        data = jnp.where(condition, x.data.data, y.data.data)
+        return MaterializedQArray(x.dims, False, DenseDataArray(data))
+    elif isinstance(x.data, SparseDIADataArray) and isinstance(
+        y.data, SparseDIADataArray
+    ):
+        if x.data.offsets != y.data.offsets:
+            raise ValueError(
+                'Sparse diagonal qarrays must have identical `offsets` attributes.'
+            )
+        try:
+            diags = jnp.where(condition, x.data.diags, y.data.diags)
+        except (TypeError, ValueError):
+            warnings.warn(
+                'Sparse diagonal qarrays have been converted to dense layout while '
+                'applying `where` with a condition that is not broadcastable to sparse '
+                'diagonal data.',
+                stacklevel=2,
+            )
+            data = jnp.where(condition, x.to_jax(), y.to_jax())
+            return MaterializedQArray(x.dims, False, DenseDataArray(data))
+
+        return MaterializedQArray(
+            x.dims, False, SparseDIADataArray(x.data.offsets, diags)
+        )
+    else:
+        raise NotImplementedError(
+            'Calling `where` on qarrays with different data types is not implemented.'
+        )
+
+
+def _normalize_batch_axis(axis: int, ndim: int) -> int:
+    axis = axis + ndim if axis < 0 else axis
+    if axis < 0 or axis >= ndim - 2:
+        raise ValueError(
+            'Axis must be a batch axis and cannot refer to the final two qarray '
+            'dimensions.'
+        )
+    return axis
 
 
 def to_qutip(x: QArrayLike, dims: tuple[int, ...] | None = None) -> Qobj | list[Qobj]:

--- a/tests/qarrays/test_dense_qarray.py
+++ b/tests/qarrays/test_dense_qarray.py
@@ -136,3 +136,67 @@ class TestDenseQArray:
     def test_elpow(self):
         assert jnp.array_equal(self.qarray.elpow(2).to_jax(), self.data**2)
         assert jnp.array_equal(self.qarray.elpow(3).to_jax(), self.data**3)
+
+
+@pytest.mark.run(order=TEST_SHORT)
+def test_dense_qarray_axis_manipulation_methods():
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4) * (1 + 1j)
+    x = asqarray(data, dims=(4,))
+
+    # batch-axis swapaxes preserves qarray structure
+    y = x.swapaxes(0, 1)
+    expected = jnp.swapaxes(data, 0, 1)
+    assert y.shape == expected.shape
+    assert y.dims == x.dims
+    assert jnp.array_equal(y.to_jax(), expected)
+
+    # final-two-axis swapaxes preserves qarray structure
+    y = x.swapaxes(-1, -2)
+    expected = jnp.swapaxes(data, -1, -2)
+    assert y.shape == expected.shape
+    assert y.dims == x.dims
+    assert jnp.array_equal(y.to_jax(), expected)
+
+    # moving batch axes preserves qarray structure
+    y = x.moveaxis(0, 1)
+    expected = jnp.moveaxis(data, 0, 1)
+    assert y.shape == expected.shape
+    assert y.dims == x.dims
+    assert jnp.array_equal(y.to_jax(), expected)
+
+    # inserting batch axes preserves qarray structure
+    y = x.expand_dims(0)
+    expected = jnp.expand_dims(data, 0)
+    assert y.shape == expected.shape
+    assert y.dims == x.dims
+    assert jnp.array_equal(y.to_jax(), expected)
+
+    y = x.expand_dims(2)
+    expected = jnp.expand_dims(data, 2)
+    assert y.shape == expected.shape
+    assert y.dims == x.dims
+    assert jnp.array_equal(y.to_jax(), expected)
+
+
+@pytest.mark.run(order=TEST_SHORT)
+def test_dense_qarray_axis_manipulation_raw_array_fallback():
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4) * (1 + 1j)
+    x = asqarray(data, dims=(4,))
+
+    y = x.swapaxes(0, -1)
+    expected = jnp.swapaxes(data, 0, -1)
+    assert not hasattr(y, 'to_jax')
+    assert y.shape == expected.shape
+    assert jnp.array_equal(y, expected)
+
+    y = x.moveaxis(-1, 0)
+    expected = jnp.moveaxis(data, -1, 0)
+    assert not hasattr(y, 'to_jax')
+    assert y.shape == expected.shape
+    assert jnp.array_equal(y, expected)
+
+    y = x.expand_dims(-1)
+    expected = jnp.expand_dims(data, -1)
+    assert not hasattr(y, 'to_jax')
+    assert y.shape == expected.shape
+    assert jnp.array_equal(y, expected)

--- a/tests/qarrays/test_sparse_dia_qarray.py
+++ b/tests/qarrays/test_sparse_dia_qarray.py
@@ -239,3 +239,73 @@ class TestSparseDIAQArray:
 
 def _allclose(a, b, rtol=1e-05, atol=1e-08):
     return jnp.allclose(a, b, rtol=rtol, atol=atol)
+
+
+@pytest.mark.run(order=TEST_SHORT)
+def test_sparse_dia_qarray_axis_manipulation_methods():
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4) * (1 + 1j)
+    dense = dq.asqarray(data, dims=(4,), layout=dq.dense)
+    sparse = dq.asqarray(data, dims=(4,), layout=dq.dia)
+
+    # batch-axis swapaxes preserves sparse qarray structure
+    y_dense = dense.swapaxes(0, 1)
+    y_sparse = sparse.swapaxes(0, 1)
+    assert y_sparse.shape == y_dense.shape
+    assert y_sparse.dims == sparse.dims
+    assert y_sparse.layout == dq.dia
+    assert _allclose(y_sparse.to_jax(), y_dense.to_jax())
+
+    # final-two-axis swapaxes preserves sparse qarray structure
+    y_dense = dense.swapaxes(-1, -2)
+    y_sparse = sparse.swapaxes(-1, -2)
+    assert y_sparse.shape == y_dense.shape
+    assert y_sparse.dims == sparse.dims
+    assert y_sparse.layout == dq.dia
+    assert _allclose(y_sparse.to_jax(), y_dense.to_jax())
+
+    # moving batch axes preserves sparse qarray structure
+    y_dense = dense.moveaxis(0, 1)
+    y_sparse = sparse.moveaxis(0, 1)
+    assert y_sparse.shape == y_dense.shape
+    assert y_sparse.dims == sparse.dims
+    assert y_sparse.layout == dq.dia
+    assert _allclose(y_sparse.to_jax(), y_dense.to_jax())
+
+    # inserting batch axes preserves sparse qarray structure
+    y_dense = dense.expand_dims(0)
+    y_sparse = sparse.expand_dims(0)
+    assert y_sparse.shape == y_dense.shape
+    assert y_sparse.dims == sparse.dims
+    assert y_sparse.layout == dq.dia
+    assert _allclose(y_sparse.to_jax(), y_dense.to_jax())
+
+    y_dense = dense.expand_dims(2)
+    y_sparse = sparse.expand_dims(2)
+    assert y_sparse.shape == y_dense.shape
+    assert y_sparse.dims == sparse.dims
+    assert y_sparse.layout == dq.dia
+    assert _allclose(y_sparse.to_jax(), y_dense.to_jax())
+
+
+@pytest.mark.run(order=TEST_SHORT)
+def test_sparse_dia_qarray_axis_manipulation_raw_array_fallback():
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4) * (1 + 1j)
+    x = dq.asqarray(data, dims=(4,), layout=dq.dia)
+
+    y = x.swapaxes(0, -1)
+    expected = jnp.swapaxes(data, 0, -1)
+    assert not hasattr(y, 'to_jax')
+    assert y.shape == expected.shape
+    assert _allclose(y, expected)
+
+    y = x.moveaxis(-1, 0)
+    expected = jnp.moveaxis(data, -1, 0)
+    assert not hasattr(y, 'to_jax')
+    assert y.shape == expected.shape
+    assert _allclose(y, expected)
+
+    y = x.expand_dims(-1)
+    expected = jnp.expand_dims(data, -1)
+    assert not hasattr(y, 'to_jax')
+    assert y.shape == expected.shape
+    assert _allclose(y, expected)

--- a/tests/qarrays/test_utils.py
+++ b/tests/qarrays/test_utils.py
@@ -126,3 +126,79 @@ def test_qutip_tensor_compatibility():
     expected_tensor = jnp.zeros((6, 1), dtype=complex)
     expected_tensor = expected_tensor.at[1].set(1.0)  # |01⟩ state
     assert jnp.allclose(tensor_result.to_jax(), expected_tensor)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize('layout', [dq.dense, dq.dia])
+def test_concatenate(layout, rtol=1e-05, atol=1e-08):
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4)
+    other = data + 1000
+
+    x = dq.asqarray(data, dims=(4,), layout=layout)
+    y = dq.asqarray(other, dims=(4,), layout=layout)
+
+    out = dq.concatenate([x, y], axis=0)
+    expected = jnp.concatenate([data, other], axis=0)
+    assert out.shape == expected.shape
+    assert out.dims == x.dims
+    assert out.layout == layout
+    assert jnp.allclose(out.to_jax(), expected, rtol=rtol, atol=atol)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize('layout', [dq.dense, dq.dia])
+def test_concatenate_rejects_quantum_axes(layout):
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4)
+    x = dq.asqarray(data, dims=(4,), layout=layout)
+
+    with pytest.raises(ValueError, match='Axis must be a batch axis'):
+        dq.concatenate([x, x], axis=-1)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+@pytest.mark.parametrize('layout', [dq.dense, dq.dia])
+def test_where_scalar_condition(layout, rtol=1e-05, atol=1e-08):
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4)
+    other = data + 1000
+
+    x = dq.asqarray(data, dims=(4,), layout=layout)
+    y = dq.asqarray(other, dims=(4,), layout=layout)
+
+    out = dq.where(True, x, y)
+    assert out.shape == x.shape
+    assert out.dims == x.dims
+    assert out.layout == layout
+    assert jnp.allclose(out.to_jax(), data, rtol=rtol, atol=atol)
+
+    out = dq.where(False, x, y)
+    assert out.shape == y.shape
+    assert out.dims == y.dims
+    assert out.layout == layout
+    assert jnp.allclose(out.to_jax(), other, rtol=rtol, atol=atol)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_dense_broadcast_condition(rtol=1e-05, atol=1e-08):
+    data = jnp.arange(2 * 3 * 4 * 4).reshape(2, 3, 4, 4)
+    other = data + 1000
+    condition = jnp.array([[True, False, True], [False, True, False]])[..., None, None]
+
+    x = dq.asqarray(data, dims=(4,), layout=dq.dense)
+    y = dq.asqarray(other, dims=(4,), layout=dq.dense)
+
+    out = dq.where(condition, x, y)
+    expected = jnp.where(condition, data, other)
+
+    assert out.shape == expected.shape
+    assert out.dims == x.dims
+    assert out.layout == dq.dense
+    assert jnp.allclose(out.to_jax(), expected, rtol=rtol, atol=atol)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_where_rejects_mismatched_dims():
+    x = dq.asqarray(jnp.eye(4), dims=(4,))
+    y = dq.asqarray(jnp.eye(4), dims=(2, 2))
+
+    with pytest.raises(ValueError, match='identical `dims`'):
+        dq.where(True, x, y)


### PR DESCRIPTION
Closes #1080

## Summary

Adds QArray manipulation utilities requested in #1080:

* `QArray.swapaxes`
* `QArray.moveaxis`
* `QArray.expand_dims`
* `dq.concatenate`
* `dq.where`

The axis-manipulation methods preserve QArray structure when the operation keeps the final two quantum axes valid, and return a raw JAX array when the operation no longer preserves QArray structure.

`dq.concatenate` supports concatenation along existing batch axes for QArrays with matching dimensions and compatible layouts.

`dq.where` supports dense QArrays directly, preserves sparse DIA layout when the condition is compatible with sparse diagonal storage, and falls back to dense layout with a warning when sparse diagonal structure cannot represent the requested condition.

## Tests

Local validation:

* `ruff check dynamiqs/qarrays tests/qarrays`
* `ruff format --check dynamiqs/qarrays tests/qarrays`
* `ty check dynamiqs`
* `python -m pytest -q tests/qarrays/test_dense_qarray.py tests/qarrays/test_sparse_dia_qarray.py tests/qarrays/test_utils.py`

  * `77 passed, 18 warnings`

The pytest warnings were from running plain pytest locally without the repo’s marker plugin setup, plus an existing sparse-to-dense warning in an existing sparse scalar-add test path.
