### PR TITLE
Fix discontinuity times not passed to the integrator

### DIFF
--- a/.test_durations
+++ b/.test_durations
@@ -1,4 +1,6 @@
 {
+  "tests/core/test_discontinuities.py::test_declared_discontinuities_improve_adaptive_stepping": 2.0,
+  "tests/core/test_discontinuities.py::test_repeated_discontinuity_ts": 2.0,
   "tests/core/test_gradient_support.py::test_default_gradient_rejects_hessian": 0.1,
   "tests/core/test_gradient_support.py::test_higher_order_supported[method0]": 0.1,
   "tests/core/test_gradient_support.py::test_higher_order_supported[method1]": 0.1,

--- a/dynamiqs/integrators/core/diffrax_integrator.py
+++ b/dynamiqs/integrators/core/diffrax_integrator.py
@@ -76,13 +76,21 @@ class DiffraxIntegrator(BaseIntegrator, AbstractSaveMixin, AbstractTimeInterface
         else:
             method = cast(_DEAdaptiveStep, self.method)
 
-            return dx.PIDController(
+            controller = dx.PIDController(
                 rtol=method.rtol,
                 atol=method.atol,
                 safety=method.safety_factor,
                 factormin=method.min_factor,
                 factormax=method.max_factor,
             )
+
+            # Clip the steps to the discontinuities of the vector field (e.g. the
+            # boundaries of a piecewise constant Hamiltonian). Without this, the
+            # adaptive controller must discover each discontinuity by rejecting
+            # steps.
+            disc_ts = self.discontinuity_ts
+            jump_ts = disc_ts if disc_ts.size > 0 else None
+            return dx.ClipStepSizeController(controller, jump_ts=jump_ts)
 
     @property
     def dt0(self) -> float | None:

--- a/tests/core/test_discontinuities.py
+++ b/tests/core/test_discontinuities.py
@@ -1,0 +1,53 @@
+import jax.numpy as jnp
+import pytest
+
+import dynamiqs as dq
+from dynamiqs.method import Tsit5
+
+from ..order import TEST_SHORT
+
+# The Hamiltonians below are proportional to sigma_x at all times, so H(t) commutes
+# with itself and the exact solution is exp(-i theta(t) sigma_x) |psi0> with
+# theta(t) the integral of the modulation.
+
+def square_wave(t):
+    # square wave of period 1, discontinuous at every multiple of 0.5 and of vanishing
+    # integral over each period
+    return jnp.where(jnp.sin(2 * jnp.pi * t) >= 0, 1.0, -1.0)
+
+
+def solve(H, tsave):
+    psi0 = dq.fock(2, 0)
+    return dq.sesolve(H, psi0, tsave, method=Tsit5(), progress_meter=False)
+
+
+@pytest.mark.run(order=TEST_SHORT)
+def test_declared_discontinuities_improve_adaptive_stepping():
+    # both Hamiltonians define the exact same vector field, but only the first one
+    # declares where it jumps. The square wave has a vanishing integral over each
+    # period, so the exact state is |psi0> at every integer time.
+    tsave = jnp.arange(6.0)
+    disc_ts = 0.5 * jnp.arange(11)
+    declared = solve(
+        dq.modulated(square_wave, dq.sigmax(), discontinuity_ts=disc_ts), tsave
+    )
+    hidden = solve(dq.modulated(square_wave, dq.sigmax()), tsave)
+    psi0 = dq.fock(2, 0)
+    error = lambda result: jnp.abs(result.states.to_jax() - psi0.to_jax()).max()
+    assert declared.infos.nrejected < 0.5 * hidden.infos.nrejected
+    assert error(declared) < error(hidden)
+
+
+@pytest.mark.run(order=TEST_SHORT)
+def test_repeated_discontinuity_ts():
+    # `discontinuity_ts` is sorted but not deduplicated, here because both terms of the
+    # sum jump at the same times
+    times = jnp.linspace(0.0, 1.0, 6)
+    values = jnp.array([1.0, -3.0, 5.0, -2.0, 4.0])
+    H = dq.pwc(times, values, dq.sigmax()) + dq.pwc(times, values, dq.sigmax())
+    assert len(H.discontinuity_ts) == 2 * len(times)
+
+    tsave = jnp.linspace(0.0, 1.0, 11)
+    states = solve(H, tsave).states
+    expected = solve(dq.pwc(times, 2 * values, dq.sigmax()), tsave).states
+    assert jnp.allclose(states.to_jax(), expected.to_jax(), atol=1e-5)

--- a/tests/core/test_discontinuities.py
+++ b/tests/core/test_discontinuities.py
@@ -10,6 +10,7 @@ from ..order import TEST_SHORT
 # with itself and the exact solution is exp(-i theta(t) sigma_x) |psi0> with
 # theta(t) the integral of the modulation.
 
+
 def square_wave(t):
     # square wave of period 1, discontinuous at every multiple of 0.5 and of vanishing
     # integral over each period


### PR DESCRIPTION
Closes https://github.com/dynamiqs/dynamiqs/issues/1121.

Benchmarks before/after:
```
case                                                          before (s)   after (s)      Δ%     compile (s)        nsteps
sesolve_transmon[n=12]                                            0.0005      0.0005    +1.3     0.73 → 0.62       83 → 83
sesolve_spin_chain[nspin=4]                                       0.0003      0.0003    -7.4     0.49 → 0.42       44 → 44
sesolve_spin_chain[nspin=8]                                       0.0021      0.0020    -4.6     0.52 → 0.49       74 → 74
sesolve_spin_chain[nspin=12]                                      0.0507      0.0516    +1.7     0.64 → 0.61       86 → 86
sesolve_pwc[n=128,nseg=100]                                       0.0049      0.0049    -1.3     0.47 → 0.56     657 → 619
sesolve_pwc[n=1024,nseg=100]                                      0.0386      0.0375    -2.8     0.64 → 0.55   1126 → 1055
mesolve_cavity[n=64]                                              0.0239      0.0240    +0.4     0.55 → 0.69     122 → 122
mesolve_cavity[n=256]                                             0.4732      0.4648    -1.8     0.55 → 0.54     255 → 255
mesolve_cat[alpha=2.0,batch=1,n=32]                               0.0810      0.0823    +1.7     0.74 → 0.76   1417 → 1417
mesolve_cat[alpha=3.0,batch=8,n=48]                               2.9485      2.9477    -0.0     0.92 → 0.93   3720 → 3720
mesolve_cross_resonance[batch=16,n=9]                             0.0105      0.0106    +0.9     1.87 → 2.11       79 → 79
mesolve_grad[n=32,nparams=20]                                     0.0355      0.0406   +14.4     1.84 → 2.39         - → -
sepropagator_expm[n=64,ntsave=21]                                 0.0123      0.0129    +4.7     0.25 → 0.26       20 → 20
mepropagator_expm[n=16,ntsave=21]                                 0.1781      0.2017   +13.2     0.33 → 0.34       20 → 20
floquet_driven_kerr[n=32]                                         0.1012      0.1040    +2.7     0.56 → 0.57   2553 → 2553
jssesolve_cavity[dt=0.001,n=16,ntraj=32]                          0.0057      0.0058    +1.8     0.74 → 1.05   1000 → 1000
jsmesolve_cavity[dt=0.001,n=16,ntraj=32]                          0.0531      0.0506    -4.7     0.94 → 0.95   1000 → 1000
dssesolve_cavity[dt=0.001,n=16,ntraj=32]                          0.0061      0.0059    -3.6     0.65 → 0.60   1000 → 1000
dsmesolve_cavity[dt=0.001,n=16,ntraj=32]                          0.0887      0.0887    -0.0     0.99 → 0.98   1000 → 1000
```
Roughly speaking, nothing changes but the `nsteps` which is reduced thanks to the discontinuity times being properly passed, see the two following lines:
```
sesolve_pwc[n=128,nseg=100]                                       0.0049      0.0049    -1.3     0.47 → 0.56     657 → 619
sesolve_pwc[n=1024,nseg=100]                                      0.0386      0.0375    -2.8     0.64 → 0.55   1126 → 1055
```