### PR TITLE
Give Rouchon methods a third-order dense output to fix forward-mode gradients

### DIFF
--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -26,7 +26,7 @@ from ...method import (
     _DEFixedStep,
 )
 from ...options import Options
-from ...progress_meter import AbstractProgressMeter
+from ...progress_meter import AbstractProgressMeter, _ForwardModeProgressMeter
 from ...result import MESolveResult, Result, SolveSaved
 from ...utils.vectorization import slindbladian, unvectorize, vectorize
 from .abstract_integrator import BaseIntegrator
@@ -144,6 +144,11 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
                     get_dtmax, stepsize_controller, dtmax, is_leaf=lambda x: x is None
                 )
 
+            # === prepare progress meter
+            progress_meter = _ForwardModeProgressMeter(
+                cast(AbstractProgressMeter, self.options.progress_meter).to_diffrax()
+            )
+
             # === solve differential equation with diffrax
             return dx.diffeqsolve(
                 self.terms,
@@ -157,9 +162,7 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
                 adjoint=self.adjoint,
                 event=event,
                 max_steps=self.max_steps,
-                progress_meter=cast(
-                    AbstractProgressMeter, self.options.progress_meter
-                ).to_diffrax(),
+                progress_meter=progress_meter,
             )
 
     def run(self) -> Result:

--- a/dynamiqs/integrators/core/rouchon_integrator.py
+++ b/dynamiqs/integrators/core/rouchon_integrator.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
-from dataclasses import replace
 from typing import ClassVar
 
 import diffrax as dx
@@ -11,7 +10,7 @@ import jax
 import jax.numpy as jnp
 from diffrax import AbstractRungeKutta, Bosh3, Euler, Midpoint, ODETerm
 from diffrax._custom_types import VF, Args, BoolScalarLike, Control, RealScalarLike, Y
-from diffrax._local_interpolation import LocalLinearInterpolation
+from diffrax._local_interpolation import ThirdOrderHermitePolynomialInterpolation
 from jaxtyping import PyTree
 
 from ...gradient import Forward, Gradient
@@ -31,6 +30,8 @@ class AbstractRouchonTerm(dx.AbstractTerm):
 
     rouchon_step: Callable[[RealScalarLike, RealScalarLike, Y], tuple[Y, Y]]
     # should be defined as `rouchon_step(t0, t1, y0) -> y1, error`
+    lindbladian: Callable[[RealScalarLike, Y], Y]
+    # should be defined as `lindbladian(t, y) -> dy/dt`, only used for dense output
 
     def vf(self, t: RealScalarLike, y: Y, args: Args):
         del t, y, args
@@ -45,7 +46,7 @@ class AbstractRouchonTerm(dx.AbstractTerm):
 class RouchonDXSolver(dx.AbstractSolver):
     _order: int
     term_structure = AbstractRouchonTerm
-    interpolation_cls = LocalLinearInterpolation
+    interpolation_cls = ThirdOrderHermitePolynomialInterpolation
 
     def init(
         self,
@@ -69,7 +70,13 @@ class RouchonDXSolver(dx.AbstractSolver):
     ) -> tuple:
         del solver_state, made_jump, args
         y1, error = terms.term.rouchon_step(t0, t1, y0)  # ty: ignore
-        dense_info = dict(y0=y0, y1=y1)
+        # Third-order Hermite dense output, so that saving at times not aligned with
+        # the step grid does not degrade the order of the scheme. Note that
+        # `ThirdOrderHermitePolynomialInterpolation` expects dt-scaled derivatives.
+        dt = t1 - t0
+        k0 = dt * terms.term.lindbladian(t0, y0)  # ty: ignore
+        k1 = dt * terms.term.lindbladian(t1, y1)  # ty: ignore
+        dense_info = dict(y0=y0, y1=y1, k0=k0, k1=k1)
         return y1, error, dense_info, None, dx.RESULTS.successful
 
     def func(self, terms: AbstractRouchonTerm, t0: RealScalarLike, y0: Y, args: Args):
@@ -323,6 +330,14 @@ class RouchonPropertiesMixin:
         LdL = sum(Mdag_M(_L) for _L in self.L(t))
         return -1j * self.H(t) - 0.5 * LdL
 
+    def lindbladian(self, t: RealScalarLike, rho: QArray) -> QArray:
+        r"""Lindbladian $\dot\rho = G \rho + \rho G^\dagger
+        + \sum_k L_k \rho L_k^\dagger$.
+        """
+        G = self.G(t)
+        jump_term = sum_qarrays([M_rho_Mdag(_L, rho) for _L in self.L(t)])
+        return G @ rho + rho @ G.dag() + jump_term
+
     @property
     def identity(self) -> QArray:
         struct = jax.eval_shape(lambda: self.H(0.0))
