### PR TITLE
Fix arithmetic methods fallback for QArrays

### DIFF
--- a/dynamiqs/_utils.py
+++ b/dynamiqs/_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, get_args
+from typing import Any, TypeGuard, get_args
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -45,7 +45,7 @@ def concatenate_sort(*args: Array) -> Array:
     return jnp.sort(jnp.concatenate(args))
 
 
-def is_batched_scalar(y: Any) -> bool:
+def is_batched_scalar(y: Any) -> TypeGuard[ArrayLike]:
     # check if a qarray-like is a scalar or a set of scalars of shape (..., 1, 1)
     return isinstance(y, get_args(ScalarLike)) or (
         isinstance(y, get_args(ArrayLike))

--- a/dynamiqs/qarrays/composite_qarray.py
+++ b/dynamiqs/qarrays/composite_qarray.py
@@ -141,7 +141,7 @@ class CompositeTerm(eqx.Module):
 
     # === Arithmetic ===
 
-    def __mul__(self, y: ArrayLike) -> CompositeTerm:
+    def __mul__(self, y: QArrayLike) -> CompositeTerm:
         # y·(c·⊗A_k) = (y·c)·⊗A_k; only touches coeff.
         raise NotImplementedError
 
@@ -331,7 +331,7 @@ class CompositeQArray(QArray):
 
     # === Arithmetic ===
 
-    def __mul__(self, y: ArrayLike) -> QArray:
+    def __mul__(self, y: QArrayLike) -> QArray:
         # LAZY y·Σc_j⊗A_{jk}=Σ(y·c_j)⊗A_{jk} → term.__mul__(y).
         raise NotImplementedError
 

--- a/dynamiqs/qarrays/materialized_qarray.py
+++ b/dynamiqs/qarrays/materialized_qarray.py
@@ -19,6 +19,20 @@ from .qarray import QArray, QArrayLike, check_compatible_dims, isqarraylike, to_
 __all__ = []
 
 
+def _resolve_operand(dims: tuple[int, ...], y: QArrayLike) -> DataArray | Array:
+    """Resolves `y` into raw data compatible with a qarray of Hilbert dims `dims`.
+
+    Checks Hilbert space dimension compatibility if `y` is itself a materialized
+    qarray. Returns `NotImplemented` if `y` is not a recognized qarray-like.
+    """
+    if isinstance(y, MaterializedQArray):
+        check_compatible_dims(dims, y.dims)
+        return y.data
+    if isqarraylike(y):
+        return to_jax(y)
+    return NotImplemented
+
+
 class MaterializedQArray(QArray):
     vectorized: bool = eqx.field(static=True)
     data: DataArray
@@ -203,8 +217,10 @@ class MaterializedQArray(QArray):
         res += self.data._repr_extra()
         return res
 
-    def __mul__(self, y: ArrayLike) -> QArray:
+    def __mul__(self, y: QArrayLike) -> QArray:
         if not is_batched_scalar(y):
+            if not isqarraylike(y):
+                return NotImplemented
             raise NotImplementedError(
                 'Element-wise multiplication of two qarrays with the `*` operator is '
                 'not supported. For matrix multiplication, use `x @ y`. For '
@@ -224,16 +240,11 @@ class MaterializedQArray(QArray):
                 ' To add a scalar, use `x.addscalar(scalar)`.'
             )
 
-        if isinstance(y, MaterializedQArray):
-            check_compatible_dims(self.dims, y.dims)
-            result = self.data + y.data
-        elif isqarraylike(y):
-            result = self.data + to_jax(y)
-        else:
+        y_data = _resolve_operand(self.dims, y)
+        if y_data is NotImplemented:
             return NotImplemented
 
-        if result is NotImplemented:
-            return NotImplemented
+        result = self.data + y_data
         if isinstance(result, DataArray):
             return replace(self, data=result)
         return result
@@ -245,14 +256,11 @@ class MaterializedQArray(QArray):
     def __matmul__(self, y: ArrayLike) -> Array: ...
 
     def __matmul__(self, y: QArrayLike) -> QArray | Array:
-        if isinstance(y, MaterializedQArray):
-            check_compatible_dims(self.dims, y.dims)
-            y_data = y.data
-        elif is_batched_scalar(y):
+        if is_batched_scalar(y):
             raise TypeError('Attempted matrix product between a scalar and a qarray.')
-        elif isqarraylike(y):
-            y_data = to_jax(y)
-        else:
+
+        y_data = _resolve_operand(self.dims, y)
+        if y_data is NotImplemented:
             return NotImplemented
 
         result = self.data @ y_data
@@ -284,14 +292,11 @@ class MaterializedQArray(QArray):
     def __rmatmul__(self, y: ArrayLike) -> Array: ...
 
     def __rmatmul__(self, y: QArrayLike) -> QArray | Array:
-        if isinstance(y, MaterializedQArray):
-            check_compatible_dims(self.dims, y.dims)
-            y_data = y.data
-        elif is_batched_scalar(y):
+        if is_batched_scalar(y):
             raise TypeError('Attempted matrix product between a scalar and a qarray.')
-        elif isqarraylike(y):
-            y_data = to_jax(y)
-        else:
+
+        y_data = _resolve_operand(self.dims, y)
+        if y_data is NotImplemented:
             return NotImplemented
 
         # y_data @ self.data
@@ -300,9 +305,6 @@ class MaterializedQArray(QArray):
         else:
             # y_data is a raw array; use DataArray's __rmatmul__
             result = self.data.__rmatmul__(y_data)
-
-        if result is NotImplemented:
-            return NotImplemented
 
         if isinstance(result, DataArray):
             return replace(self, data=result)
@@ -344,16 +346,11 @@ class MaterializedQArray(QArray):
         Returns:
             New qarray resulting from the element-wise multiplication.
         """
-        if isinstance(y, MaterializedQArray):
-            check_compatible_dims(self.dims, y.dims)
-            result = self.data * y.data
-        elif isqarraylike(y):
-            result = self.data * to_jax(y)
-        else:
+        y_data = _resolve_operand(self.dims, y)
+        if y_data is NotImplemented:
             return NotImplemented
 
-        if result is NotImplemented:
-            return NotImplemented
+        result = self.data * y_data
         if isinstance(result, DataArray):
             return replace(self, data=result)
         return result

--- a/dynamiqs/qarrays/qarray.py
+++ b/dynamiqs/qarrays/qarray.py
@@ -13,6 +13,7 @@ from jax import Array, Device
 from jaxtyping import ArrayLike
 from qutip import Qobj
 
+from .._utils import is_batched_scalar
 from .dataarray import IndexType
 from .layout import Layout
 
@@ -43,7 +44,8 @@ def isqarraylike(x: Any) -> TypeGuard[QArrayLike]:
     """
     if isinstance(x, get_args(_QArrayLike)):
         return True
-    elif isinstance(x, Sequence):
+    elif isinstance(x, Sequence) and not isinstance(x, str):
+        # strings yield infinite recursion, so we exclude them from the sequence check
         return all(isqarraylike(sub_x) for sub_x in x)
     return False
 
@@ -76,14 +78,14 @@ def to_jax(x: QArrayLike) -> Array:
         return x.to_jax()
     elif isinstance(x, Qobj):
         return jnp.asarray(x.full())
-    elif isinstance(x, Sequence):
+    elif isinstance(x, Sequence) and not isinstance(x, str):
         return jnp.asarray([to_jax(cast(QArrayLike, sub_x)) for sub_x in x])
     else:
         return jnp.asarray(x)
 
 
 def get_dims(x: QArrayLike) -> tuple[int, ...] | None:
-    if isinstance(x, Sequence):
+    if isinstance(x, Sequence) and not isinstance(x, str):
         sub_dims = [get_dims(cast(QArrayLike, sub_x)) for sub_x in x]
         return sub_dims[0] if all(sd == sub_dims[0] for sd in sub_dims) else None
     if isinstance(x, QArray):
@@ -124,7 +126,7 @@ def to_numpy(x: QArrayLike) -> np.ndarray:
         return x.to_numpy()
     elif isinstance(x, Qobj):
         return np.asarray(x.full())
-    elif isinstance(x, Sequence):
+    elif isinstance(x, Sequence) and not isinstance(x, str):
         return np.asarray([to_numpy(cast(QArrayLike, sub_x)) for sub_x in x])
     else:
         return np.asarray(x)
@@ -486,13 +488,20 @@ class QArray(eqx.Module):
         return self * (-1)
 
     @abstractmethod
-    def __mul__(self, y: ArrayLike) -> QArray:
+    def __mul__(self, y: QArrayLike) -> QArray:
         pass
 
-    def __rmul__(self, y: ArrayLike) -> QArray:
+    def __rmul__(self, y: QArrayLike) -> QArray:
         return self * y
 
-    def __truediv__(self, y: ArrayLike) -> QArray:
+    def __truediv__(self, y: QArrayLike) -> QArray:
+        if not is_batched_scalar(y):
+            if not isqarraylike(y):
+                return NotImplemented
+            raise NotImplementedError(
+                'Division of a qarray by a non-scalar with the `/` operator is not '
+                'supported.'
+            )
         return self * (1 / y)
 
     def __rtruediv__(self, y: QArrayLike) -> QArray:
@@ -512,6 +521,8 @@ class QArray(eqx.Module):
         return self.__add__(y)
 
     def __sub__(self, y: QArrayLike) -> QArray:
+        if not isqarraylike(y):
+            return NotImplemented
         if not isinstance(y, QArray):
             y = to_jax(y)
         return self + (-y)
@@ -547,6 +558,9 @@ class QArray(eqx.Module):
         # to deal with the x**ω notation from equinox (used in diffrax internals)
         if isinstance(power, _Metaω):
             return _Metaω.__rpow__(power, self)
+
+        if not isqarraylike(power):
+            return NotImplemented
 
         raise NotImplementedError(
             'Computing the element-wise power of a qarray with the `**` operator is '

--- a/tests/qarrays/test_qarray.py
+++ b/tests/qarrays/test_qarray.py
@@ -1,0 +1,91 @@
+import jax.numpy as jnp
+import pytest
+import qutip as qt
+
+import dynamiqs as dq
+
+from ..order import TEST_INSTANT
+
+pytestmark = [
+    pytest.mark.run(order=TEST_INSTANT),
+    pytest.mark.parametrize('layout', [dq.dense, dq.dia]),
+]
+
+OPS = [
+    ('add', lambda x, y: x + y),
+    ('sub', lambda x, y: x - y),
+    ('mul', lambda x, y: x * y),
+    ('truediv', lambda x, y: x / y),
+    ('matmul', lambda x, y: x @ y),
+    ('pow', lambda x, y: x**y),
+]
+
+
+class _ReflectedOnly:
+    """Object that only implements reflected arithmetic dunders.
+
+    Used to check that qarray arithmetic operators correctly return
+    `NotImplemented` for operands they don't understand, so that Python falls
+    back to the other operand's reflected method instead of raising.
+    """
+
+    def __radd__(self, other):
+        return ('add', other)
+
+    def __rsub__(self, other):
+        return ('sub', other)
+
+    def __rmul__(self, other):
+        return ('mul', other)
+
+    def __rtruediv__(self, other):
+        return ('truediv', other)
+
+    def __rmatmul__(self, other):
+        return ('matmul', other)
+
+    def __rpow__(self, other):
+        return ('pow', other)
+
+
+@pytest.fixture
+def x(layout):
+    return dq.asqarray(dq.sigmax(), layout=layout)
+
+
+@pytest.mark.parametrize(('name', 'op'), OPS, ids=[name for name, _ in OPS])
+def test_arithmetic_falls_back_to_reflected_method(x, name, op):
+    assert op(x, _ReflectedOnly()) == (name, x)
+
+
+@pytest.mark.parametrize('op', [op for _, op in OPS], ids=[name for name, _ in OPS])
+def test_arithmetic_with_unsupported_type_raises_typeerror(x, op):
+    # objects with no arithmetic support at all should raise a plain `TypeError`
+    # (Python's usual error for unsupported operand types), not crash or hang
+    with pytest.raises(TypeError):
+        op(x, object())
+
+
+@pytest.mark.parametrize(
+    'y',
+    [dq.sigmay(), qt.sigmax(), [[1, 2], [3, 4]], jnp.array([[1.0, 2.0], [3.0, 4.0]])],
+    ids=['qarray', 'qobj', 'nested_list', 'raw_array'],
+)
+def test_truediv_by_non_scalar_raises_cleanly(x, y):
+    # dividing a qarray by a non-scalar qarray-like must raise a clear
+    # `NotImplementedError`, not crash inside the `1 / y` reciprocal computation
+    # (e.g. `1 / qutip.Qobj` used to raise a confusing raw `TypeError`)
+    with pytest.raises(NotImplementedError):
+        x / y
+
+
+def test_arithmetic_between_two_qarrays_still_raises(x, layout):
+    # legitimate error messages for unsupported qarray-qarray operations must
+    # still raise `NotImplementedError`, not silently fall back
+    y = dq.asqarray(dq.sigmay(), layout=layout)
+    with pytest.raises(NotImplementedError):
+        x * y
+    with pytest.raises(NotImplementedError):
+        1 / x
+    with pytest.raises(NotImplementedError):
+        x**2

--- a/tests/qarrays/test_utils.py
+++ b/tests/qarrays/test_utils.py
@@ -4,6 +4,7 @@ import pytest
 import qutip as qt
 
 import dynamiqs as dq
+from dynamiqs.qarrays.qarray import get_dims, to_jax, to_numpy
 
 from ..order import TEST_INSTANT
 
@@ -126,3 +127,17 @@ def test_qutip_tensor_compatibility():
     expected_tensor = jnp.zeros((6, 1), dtype=complex)
     expected_tensor = expected_tensor.at[1].set(1.0)  # |01⟩ state
     assert jnp.allclose(tensor_result.to_jax(), expected_tensor)
+
+
+@pytest.mark.run(order=TEST_INSTANT)
+def test_string_does_not_recurse():
+    # strings are `Sequence`s of single-character strings, so a naive recursive
+    # walk over `Sequence` elements never bottoms out; these helpers must special
+    # case `str` to avoid a `RecursionError`
+    assert dq.isqarraylike('not a qarray') is False
+    with pytest.raises(TypeError):
+        to_jax('not a qarray')
+    assert to_numpy('not a qarray').item() == 'not a qarray'
+    assert get_dims('not a qarray') is None
+    with pytest.raises(TypeError):
+        dq.asqarray('not a qarray')


### PR DESCRIPTION

- Fix `NotImplemented` protocol handling in QArray arithmetic (`__mul__`, `__truediv__`, `__sub__`, `__pow__`) — previously any unrecognized operand raised `NotImplementedError`, breaking fallback to the other operand's reflected method (e.g. `dq.sigmax() * custom_obj` couldn't use `custom_obj.__rmul__`). This fixes https://github.com/dynamiqs/dynamiqs/issues/1123. 
- Fix infinite recursion when a `str` is passed to `isqarraylike`, `to_jax`, `to_numpy`, `get_dims` (e.g. `dq.asqarray('abc')` used to raise `RecursionError`).
- Widen `__mul__`/`__rmul__`/`__truediv__` type hints from `ArrayLike` to `QArrayLike` for consistency with `__add__`/`__sub__`; make `is_batched_scalar` a `TypeGuard` to keep this type-safe.
- Deduplicate repeated operand-resolution logic in `MaterializedQArray` into a shared `_resolve_operand` helper.

