### PR TITLE
Fix bug when substracting qarray with timeqarray

### DIFF
--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -512,6 +512,8 @@ class QArray(eqx.Module):
         return self.__add__(y)
 
     def __sub__(self, y: QArrayLike) -> QArray:
+        if not isqarraylike(y):
+            return NotImplemented
         if not isinstance(y, QArray):
             y = to_jax(y)
         return self + (-y)

--- a/tests/core/test_time_qarray.py
+++ b/tests/core/test_time_qarray.py
@@ -484,6 +484,31 @@ class TestModulatedTimeQArray:
         assert isinstance(x, SummedTimeQArray)
         assert_equal(x(0.0), [[1.0 + 1.0j, 1.0 + 2.0j], [1.0 + 3.0j, 1.0 + 4.0j]])
 
+    def test_sub(self):
+        # test type `ArrayLike`
+        x = self.x - jnp.ones_like(self.x)
+        assert isinstance(x, SummedTimeQArray)
+        assert_equal(x(0.0), [[-1.0 + 1.0j, -1.0 + 2.0j], [-1.0 + 3.0j, -1.0 + 4.0j]])
+
+        # test type `QArray`
+        y = asqarray(jnp.array([[1, 1], [1, 1]]))
+        x = self.x - y
+        assert isinstance(x, SummedTimeQArray)
+        assert_equal(x(0.0), [[-1.0 + 1.0j, -1.0 + 2.0j], [-1.0 + 3.0j, -1.0 + 4.0j]])
+
+    def test_rsub(self):
+        # test type `ArrayLike`
+        x = jnp.ones_like(self.x) - self.x
+        assert isinstance(x, SummedTimeQArray)
+        assert_equal(x(0.0), [[1.0 - 1.0j, 1.0 - 2.0j], [1.0 - 3.0j, 1.0 - 4.0j]])
+
+        # test type `QArray` — regression test for QArray.__sub__ returning NotImplemented
+        # for TimeQArray instead of crashing with to_jax()
+        y = asqarray(jnp.array([[1, 1], [1, 1]]))
+        x = y - self.x
+        assert isinstance(x, SummedTimeQArray)
+        assert_equal(x(0.0), [[1.0 - 1.0j, 1.0 - 2.0j], [1.0 - 3.0j, 1.0 - 4.0j]])
+
     def test_clip(self):
         f = lambda t: 1.0 + 2.0 * t
         qarray = jnp.array([[1.0, 2.0], [3.0, 4.0]])

--- a/tests/core/test_time_qarray.py
+++ b/tests/core/test_time_qarray.py
@@ -502,7 +502,8 @@ class TestModulatedTimeQArray:
         assert isinstance(x, SummedTimeQArray)
         assert_equal(x(0.0), [[1.0 - 1.0j, 1.0 - 2.0j], [1.0 - 3.0j, 1.0 - 4.0j]])
 
-        # test type `QArray` — regression test for QArray.__sub__ returning NotImplemented
+        # test type `QArray` — regression test for QArray.__sub__ returning
+        # NotImplemented
         # for TimeQArray instead of crashing with to_jax()
         y = asqarray(jnp.array([[1, 1], [1, 1]]))
         x = y - self.x


### PR DESCRIPTION
Fixes:
```python
import dynamiqs as dq

a = dq.destroy(4)
f = lambda t: t
x = dq.modulated(f, a)

print(x + a) # ok
print(a + x) # ok
print(x - a) # ok
print(a - x) # TypeError: must be real number, not ModulatedTimeQArray
```