@@ -418,7 +433,7 @@ class MESolveFixedRouchonIntegrator(RouchonPropertiesMixin, MESolveDiffraxIntegr
 
             return kraus_map(rho), None
 
-        return AbstractRouchonTerm(rouchon_step)
+        return AbstractRouchonTerm(rouchon_step, self.lindbladian)
 
     @classmethod
     def build_kraus_map(
@@ -555,22 +570,7 @@ class MESolveAdaptiveRouchonIntegrator(
 
             return rho_high, 0.5 * (rho_high - rho_low)
 
-        return AbstractRouchonTerm(rouchon_step)
-
-    @property
-    def stepsize_controller(self) -> dx.AbstractStepSizeController:
-        # todo: can we do better?
-        stepsize_controller = super().stepsize_controller
-        # fix incorrect default linear interpolation by stepping exactly at all times
-        # in tsave, so interpolation is bypassed
-        if isinstance(stepsize_controller, dx.ClipStepSizeController):
-            return eqx.tree_at(
-                lambda c: c.step_ts,
-                stepsize_controller,
-                self.ts,
-                is_leaf=lambda x: x is None,
-            )
-        return replace(stepsize_controller, step_ts=self.ts)
+        return AbstractRouchonTerm(rouchon_step, self.lindbladian)
 
 
 def cholesky_normalize(S: QArray, rho: QArray) -> QArray:

--- a/dynamiqs/progress_meter.py
+++ b/dynamiqs/progress_meter.py
@@ -1,7 +1,10 @@
 from abc import abstractmethod
+from typing import Any
 
 import diffrax as dx
 import equinox as eqx
+import jax
+from diffrax._custom_types import FloatScalarLike
 from tqdm import tqdm
 
 __all__ = ['NoProgressMeter', 'TextProgressMeter', 'TqdmProgressMeter']
@@ -116,3 +119,24 @@ class TqdmProgressMeter(AbstractProgressMeter):
 
     def to_diffrax(self) -> dx.AbstractProgressMeter:
         return _DiffraxTqdmProgressMeter()
+
+
+class _ForwardModeProgressMeter(dx.AbstractProgressMeter):
+    """Wrapper making any Diffrax progress meter forward-mode differentiable.
+
+    Diffrax reduces the progress over the batch dimensions with `unvmap_max`, which has
+    no JVP rule. This raises a `NotImplementedError` whenever the progress carries a
+    tangent, which is the case with `gradient=Forward()` for any parameter entering the
+    time grid. The progress is a display-only quantity, so we drop its tangent.
+    """
+
+    meter: dx.AbstractProgressMeter
+
+    def init(self) -> Any:
+        return self.meter.init()
+
+    def step(self, state: Any, progress: FloatScalarLike) -> Any:
+        return self.meter.step(state, jax.lax.stop_gradient(progress))
+
+    def close(self, state: Any):
+        self.meter.close(state)

--- a/tests/mesolve/test_adaptive_rouchon.py
+++ b/tests/mesolve/test_adaptive_rouchon.py
@@ -2,7 +2,7 @@ import jax.numpy as jnp
 import pytest
 
 import dynamiqs as dq
-from dynamiqs.gradient import Direct
+from dynamiqs.gradient import Direct, Forward
 from dynamiqs.method import Rouchon2, Rouchon3
 
 from ..integrator_tester import IntegratorTester
@@ -23,7 +23,7 @@ class TestMESolveAdaptiveRouchon(IntegratorTester):
 
     @pytest.mark.parametrize('method_class', [Rouchon2])
     @pytest.mark.parametrize('system', [dense_ocavity, otdqubit])
-    @pytest.mark.parametrize('gradient', [Direct()])
+    @pytest.mark.parametrize('gradient', [Direct(), Forward()])
     def test_gradient(self, method_class, system, gradient):
         self._test_gradient(system, method_class(), gradient)
 
@@ -31,9 +31,8 @@ class TestMESolveAdaptiveRouchon(IntegratorTester):
     def test_pwc_hamiltonian(self, method_class):
         """Regression test: adaptive Rouchon with a PWC Hamiltonian must not crash.
 
-        A PWC Hamiltonian introduces discontinuities, causing diffrax to wrap the
-        step-size controller in a ClipStepSizeController. Previously,
-        dataclasses.replace() on that wrapper raised a TypeError.
+        A PWC Hamiltonian introduces discontinuities in the dynamics, which the
+        step-size controller has to cope with.
         """
         n = 2
         H = dq.pwc(jnp.array([0.0, 0.5, 1.0]), jnp.array([1.0, 2.0]), dq.sigmax())

--- a/tests/mesolve/test_rouchon_forward_ad.py
+++ b/tests/mesolve/test_rouchon_forward_ad.py
@@ -1,0 +1,74 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+from dynamiqs.gradient import Forward
+from dynamiqs.method import Rouchon1, Rouchon2, Rouchon3, Tsit5
+
+from ..order import TEST_SHORT
+
+# Regression tests for forward-mode differentiation with respect to a parameter
+# entering the time grid. Adaptive Rouchon used to force a step at every time in
+# `tsave` to compensate for a first-order interpolation. This made every save-time
+# interpolation interval degenerate, and `jacfwd` returned a Jacobian off by orders of
+# magnitude (and of the wrong sign) instead of raising.
+
+METHODS = [
+    Rouchon1(dt=1e-4),
+    Rouchon2(dt=1e-3),
+    Rouchon3(dt=1e-2),
+    Rouchon2(),
+    Rouchon3(),
+]
+
+# The Hamiltonian must be time-dependent and `t0` must be pinned explicitly: with a
+# constant Hamiltonian the dynamics is invariant under time translation, so shifting
+# `tsave` and `t0` together leaves the states unchanged and these tests pass even with
+# a broken tangent path. Do not simplify this to a constant Hamiltonian.
+H = dq.modulated(lambda t: jnp.cos(3.0 * t), dq.sigmax())
+jump_ops = [jnp.sqrt(0.3) * dq.sigmam()]
+rho0 = dq.fock_dm(2, 0)
+tsave = jnp.linspace(0.1, 1.0, 11)
+
+
+def loss(shift, method, gradient=None, progress_meter=False):
+    # expectation value at the last save time, as a function of a shift of `tsave`
+    result = dq.mesolve(
+        H,
+        jump_ops,
+        rho0,
+        tsave + shift,
+        exp_ops=[dq.sigmaz()],
+        method=method,
+        gradient=gradient,
+        progress_meter=progress_meter,
+        t0=0.0,
+    )
+    return result.expects[0, -1].real
+
+
+def reference_derivative():
+    # central difference with a tight ODE method, i.e. neither the Rouchon schemes nor
+    # automatic differentiation. `rtol=2e-2` below is set by float32 rounding
+    # accumulated over the 10000 steps of `Rouchon1(dt=1e-4)`; the broken tangent path
+    # was off by 12 orders of magnitude, so the window is not the point here.
+    h = 3e-3
+    method = Tsit5(rtol=1e-8, atol=1e-8)
+    return (loss(h, method) - loss(-h, method)) / (2 * h)
+
+
+@pytest.mark.run(order=TEST_SHORT)
+@pytest.mark.parametrize('method', METHODS)
+def test_forward_gradient_tsave_shift(method):
+    jac = jax.jacfwd(loss)(0.0, method, Forward())
+    assert jnp.allclose(jac, reference_derivative(), rtol=2e-2)
+
+
+@pytest.mark.run(order=TEST_SHORT)
+def test_forward_gradient_with_progress_meter():
+    # Diffrax reduces the progress over batch dimensions with `unvmap_max`, which has
+    # no JVP rule, so a progress meter used to raise a `NotImplementedError` as soon as
+    # the time grid carried a tangent. `_ForwardModeProgressMeter` drops that tangent.
+    jac = jax.jacfwd(loss)(0.0, Rouchon2(), Forward(), True)
+    assert jnp.allclose(jac, reference_derivative(), rtol=2e-2)


### PR DESCRIPTION
## Motivation

`Rouchon1/2/3` declare `Forward` as a supported gradient, and it does work for parameters
entering `H` or the jump operators. But it silently returns a **wrong** Jacobian as soon as
the differentiated parameter enters the time grid, e.g. a time-of-flight or a delay shifting
`tsave`. On a driven damped qubit, `jax.jacfwd` of an expectation value with respect to a
scalar shift of `tsave` gives `-1.56e+02` with `Rouchon2()` where the true derivative is
`+3.38e-02`, and exactly `0.0` with `Rouchon1(dt=...)`. No exception is raised, so callers
get a plausible-looking Jacobian (the worst failure mode for gradient-based fitting).

The cause was the `step_ts` injection in `MESolveAdaptiveRouchonIntegrator`, flagged with a
`# todo: can we do better?`:

```python
# fix incorrect default linear interpolation by stepping exactly at all times
# in tsave, so interpolation is bypassed
return replace(stepsize_controller, step_ts=self.ts)
```

That hack existed because `AbstractRouchonTerm.interpolation_cls` was
`LocalLinearInterpolation`, which is only first order, so saving at `tsave` by interpolation
would have destroyed the order of the scheme. Forcing a step at every save time routes a
differentiable quantity (`ts`) into step-size control and makes every save-time
interpolation interval degenerate, so `∂/∂t_k` of the linear interpolant becomes
`(y1 - y0) / (t1 - t0) ≈ 0/0`.

## Changes

- `RouchonPropertiesMixin` gains a `lindbladian(t, rho)` method, the vector field
  `dρ/dt = G ρ + ρ G† + Σ_k L_k ρ L_k†`, built from the existing `G(t)` and `self.L(t)`.
- `AbstractRouchonTerm` carries it as a second field next to `rouchon_step`, and
  `RouchonDXSolver.step` emits `dense_info = dict(y0=y0, y1=y1, k0=k0, k1=k1)` with
  `k0 = dt * lindbladian(t0, y0)` and `k1 = dt * lindbladian(t1, y1)`
  (`ThirdOrderHermitePolynomialInterpolation` expects dt-scaled derivatives).
- `interpolation_cls` becomes `ThirdOrderHermitePolynomialInterpolation`, so saving at times
  that are not step times no longer degrades the order of the scheme.
- The `stepsize_controller` override is deleted; adaptive Rouchon now uses the inherited
  controller, with `step_ts` unset.
- Diffrax progress meters are wrapped in `_ForwardModeProgressMeter`, which applies
  `stop_gradient` to the progress. Diffrax reduces the progress across batch dimensions with
  `unvmap_max`, which has no JVP rule, so any progress meter raised
  `NotImplementedError: Differentiation rule for 'unvmap_max' not implemented` as soon as the
  time grid carried a tangent. This is method-independent (`Tsit5` failed identically); the
  progress is a display-only quantity, so dropping its tangent is safe.

With this, `∂ρ/∂t_k` evaluates to the Lindbladian at `t_k`, the physically correct
derivative, and fixed-step Rouchon gains a nonzero time-shift derivative for free. Cost is
two extra applications of the Lindbladian per step, small next to the Kraus map.

## Behavior change

Adaptive Rouchon no longer forces a step at every time in `tsave`. Previously this
implicitly capped the step size at the save-grid spacing, so a fine `tsave` with a loose
tolerance silently returned results far more accurate than requested. Now `atol`/`rtol` are
honored as they are for every other method. On a modulated-`H` damped oscillator (`n = 8`,
301 save points, max error against `Tsit5(atol=rtol=1e-12)`):

| `atol = rtol` | `Rouchon2()` before → after | `Rouchon3()` before → after |
|---|---|---|
| `1e-4` | 2.49e-04 → 2.89e-03 | 1.91e-05 → 3.45e-03 |
| `1e-6` (default) | 5.19e-05 → 4.82e-05 | 1.91e-05 → 3.16e-05 |
| `1e-8` | `max_steps` reached | 3.71e-04 → 2.99e-05 |

The dense output itself costs no accuracy: with 4 save points instead of 301 the errors after
the change are identical (2.891e-03 and 3.446e-03 at `atol = rtol = 1e-4`), i.e. the
remaining error is step truncation error, not interpolation error. Note also that the
previous behavior could exhaust `max_steps` at tight tolerances on a fine save grid, which no
longer happens. Users relying on the old implicit step cap should pass a tighter tolerance or
a `dtmax`.

## Tests

- New `tests/mesolve/test_rouchon_forward_ad.py`: `jacfwd` of an expectation value with
  respect to a shift of `tsave`, compared against a central difference computed with
  `Tsit5(rtol=atol=1e-8)`, for `Rouchon1/2/3` fixed step and `Rouchon2/3` adaptive. The
  Hamiltonian is time-dependent and `t0` is pinned explicitly, since a constant Hamiltonian
  is invariant under time translation and would pass even with a broken tangent path (there
  is a comment saying so, to keep the test from being simplified into a no-op).
- Same file: a `Forward()` gradient with a progress meter enabled, which used to raise
  `NotImplementedError: unvmap_max`.
- `tests/mesolve/test_adaptive_rouchon.py::test_gradient` is now parametrized with
  `Forward()` in addition to `Direct()` (the fixed-step suite already was).
- `test_pwc_hamiltonian` still passes: the `ClipStepSizeController` wrapping around PWC
  Hamiltonians is diffrax's own and independent of the deleted override. Its docstring is
  updated, since the `dataclasses.replace` `TypeError` it guarded no longer exists.
